### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/libs/spark-icons/CHANGELOG.md
+++ b/libs/spark-icons/CHANGELOG.md
@@ -1,51 +1,55 @@
 # Changelog
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...vNext) (yyyy-mm-dd)
+## [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.16.0...vNext) (yyyy-mm-dd)
+
+## [v0.16.0](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...v0.16.0) (2021-10-29)
 
 ### Features
 
 - **Spark:** Added icon
 
-# [v0.15.0](https://github.com/prenda-school/prenda-spark/compare/v0.14.0...v0.15.0) (2021-10-25)
+## [v0.15.0](https://github.com/prenda-school/prenda-spark/compare/v0.14.0...v0.15.0) (2021-10-25)
 
-# [v0.14.0](https://github.com/prenda-school/prenda-spark/compare/v0.13.1...v0.14.0) (2021-10-04)
+No changes.
 
-No changes
+## [v0.14.0](https://github.com/prenda-school/prenda-spark/compare/v0.13.1...v0.14.0) (2021-10-04)
 
-# [v0.13.1](https://github.com/prenda-school/prenda-spark/compare/v0.13.0...v0.13.1) (2021-10-01)
+No changes,
 
-No changes
+## [v0.13.1](https://github.com/prenda-school/prenda-spark/compare/v0.13.0...v0.13.1) (2021-10-01)
 
-# [v0.13.0](https://github.com/prenda-school/prenda-spark/compare/v0.12.0...v0.13.0) (2021-09-30)
+No changes.
 
-No changes
+## [v0.13.0](https://github.com/prenda-school/prenda-spark/compare/v0.12.0...v0.13.0) (2021-09-30)
 
-# [v0.12.0](https://github.com/prenda-school/prenda-spark/compare/v0.11.1...v0.12.0) (2021-09-28)
+No changes.
 
-No changes
+## [v0.12.0](https://github.com/prenda-school/prenda-spark/compare/v0.11.1...v0.12.0) (2021-09-28)
 
-# [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-08)
+No changes.
 
-No changes
+## [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-08)
 
-# [0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
+No changes.
+
+## [0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 ### Fixes
 
-- camelCase missed `stroke-*` attributes
+- camelCase missed `stroke-*` attributes.
   - affected icons: `BeakerDuotone`, `HighFiveDuotone`, `MountainDuotone`, `Users3Duotone`
 
-# [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
+## [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
 
-No changes
+No changes.
 
-# [0.9.0](https://github.com/prenda-school/prenda-spark/compare/v0.8.0...v0.9.0) (2021-07-29)
+## [0.9.0](https://github.com/prenda-school/prenda-spark/compare/v0.8.0...v0.9.0) (2021-07-29)
 
 ### Features
 
