### PR TITLE
feat(IconButton): customize without `ThemeProvider`

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v0.16.0...vNext) (yyyy-mm-dd)
 
+### Features
+
+- **IconButton**
+  - Can render without `ThemeProvider`.
+
 ## [v0.16.0](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...v0.16.0) (2021-10-29)
 
 No changes.

--- a/libs/spark/src/IconButton/IconButton.spec.tsx
+++ b/libs/spark/src/IconButton/IconButton.spec.tsx
@@ -1,15 +1,16 @@
-import { render } from '@testing-library/react';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
 import IconButton from './IconButton';
-import SparkThemeProvider from '../SparkThemeProvider';
+import { ChevronDown } from '../internal';
 
 describe('IconButton', () => {
-  it('is truthy', () => {
-    const { baseElement } = render(
-      <SparkThemeProvider>
-        <IconButton />
-      </SparkThemeProvider>
+  it('renders', () => {
+    render(
+      <IconButton>
+        <ChevronDown data-testid="test" />
+      </IconButton>
     );
 
-    expect(baseElement).toBeTruthy();
+    expect(screen.getByTestId('test')).toBeTruthy();
   });
 });

--- a/libs/spark/src/IconButton/IconButton.stories.tsx
+++ b/libs/spark/src/IconButton/IconButton.stories.tsx
@@ -1,23 +1,26 @@
 import * as React from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
-import Box from '../Box';
-import IconButton from './IconButton';
+import { Box, IconButton } from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedIconButton = IconButton;
+export const SbIconButton = IconButton;
 
 export default {
   title: '@ps/IconButton',
-  component: TypedIconButton,
-  excludeStories: ['TypedIconButton'],
+  component: SbIconButton,
+  excludeStories: ['SbIconButton'],
   argTypes: {
     children: {
       control: 'select',
-      options: ['ChevronDown'],
+      options: ['undefined', 'ChevronDown'],
+      mapping: {
+        undefined: undefined,
+        ChevronDown: <ChevronDown />,
+      },
     },
   },
   args: {
@@ -25,11 +28,9 @@ export default {
   },
 } as Meta;
 
-const Template: Story = (args) => (
-  <IconButton {...args}>{<ChevronDown />}</IconButton>
-);
+const Template = (args) => <IconButton {...args} />;
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const GridContainer = (props) => (
   <Box
@@ -42,7 +43,7 @@ const GridContainer = (props) => (
   />
 );
 
-const VariantAndSizeTemplate: Story = (args) => (
+const VariantAndSizeTemplate = (args) => (
   <GridContainer>
     <span>Variant / Size</span>
     <span>Large</span>
@@ -86,18 +87,18 @@ const VariantAndSizeTemplate: Story = (args) => (
   </GridContainer>
 );
 
-export const VariantAndSize = VariantAndSizeTemplate.bind({});
+export const VariantAndSize: Story = VariantAndSizeTemplate.bind({});
 
-export const VariantAndSizeDisabled = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeDisabled: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeDisabled.args = { disabled: true };
 
-export const VariantAndSizeHover = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeHover: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeHover.parameters = { pseudo: { hover: true } };
 
-export const VariantAndSizeFocus = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeFocus: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeFocus.parameters = { pseudo: { focus: true } };
 
-export const VariantAndSizeActive = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeActive: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeActive.parameters = { pseudo: { active: true } };
 
 const IconButtonDocTemplate = (args) => <DocumentationTemplate {...args} />;

--- a/libs/spark/src/IconButton/IconButton.tsx
+++ b/libs/spark/src/IconButton/IconButton.tsx
@@ -150,7 +150,6 @@ const IconButton: OverridableComponent<IconButtonTypeMap> = React.forwardRef(
 
     return (
       <MuiIconButton
-        ref={ref}
         classes={{
           ...otherClasses,
           root: clsx(
@@ -161,6 +160,9 @@ const IconButton: OverridableComponent<IconButtonTypeMap> = React.forwardRef(
           label: customClasses.label,
           disabled: customClasses.disabled,
         }}
+        disableFocusRipple
+        disableRipple
+        ref={ref}
         {...other}
       >
         {children}

--- a/libs/spark/src/IconButton/defaults.ts
+++ b/libs/spark/src/IconButton/defaults.ts
@@ -1,9 +1,0 @@
-import type { IconButtonProps } from './IconButton';
-
-// omit size because the customization is incompatible
-export const MuiIconButtonDefaultProps: Partial<
-  Omit<IconButtonProps, 'size'>
-> = {
-  disableFocusRipple: true,
-  disableRipple: true,
-};

--- a/libs/spark/src/theme/props.ts
+++ b/libs/spark/src/theme/props.ts
@@ -5,7 +5,6 @@ import { MuiButtonDefaultProps } from '../Button/defaults';
 import { MuiButtonBaseDefaultProps } from '../ButtonBase/defaults';
 import { MuiCardDefaultProps } from '../Card/defaults';
 import { MuiCheckboxDefaultProps } from '../Checkbox/defaults';
-import { MuiIconButtonDefaultProps } from '../IconButton/defaults';
 import { MuiInputDefaultProps } from '../Input/defaults';
 import { MuiInputLabelDefaultProps } from '../InputLabel/defaults';
 import { MuiMenuDefaultProps } from '../Menu/defaults';
@@ -22,7 +21,6 @@ export default {
   MuiButtonBase: MuiButtonBaseDefaultProps,
   MuiCard: MuiCardDefaultProps,
   MuiCheckbox: MuiCheckboxDefaultProps,
-  MuiIconButton: MuiIconButtonDefaultProps,
   MuiInput: MuiInputDefaultProps,
   MuiInputLabel: MuiInputLabelDefaultProps,
   MuiMenu: MuiMenuDefaultProps,


### PR DESCRIPTION
Moves default props to component, adjusts test. Minor, unrelated corrections in the stories. 