### PR TITLE
chore: improve husky hooks and CI workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,6 @@
 name: 'Chromatic'
 
-on:  
+on:
   push:
     branches: [main]
   pull_request:
@@ -10,9 +10,9 @@ jobs:
   chromatic-deployment:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v1
-        
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Install Dependencies
         run: npm i
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,12 +11,16 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm i
 
-      - name: Build Storybook
+      # Build independent of publish because of custom command and output location
+      - name: Build storybook
         run: npx nx run spark:build-storybook
 
       - name: Publish to Chromatic

--- a/.github/workflows/ci:main.yml
+++ b/.github/workflows/ci:main.yml
@@ -14,7 +14,9 @@ jobs:
         run: sudo sysctl fs.inotify.max_user_watches=524288
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/ci:main.yml
+++ b/.github/workflows/ci:main.yml
@@ -27,8 +27,14 @@ jobs:
       - name: Lint
         run: npm run affected:lint
 
-      - name: Spark Jest tests
+      - name: Check format
+        run: npm run format:check
+
+      - name: Unit test project spark
         run: npx nx run spark:test
 
-      - name: Spark Cypress end-to-end tests
+      - name: Unit test project spark-icons
+        run: npx nx run spark-icons:test
+
+      - name: End-to-end test project spark-e2e
         run: npx nx run spark-e2e:e2e

--- a/.github/workflows/ci:main.yml
+++ b/.github/workflows/ci:main.yml
@@ -24,6 +24,9 @@ jobs:
       - name: NPM clean install
         run: npm ci
 
+      - name: Lint
+        run: npm run affected:lint
+
       - name: Spark Jest tests
         run: npx nx run spark:test
 

--- a/.github/workflows/ci:main.yml
+++ b/.github/workflows/ci:main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Increase system files monitor limit
         run: sudo sysctl fs.inotify.max_user_watches=524288
 
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -26,8 +26,8 @@ jobs:
       - name: NPM clean install
         run: npm ci
 
-      - name: Lint
-        run: npm run affected:lint
+      - name: Lint workspace and projects
+        run: npm run lint
 
       - name: Check format
         run: npm run format:check

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
         run: sudo sysctl fs.inotify.max_user_watches=524288
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Since `format:write` doesn't stage its changes AND doesn't fail the pre-commit if it writes (returns zero exit code), we have to customize this process in order to avoid amending commits or not noticing formatting changes entirely until the next commit.
+# Check the formatting; if exit code 1, then write format and fail; otherwise do nothing. But, Husky runs this script with `sh -e` which fails at the first line which has a non-zero exit code, unless the command is in a condition (if, &&, ||). So, we trash the output in order for the condition to rely entirely on the exit code, and follow our logic stated above.
+npm run --silent format:check >/dev/null || (npm run format:write; echo '\nfailed formatting; commit automatic `format:write` changes (if any) and try again\n'; exit 1)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run affected:test
-npm run affected:lint
-npm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run affected:test
 npm run affected:lint
 npm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run affected:lint
 npm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run format
+# See comment in ./pre-commit
+npm run --silent format:check >/dev/null || (npm run format:write; echo '\nfailed formatting; commit automatic `format:write` changes (if any) and try again\n'; exit 1)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "affected:build": "nx affected:build",
     "affected:e2e": "nx affected:e2e",
     "affected:test": "nx affected:test",
-    "affected:lint": "nx affected:lint",
+    "affected:lint": "nx affected:lint --maxWarnings=0",
     "affected:dep-graph": "nx affected:dep-graph",
     "affected": "nx affected",
     "format": "nx format:write",


### PR DESCRIPTION
Removes testing and linting on both Husky pre-commit and pre-push hook scripts, and improves the format command.

Why remove testing and linting? Both of these processes take an amount of time that reduces developer productivity and increases frustration (speaking from my experience and multiple peers). So, I've moved those checks into the Continuous Integration workflow, increasing its value and utility for contributors (imo, it had low value before; I knew it would pass because I couldn't have pushed it up otherwise).

We don't need to be worried about "every commit should be linted and tested". First, we squash and merge, so it's not important beyond the PR state. Second, in the PR stage, there's good reason to *want* to commit or push failing code: so others can pull it down and collaborate to fix failures, or just let the CI infrastructure run the tests instead of your machine; of course, `--no-verify` is always an option, but we should be in the business of choosing the best and sane defaults. The CI workflow will now fail when linting, formatting, or testing has a non-zero exit code -- linting was adjusted to error on warnings.

Finally, the existing command to format had a flaw imo; it would write its formatting changes, but wouldn't stage them in the commit, so you'd either have to amend the commit, or include it in your next one; blegh. Instead, I customized the command to eliminate the barrier of having a commit there but keep the auto-write and fail the hook, letting the user know exactly what to do for the hook to succeed -- that should improve DX.

Looking forward to your feedback.