### PR TITLE
feat(Link): re-exported with custom styles, props

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.16.0...vNext) (yyyy-mm-dd)
 
+### Features
+
+- **Link**
+  - Re-exported
+  - Customized styling and props.
+
 ## [v0.16.0](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...v0.16.0) (2021-10-29)
 
 No changes.

--- a/libs/spark/src/Link/Link.stories.tsx
+++ b/libs/spark/src/Link/Link.stories.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { Link, LinkProps } from '..';
+
+export const SbLink = (props: LinkProps) => <Link {...props} />;
+
+export default {
+  title: '@ps/Link',
+  component: SbLink,
+  excludeStories: ['SbLink'],
+  args: {
+    href: '#',
+  },
+} as Meta;
+
+const Template = (args) => <Link {...args}>Text</Link>;
+
+export const Configurable: Story = Template.bind({});
+
+export const Hover: Story = Template.bind({});
+Hover.parameters = { pseudo: { visited: false, hover: true } };
+Hover.storyName = ':hover';
+
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.parameters = { pseudo: { visited: false, focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
+
+export const Visited: Story = Template.bind({});
+Visited.parameters = { pseudo: { visited: true } };
+Visited.storyName = ':visited';
+
+export const VisitedHover: Story = Template.bind({});
+VisitedHover.parameters = { pseudo: { visited: true, hover: true } };
+VisitedHover.storyName = ':visited :hover';
+
+export const VisitedFocusVisible: Story = Template.bind({});
+VisitedFocusVisible.parameters = {
+  pseudo: { visited: true, focusVisible: true },
+};
+VisitedFocusVisible.storyName = ':visited :focus-visible';
+
+export const Standalone: Story = Template.bind({});
+Standalone.args = { standalone: true };
+Standalone.storyName = 'standalone';
+
+export const StandaloneHover: Story = Template.bind({});
+StandaloneHover.args = { standalone: true };
+StandaloneHover.parameters = { pseudo: { visited: false, hover: true } };
+StandaloneHover.storyName = 'standalone :hover';
+
+export const StandaloneFocusVisible: Story = Template.bind({});
+StandaloneFocusVisible.args = { standalone: true };
+StandaloneFocusVisible.parameters = {
+  pseudo: { visited: false, focusVisible: true },
+};
+StandaloneFocusVisible.storyName = 'standalone :focus-visible';
+
+export const StandaloneVisited: Story = Template.bind({});
+StandaloneVisited.args = { standalone: true };
+StandaloneVisited.parameters = { pseudo: { visited: true } };
+StandaloneVisited.storyName = 'standalone :visited';
+
+export const StandaloneVisitedHover: Story = Template.bind({});
+StandaloneVisitedHover.args = { standalone: true };
+StandaloneVisitedHover.parameters = { pseudo: { visited: true, hover: true } };
+StandaloneVisitedHover.storyName = 'standalone :visited :hover';
+
+export const StandaloneVisitedFocusVisible: Story = Template.bind({});
+StandaloneVisitedFocusVisible.args = { standalone: true };
+StandaloneVisitedFocusVisible.parameters = {
+  pseudo: { visited: true, focusVisible: true },
+};
+StandaloneVisitedFocusVisible.storyName = 'standalone :visited :focus-visible';

--- a/libs/spark/src/Link/Link.tsx
+++ b/libs/spark/src/Link/Link.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import {
+  default as MuiLink,
+  LinkProps as MuiLinkProps,
+} from '@material-ui/core/Link';
+import makeStyles from '../makeStyles';
+import { OverridableComponent, OverrideProps, useMergeClasses } from '../utils';
+
+export interface LinkTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends React.ElementType = 'a'
+> {
+  props: P &
+    Omit<MuiLinkProps, 'classes' | 'underline'> & {
+      /**
+       * Whether the link is displayed alone (not inline with other text). Removes "underline" text-decoration of the link.
+       */
+      standalone?: boolean;
+    };
+  defaultComponent: D;
+  classKey: LinkClassKey;
+}
+
+export type LinkProps<
+  D extends React.ElementType = LinkTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<LinkTypeMap<P, D>, D>;
+
+export type LinkClassKey = 'root' | 'standalone' | 'focusVisible';
+
+const useStyles = makeStyles<LinkClassKey>(
+  ({ palette }) => ({
+    /* Styles applied to the root element. */
+    root: {
+      textDecoration: 'underline',
+      color: palette.blue[3],
+      '&:hover': {
+        color: palette.blue[2],
+      },
+      '&$focusVisible, &:focus-visible': {
+        color: palette.blue[2],
+        boxShadow: `0 0 0 4px ${palette.blue[1]}`,
+      },
+      '&:visited': {
+        color: palette.purple[3],
+        '&:hover': {
+          color: palette.purple[2],
+        },
+      },
+    },
+    /* Styles applied to the root element if `standalone={true}`. */
+    standalone: {
+      textDecoration: 'none',
+    },
+    /* Pseudo-class applied to the root element if the link is keyboard focused. */
+    focusVisible: {},
+  }),
+  { name: 'MuiSparkLink' }
+);
+
+const Link: OverridableComponent<LinkTypeMap> = React.forwardRef(function Link(
+  {
+    classes: classesProp,
+    // reset MuiLink default prop to match our Typography default
+    color = 'inherit',
+    standalone,
+    ...other
+  },
+  ref
+) {
+  const baseClasses = useStyles();
+
+  // Should use classes capture, but this extra work is menial.
+  const { standalone: standaloneClass, ...otherClasses } = useMergeClasses({
+    baseClasses,
+    classesProp,
+  });
+
+  return (
+    <MuiLink
+      classes={{
+        ...otherClasses,
+        root: clsx(otherClasses.root, { [standaloneClass]: standalone }),
+      }}
+      color={color}
+      underline="none"
+      ref={ref}
+      {...other}
+    />
+  );
+});
+
+export default Link;

--- a/libs/spark/src/Link/index.ts
+++ b/libs/spark/src/Link/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Link';
+export * from './Link';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -82,6 +82,9 @@ export * from './InputBase';
 export { default as InputLabel } from './InputLabel';
 export * from './InputLabel';
 
+export { default as Link } from './Link';
+export * from './Link';
+
 export { default as List } from './List';
 export * from './List';
 


### PR DESCRIPTION
Backport of a PDS v2 component spec using the best palette parallels. This is immediately useful.

Figma spec page: https://www.figma.com/file/6MR4jvUO9jG5pKEogHszHR/?node-id=4284%3A5154

Between "inline" and "standalone", I'm assuming that "inline" will be the more common use-case, so `standalone` is an opt-in prop -- replaces underlying `underline` prop.

All stories spec'd out.