-- **SvgIcon:** make default color 'inherit'; use in @prenda/spark-icons; expand colors; improve props ([#174](https://github.com/prenda-school/prenda-spark/issues/174)) ([777213a](https://github.com/prenda-school/prenda-spark/commit/777213a143c87f6fc4762a70d065ac16cf501a10))
-- simplify dependency narrative ([#169](https://github.com/prenda-school/prenda-spark/issues/169)) ([9936891](https://github.com/prenda-school/prenda-spark/commit/99368918c86ef8f9fa67139e4a3c2701cda02ec5))
-- add all icons ([#135](https://github.com/prenda-school/prenda-spark/issues/135)) ([8a430d3](https://github.com/prenda-school/prenda-spark/commit/8a430d36c99bbdef568820be04914ff571622fa5))
+- **SvgIcon:** make default color 'inherit'; use in @prenda/spark-icons; expand colors; improve props ([#174](https://github.com/prenda-school/prenda-spark/issues/174)) ([777213a](https://github.com/prenda-school/prenda-spark/commit/777213a143c87f6fc4762a70d065ac16cf501a10)).
+- simplify dependency narrative ([#169](https://github.com/prenda-school/prenda-spark/issues/169)) ([9936891](https://github.com/prenda-school/prenda-spark/commit/99368918c86ef8f9fa67139e4a3c2701cda02ec5)).
+- add all icons ([#135](https://github.com/prenda-school/prenda-spark/issues/135)) ([8a430d3](https://github.com/prenda-school/prenda-spark/commit/8a430d36c99bbdef568820be04914ff571622fa5)).
   - **Usage Instructions**:
     - Go to the "Prenda" Organization in Figma
     - Go to the "Prenda Design" Team (Join if you haven't)

--- a/libs/spark-icons/package.json
+++ b/libs/spark-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark-icons",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {
@@ -12,7 +12,7 @@
     "@babel/runtime": "^7.10.2"
   },
   "peerDependencies": {
-    "@prenda/spark": "^0.15.0",
+    "@prenda/spark": "0.16.0",
     "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-# [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...vNext) (yyyy-mm-dd)
+## [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.16.0...vNext) (yyyy-mm-dd)
 
-# [v0.15.0](https://github.com/prenda-school/prenda-spark/compare/v0.14.0...v0.15.0) (2021-10-25)
+## [v0.16.0](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...v0.16.0) (2021-10-29)
+
+No changes.
+
+## [v0.15.0](https://github.com/prenda-school/prenda-spark/compare/v0.14.0...v0.15.0) (2021-10-25)
 
 ### Fixes
 
@@ -92,7 +96,7 @@
       - `palette.text.onDark` to `palette.text.light`
       - `palette.text.onDarkLowContrast` to `palette.text.lightLowContrast`
 
-# [v0.14.0](https://github.com/prenda-school/prenda-spark/compare/v0.13.1...v0.14.0) (2021-10-04)
+## [v0.14.0](https://github.com/prenda-school/prenda-spark/compare/v0.13.1...v0.14.0) (2021-10-04)
 
 ### Fixes
 
@@ -123,7 +127,7 @@
 - **theme**
   - Re-exported typing (**Theme**).
 
-# [v0.13.1](https://github.com/prenda-school/prenda-spark/compare/v0.13.0...v0.13.1) (2021-10-01)
+## [v0.13.1](https://github.com/prenda-school/prenda-spark/compare/v0.13.0...v0.13.1) (2021-10-01)
 
 ### Fixes
 
@@ -131,14 +135,14 @@
 - **SectionMessage**
   - Ensure `React` is in scope for component file.
 
-# [v0.13.0](https://github.com/prenda-school/prenda-spark/compare/v0.12.0...v0.13.0) (2021-09-30)
+## [v0.13.0](https://github.com/prenda-school/prenda-spark/compare/v0.12.0...v0.13.0) (2021-09-30)
 
 ### Features
 
 - Support deeper file imports
   - example: `import Avatar from '@prenda/spark/Avatar';`
 
-# [v0.12.0](https://github.com/prenda-school/prenda-spark/compare/v0.11.1...v0.12.0) (2021-09-28)
+## [v0.12.0](https://github.com/prenda-school/prenda-spark/compare/v0.11.1...v0.12.0) (2021-09-28)
 
 ### Features
 
@@ -204,7 +208,7 @@
   - Removed.
     - Migration: use **MenuItem** instead.
 
-# [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-08)
+## [v0.11.1](https://github.com/prenda-school/prenda-spark/compare/v0.11.0...v0.11.1) (2021-09-08)
 
 ### Fixes
 
@@ -217,7 +221,7 @@
 - **Typography**
   - Custom classes not being global.
 
-# [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
+## [v0.11.0](https://github.com/prenda-school/prenda-spark/compare/v0.10.0...v0.11.0) (2021-08-21)
 
 ### Fixes
 
@@ -365,7 +369,7 @@
   - _Migration:_ use `font-weight: 700`.
   - Affected components: `FormControlLabel`, `MenuItem`, `Typography`.
 
-# [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
+## [0.10.0](https://github.com/prenda-school/prenda-spark/compare/v0.9.0...v0.10.0) (2021-08-06)
 
 ### Bug Fixes
 
@@ -375,7 +379,7 @@
 
 Spark no longer exports all of `@material-ui/core`, only components it themes, in addition to re-exporting the following theme related utilities from Mui core: `{ styled, useTheme, withStyles, makeStyles }`
 
-# [0.9.0](https://github.com/prenda-school/prenda-spark/compare/v0.8.0...v0.9.0) (2021-07-29)
+## [0.9.0](https://github.com/prenda-school/prenda-spark/compare/v0.8.0...v0.9.0) (2021-07-29)
 
 ### Bug Fixes
 
@@ -453,7 +457,7 @@ Many components faced breaking prop API changes (and theme-wide default props) a
   - make default color 'inherit'; use in @prenda/spark-icons; expand colors; improve props ([#174](https://github.com/prenda-school/prenda-spark/issues/174)) ([777213a](https://github.com/prenda-school/prenda-spark/commit/777213a143c87f6fc4762a70d065ac16cf501a10))
 - **TextField:** add theme-level style overrides ([#153](https://github.com/prenda-school/prenda-spark/issues/153)) ([d2220dd](https://github.com/prenda-school/prenda-spark/commit/d2220ddef00bfd19c4e6e1f0e766d660592e37c1))
 
-# [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)
+## [0.8.0](https://github.com/prenda-school/prenda-spark/compare/v0.7.3...v0.8.0) (2021-06-22)
 
 ### Features
 

--- a/libs/spark/package.json
+++ b/libs/spark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prenda/spark",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Prenda",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
- [x] Replace `vNext` and `yyyy-mm-dd` with incremented version number and current date.
- [x] Add new `vNext` heading in CHANGELOG.
- [x] Increment synchronized package versions & peer-dependencies.
- [x] Commit with message `chore(release): <vNext>`
- [x] Tag commit: `git tag -a <vNext> -m "chore(release): <vNext>"`
- [x] Push branch and tag to origin: `git push && git push origin <vNext>`
- [x] Open PR
- [ ] _(after PR merge)_ Draft new release

Adjusted markdown of changelogs, versions are second-level headers instead of first-level -- first-level was unreasonably large and nonsensical to have for each one. Also added some periods to top-level sentences.

Removed caret ("^") from the peer dependency of `spark-icons` on `spark`. I found out that by semver, the caret means something different to `0.x` versions since they're pre-stable-api, making it counterintuitive: `Major zero and minor >1: ^0.y.z → 0.y.z - 0.(y+1).0` ([source](https://nodesource.com/blog/semver-tilde-and-caret/)). Since we've already adopted the rule to synchronize the versions of `@prenda/spark` and `@prenda/spark-icons`, I think it will reduce confusion and complexity to eliminate it and modify one of the above steps to account explicitly for the version:
- "Increment package versions"  ->  "Increment synchronized package versions & peer-dependencies."