### PR TITLE
chore(stories): cleanup & normalize behaviors

### DIFF
--- a/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
+++ b/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Autocomplete from './Autocomplete';
-import Checkbox from '../Checkbox';
-import ListItemText from '../ListItemText';
-import ListItemIcon from '../ListItemIcon';
-import TextField from '../TextField';
-import Tag from '../Tag';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Autocomplete,
+  Checkbox,
+  ListItemText,
+  ListItemIcon,
+  TextField,
+  Tag,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
@@ -28,7 +30,7 @@ const reasons = [
   { value: '7', label: 'Label' },
 ];
 
-export const MultipleValuesCheckboxes = (args) => (
+export const MultipleValuesCheckboxes: Story = (args) => (
   <Autocomplete
     multiple
     options={reasons}
@@ -67,9 +69,7 @@ export const MultipleValuesCheckboxes = (args) => (
   />
 );
 
-const AutocompleteDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = AutocompleteDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Autocomplete',
@@ -87,9 +87,7 @@ Documentation.args = {
   },
 };
 
-const AutocompleteChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = AutocompleteChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Avatar/Avatar.stories.tsx
+++ b/libs/spark/src/Avatar/Avatar.stories.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { UserDuotone } from '@prenda/spark-icons';
-import Avatar from './Avatar';
-import Box from '../Box';
+import { Avatar, Box } from '..';
 import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
 
-export const TypedAvatar = Avatar;
+export const SbAvatar = Avatar;
 
 export default {
   title: '@ps/Avatar',
-  component: TypedAvatar,
-  excludeStories: ['TypedAvatar'],
+  component: SbAvatar,
+  excludeStories: ['SbAvatar'],
   args: {
     src: '/img/guide-1.png',
   },
@@ -102,9 +101,7 @@ const ContentAndSizeTemplate = ({ src, alt, ...other }) => (
 
 export const ContentAndSize: Story = ContentAndSizeTemplate.bind({});
 
-const AvatarDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = AvatarDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Avatar',
@@ -136,9 +133,7 @@ Documentation.args = {
   },
 };
 
-const AvatarChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = AvatarChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Banner/Banner.stories.tsx
+++ b/libs/spark/src/Banner/Banner.stories.tsx
@@ -1,27 +1,23 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { default as Banner, BannerProps } from './Banner';
-import styled from '../styled';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Banner, BannerProps, styled } from '..';
 import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
 
-export const TypedBanner = (props: BannerProps) => <Banner {...props} />;
+interface SbBannerProps extends BannerProps {
+  closeText?: BannerProps['closeText'];
+  onClose?: BannerProps['onClose'];
+  severity?: BannerProps['severity'];
+}
+
+export const SbBanner = (props: SbBannerProps) => <Banner {...props} />;
 
 export default {
   title: '@ps/Banner',
-  component: TypedBanner,
-  excludeStories: ['TypedBanner'],
-  // Doesn't pick up extended AlertProps
-  argTypes: {
-    severity: {
-      control: 'select',
-      options: ['error', 'info', 'warning', 'success'],
-    },
-    onClose: { action: 'closed' },
-    closeText: { control: 'text' },
-  },
+  component: SbBanner,
+  excludeStories: ['SbBanner'],
   args: {
     severity: 'info',
     onDetails: null,
@@ -29,19 +25,18 @@ export default {
   },
 } as Meta;
 
-// severity: message
-const messages = {
+const messages: Record<BannerProps['severity'], string> = {
   info: 'Information banner',
   success: 'Successful',
   warning: 'Attention needed',
   error: 'There are two errors with your submission',
 };
 
-const Template: Story = (args) => (
+const Template = (args) => (
   <Banner {...args}>{messages[args.severity || 'success']}</Banner>
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const Container = styled('div')({
   display: 'flex',
@@ -49,7 +44,7 @@ const Container = styled('div')({
   gap: 16,
 });
 
-const SeverityTemplate: Story = (args) => (
+const SeverityTemplate = (args) => (
   <Container>
     <Banner {...args} severity="info">
       {messages.info}
@@ -66,16 +61,16 @@ const SeverityTemplate: Story = (args) => (
   </Container>
 );
 
-export const Severity = SeverityTemplate.bind({});
+export const Severity: Story = SeverityTemplate.bind({});
 
-export const SeverityClose = SeverityTemplate.bind({});
+export const SeverityClose: Story = SeverityTemplate.bind({});
 SeverityClose.args = {
   onClose: () => {
     return;
   },
 };
 
-export const SeverityCloseFocus = SeverityTemplate.bind({});
+export const SeverityCloseFocus: Story = SeverityTemplate.bind({});
 SeverityCloseFocus.args = {
   onClose: () => {
     return;
@@ -83,14 +78,14 @@ SeverityCloseFocus.args = {
 };
 SeverityCloseFocus.parameters = { pseudo: { focus: true } };
 
-export const SeverityDetails = SeverityTemplate.bind({});
+export const SeverityDetails: Story = SeverityTemplate.bind({});
 SeverityDetails.args = {
   onDetails: () => {
     return;
   },
 };
 
-export const SeverityDetailsFocus = SeverityTemplate.bind({});
+export const SeverityDetailsFocus: Story = SeverityTemplate.bind({});
 SeverityDetailsFocus.args = {
   onDetails: () => {
     return;
@@ -98,9 +93,7 @@ SeverityDetailsFocus.args = {
 };
 SeverityDetailsFocus.parameters = { pseudo: { focus: true } };
 
-const BannerDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = BannerDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Alert',
@@ -136,9 +129,7 @@ Documentation.args = {
   },
 };
 
-const BannerChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = BannerChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Button/Button.stories.tsx
+++ b/libs/spark/src/Button/Button.stories.tsx
@@ -1,54 +1,53 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
-import { default as Button, ButtonTypeMap } from './Button';
-import Box from '../Box';
-import { ExtendButtonBase } from '../ButtonBase';
+import { Box, Button, ButtonProps } from '..';
 
-export const TypedButton: ExtendButtonBase<ButtonTypeMap> = (props) => (
-  <Button {...props} />
-);
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface SbButtonProps
+  extends Omit<
+    ButtonProps,
+    | 'disableElevation'
+    | 'disableFocusRipple'
+    | 'centerRipple'
+    | 'disableRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'tabIndex'
+    | 'TouchRippleProps'
+  > {}
+
+export const SbButton = (props: SbButtonProps) => <Button {...props} />;
 
 export default {
   title: '@ps/Button',
-  component: TypedButton,
-  excludeStories: ['TypedButton'],
-  // Doesn't pick up props
+  component: SbButton,
+  excludeStories: ['SbButton'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
   argTypes: {
-    onClick: { actions: 'clicked' },
-    variant: {
-      control: 'select',
-      options: ['contained', 'outlined', 'text'],
-    },
-    size: {
-      control: 'select',
-      options: ['large', 'medium', 'small'],
-    },
     startIcon: {
       control: 'select',
-      options: [undefined, 'ChevronDown'],
+      options: ['undefined', 'ChevronDown'],
+      mapping: {
+        undefined: undefined,
+        ChevronDown: <ChevronDown />,
+      },
     },
     endIcon: {
       control: 'select',
-      options: [undefined, 'ChevronDown'],
+      options: ['undefined', 'ChevronDown'],
+      mapping: {
+        undefined: undefined,
+        ChevronDown: <ChevronDown />,
+      },
     },
-    disabled: { control: 'boolean' },
   },
   args: {
-    variant: 'contained',
-    size: 'large',
+    children: 'Label',
   },
 } as Meta;
 
-const Template = (args) => (
-  <Button
-    {...args}
-    startIcon={args.startIcon ? <ChevronDown /> : undefined}
-    endIcon={args.endIcon ? <ChevronDown /> : undefined}
-  >
-    Label
-  </Button>
-);
+const Template = (args) => <Button {...args} />;
 
 export const Configurable: Story = Template.bind({});
 
@@ -138,59 +137,59 @@ export const VariantAndSizeActive: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeActive.parameters = { pseudo: { active: true } };
 
 export const StartIconVariantAndSize: Story = VariantAndSizeTemplate.bind({});
-StartIconVariantAndSize.args = { startIcon: <ChevronDown /> };
+StartIconVariantAndSize.args = { startIcon: 'ChevronDown' };
 
 export const StartIconVariantAndSizeDisabled: Story = VariantAndSizeTemplate.bind(
   {}
 );
 StartIconVariantAndSizeDisabled.args = {
   disabled: true,
-  startIcon: <ChevronDown />,
+  startIcon: 'ChevronDown',
 };
 
 export const StartIconVariantAndSizeHover: Story = VariantAndSizeTemplate.bind(
   {}
 );
-StartIconVariantAndSizeHover.args = { startIcon: <ChevronDown /> };
+StartIconVariantAndSizeHover.args = { startIcon: 'ChevronDown' };
 StartIconVariantAndSizeHover.parameters = { pseudo: { hover: true } };
 
 export const StartIconVariantAndSizeFocus: Story = VariantAndSizeTemplate.bind(
   {}
 );
-StartIconVariantAndSizeFocus.args = { startIcon: <ChevronDown /> };
+StartIconVariantAndSizeFocus.args = { startIcon: 'ChevronDown' };
 StartIconVariantAndSizeFocus.parameters = { pseudo: { focus: true } };
 
 export const StartIconVariantAndSizeActive: Story = VariantAndSizeTemplate.bind(
   {}
 );
-StartIconVariantAndSizeActive.args = { startIcon: <ChevronDown /> };
+StartIconVariantAndSizeActive.args = { startIcon: 'ChevronDown' };
 StartIconVariantAndSizeActive.parameters = { pseudo: { active: true } };
 
 export const EndIconVariantAndSize: Story = VariantAndSizeTemplate.bind({});
-EndIconVariantAndSize.args = { endIcon: <ChevronDown /> };
+EndIconVariantAndSize.args = { endIcon: 'ChevronDown' };
 
 export const EndIconVariantAndSizeDisabled: Story = VariantAndSizeTemplate.bind(
   {}
 );
 EndIconVariantAndSizeDisabled.args = {
   disabled: true,
-  endIcon: <ChevronDown />,
+  endIcon: 'ChevronDown',
 };
 
 export const EndIconVariantAndSizeHover: Story = VariantAndSizeTemplate.bind(
   {}
 );
-EndIconVariantAndSizeHover.args = { endIcon: <ChevronDown /> };
+EndIconVariantAndSizeHover.args = { endIcon: 'ChevronDown' };
 EndIconVariantAndSizeHover.parameters = { pseudo: { hover: true } };
 
 export const EndIconVariantAndSizeFocus: Story = VariantAndSizeTemplate.bind(
   {}
 );
-EndIconVariantAndSizeFocus.args = { endIcon: <ChevronDown /> };
+EndIconVariantAndSizeFocus.args = { endIcon: 'ChevronDown' };
 EndIconVariantAndSizeFocus.parameters = { pseudo: { focus: true } };
 
 export const EndIconVariantAndSizeActive: Story = VariantAndSizeTemplate.bind(
   {}
 );
-EndIconVariantAndSizeActive.args = { endIcon: <ChevronDown /> };
+EndIconVariantAndSizeActive.args = { endIcon: 'ChevronDown' };
 EndIconVariantAndSizeActive.parameters = { pseudo: { active: true } };

--- a/libs/spark/src/Card/Card.stories.tsx
+++ b/libs/spark/src/Card/Card.stories.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { HeartDuotone } from '@prenda/spark-icons';
-import Box from '../Box';
-import Button from '../Button';
-import { default as Card, CardProps } from './Card';
-import CardActions from '../CardActions';
-import CardContent from '../CardContent';
-import CardMedia from '../CardMedia';
-import IconButton from '../IconButton';
-import Typography from '../Typography';
-import styled from '../styled';
-import withStyles from '../withStyles';
-
-export const TypedCard = (props: CardProps) => <Card {...props} />;
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  IconButton,
+  Typography,
+  styled,
+  withStyles,
+} from '..';
 
 export default {
   title: '@ps/Card',
-  component: TypedCard,
-  excludeStories: ['TypedCard'],
+  component: Card,
+  excludeStories: ['Card'],
 } as Meta;
 
 const CustomCard = withStyles({

--- a/libs/spark/src/Checkbox/Checkbox.stories.tsx
+++ b/libs/spark/src/Checkbox/Checkbox.stories.tsx
@@ -1,26 +1,34 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { default as Checkbox, CheckboxProps } from './Checkbox';
-import FormControlLabel from '../FormControlLabel';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Checkbox, CheckboxProps, FormControlLabel } from '..';
 import { DocumentationTemplate } from '../../stories/templates';
 
-export const TypedCheckbox = (props: CheckboxProps) => <Checkbox {...props} />;
+// Doesn't pick up extended SwitchBaseProps
+interface SbCheckboxProps
+  extends Omit<
+    CheckboxProps,
+    | 'disableFocusRipple'
+    | 'centerRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'TouchRippleProps'
+  > {
+  checked?: CheckboxProps['checked'];
+  disabled?: CheckboxProps['disabled'];
+  indeterminate?: CheckboxProps['indeterminate'];
+  value?: CheckboxProps['value'];
+}
+
+export const SbCheckbox = (props: SbCheckboxProps) => <Checkbox {...props} />;
 
 export default {
   title: '@ps/Checkbox',
-  component: TypedCheckbox,
-  excludeStories: ['TypedCheckbox'],
-  parameters: { actions: { handles: ['change'] } },
-  // Doesn't pick up extended SwitchBaseProps
-  argTypes: {
-    checked: { control: 'boolean' },
-    indeterminate: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-  },
-  args: {},
+  component: SbCheckbox,
+  excludeStories: ['SbCheckbox'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
 } as Meta;
 
-const Template: Story = (args) => (
+const Template = (args) => (
   <Checkbox
     // a11y required props when there's no label
     name="Demo"
@@ -30,9 +38,9 @@ const Template: Story = (args) => (
   />
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
-const StatesTemplate: Story = () => (
+const StatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <Checkbox
       name="nameA"
@@ -74,7 +82,7 @@ const StatesTemplate: Story = () => (
   </div>
 );
 
-const PseudoStatesTemplate: Story = () => (
+const PseudoStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <Checkbox
       name="nameA"
@@ -96,15 +104,15 @@ const PseudoStatesTemplate: Story = () => (
   </div>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesHover = PseudoStatesTemplate.bind({});
+export const StatesHover: Story = PseudoStatesTemplate.bind({});
 StatesHover.parameters = { pseudo: { hover: true } };
 
-export const StatesFocus = PseudoStatesTemplate.bind({});
+export const StatesFocus: Story = PseudoStatesTemplate.bind({});
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const LabeledStatesTemplate: Story = () => (
+const LabeledStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <FormControlLabel label="Label" control={<Checkbox />} />
     <FormControlLabel label="Label" control={<Checkbox />} disabled />
@@ -119,7 +127,7 @@ const LabeledStatesTemplate: Story = () => (
   </div>
 );
 
-const PseudoLabeledStatesTemplate: Story = () => (
+const PseudoLabeledStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <FormControlLabel label="Label" control={<Checkbox />} />
     <FormControlLabel label="Label" control={<Checkbox checked />} />
@@ -127,15 +135,15 @@ const PseudoLabeledStatesTemplate: Story = () => (
   </div>
 );
 
-export const LabeledStates = LabeledStatesTemplate.bind({});
+export const LabeledStates: Story = LabeledStatesTemplate.bind({});
 
-export const LabeledStatesHover = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesHover: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesHover.parameters = { pseudo: { hover: true } };
 
-export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesFocus: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesFocus.parameters = { pseudo: { focus: true } };
 
-export const Documentation = DocumentationTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Checkbox',

--- a/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
@@ -1,61 +1,88 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { UserDuotone, ChevronDown } from '@prenda/spark-icons';
-import Box from '../Box';
-import Button from '../Button';
-import Divider from '../Divider';
-import DropdownAnchor from '../DropdownAnchor';
 import {
-  default as DropdownContext,
+  Box,
+  Button,
+  Divider,
+  DropdownAnchor,
+  DropdownAnchorProps,
+  DropdownContext,
   DropdownContextProps,
-} from './DropdownContext';
-import DropdownMenu from '../DropdownMenu';
-import IconButton from '../IconButton';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../ListItemText';
-import MenuItem from '../MenuItem';
+  DropdownMenu,
+  DropdownMenuProps,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+} from '..';
 
-export const TypedDropdownContext = (props: DropdownContextProps) => (
-  <DropdownContext {...props} />
-);
+interface SbDropdownContextProps extends DropdownContextProps {
+  /**
+   * **[Storybook-only:** passed to `DropdownAnchor`.**]**
+   *
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  sb_DropdownAnchor_component?: DropdownAnchorProps['component'];
+  /**
+   * **[Storybook-only:** passed to `DropdownAnchor`.**]**
+   *
+   * If `true`, the anchor component is disabled.
+   */
+  sb_DropdownAnchor_disabled?: boolean;
+  /**
+   * **[Storybook-only:** passed to `DropdownMenu`.**]**
+   *
+   * If `true`, the menu is visible.
+   */
+  sb_DropdownMenu_open?: DropdownMenuProps['open'];
+  /**
+   * **[Storybook-only:** passed to `DropdownMenu`.**]**
+   *
+   * The placement of the menu `Popover` in relation to its anchor.
+   * This is a shortcut for common combinations of `anchorOrigin` and `transformOrigin`.
+   */
+  sb_DropdownMenu_placement?: DropdownMenuProps['placement'];
+}
 
-const components = { Button, IconButton };
+export const SbDropdownContext = ({
+  sb_DropdownAnchor_component,
+  sb_DropdownAnchor_disabled,
+  sb_DropdownMenu_open,
+  sb_DropdownMenu_placement,
+  ...props
+}: SbDropdownContextProps) => <DropdownContext {...props} />;
 
 export default {
   title: '@ps/DropdownContext',
-  component: TypedDropdownContext,
-  excludeStories: ['TypedDropdownContext'],
+  component: SbDropdownContext,
+  excludeStories: ['SbDropdownContext'],
   argTypes: {
-    open: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    placement: {
+    sb_DropdownAnchor_component: {
       control: 'select',
-      options: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
-    },
-    component: {
-      options: Object.keys(components),
-      mapping: components,
-      control: {
-        type: 'select',
-      },
+      options: ['Button', 'IconButton'],
+      mapping: { Button: Button, IconButton: IconButton },
     },
   },
   args: {
-    placement: 'bottom-left',
-    component: 'Button',
+    sb_DropdownAnchor_component: 'Button',
+    sb_DropdownMenu_placement: 'bottom-left',
   },
 } as Meta;
 
-const ConfigurableTemplate: Story = ({
-  disabled,
-  open,
-  placement,
-  component,
+const ConfigurableTemplate = ({
+  sb_DropdownAnchor_component,
+  sb_DropdownAnchor_disabled,
+  sb_DropdownMenu_open,
+  sb_DropdownMenu_placement,
 }) => {
   const optionalMenuProps: { open?: boolean } = {};
-  if (open !== undefined) optionalMenuProps.open = open;
+  if (sb_DropdownMenu_open !== undefined) {
+    optionalMenuProps.open = sb_DropdownMenu_open;
+  }
 
-  const positioningStyles = getPositioningStyles(placement);
+  const positioningStyles = getPositioningStyles(sb_DropdownMenu_placement);
 
   return (
     // menu height + (largest) anchor el height + space between; menu width
@@ -63,17 +90,25 @@ const ConfigurableTemplate: Story = ({
       <Box {...positioningStyles}>
         <DropdownContext>
           <DropdownAnchor
-            component={component}
+            component={sb_DropdownAnchor_component}
             endIcon={
-              component.displayName === 'IconButton' ? undefined : (
+              sb_DropdownAnchor_component.displayName ===
+              'IconButton' ? undefined : (
                 <ChevronDown />
               )
             }
-            disabled={disabled}
+            disabled={sb_DropdownAnchor_disabled}
           >
-            {component.displayName === 'IconButton' ? <ChevronDown /> : 'Label'}
+            {sb_DropdownAnchor_component.displayName === 'IconButton' ? (
+              <ChevronDown />
+            ) : (
+              'Label'
+            )}
           </DropdownAnchor>
-          <DropdownMenu placement={placement} {...optionalMenuProps}>
+          <DropdownMenu
+            placement={sb_DropdownMenu_placement}
+            {...optionalMenuProps}
+          >
             <MenuItem>
               <ListItemIcon>
                 <UserDuotone />
@@ -97,7 +132,7 @@ const ConfigurableTemplate: Story = ({
   );
 };
 
-export const Configurable = ConfigurableTemplate.bind({});
+export const Configurable: Story = ConfigurableTemplate.bind({});
 
 function getPositioningStyles(placement) {
   let top, left, right, bottom;

--- a/libs/spark/src/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/DropdownMenu/DropdownMenu.tsx
@@ -7,7 +7,14 @@ import Menu from '../Menu';
 type Placement = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
 
 export interface DropdownMenuProps extends Omit<MenuProps, 'open'> {
+  /**
+   * If `true`, the menu is visible.
+   */
   open?: boolean | undefined;
+  /**
+   * The placement of the menu `Popover` in relation to its anchor.
+   * This is a shortcut for common combinations of `anchorOrigin` and `transformOrigin`.
+   */
   placement?: Placement;
 }
 

--- a/libs/spark/src/FormControl/FormControl.stories.tsx
+++ b/libs/spark/src/FormControl/FormControl.stories.tsx
@@ -1,25 +1,28 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Box from '../Box';
-import Checkbox from '../Checkbox';
-import { default as FormControl, FormControlProps } from './FormControl';
-import FormControlLabel from '../FormControlLabel';
-import FormGroup from '../FormGroup';
-import FormHelperText from '../FormHelperText';
-import FormLabel from '../FormLabel';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormControlProps,
+  FormGroup,
+  FormHelperText,
+  FormLabel,
+} from '..';
 
-export const TypedFormControl = (props: FormControlProps) => (
+export const SbFormControl = (props: FormControlProps) => (
   <FormControl {...props} />
 );
 
 export default {
   title: '@ps/FormControl',
-  component: TypedFormControl,
-  excludeStories: ['TypedFormControl'],
-  parameters: { actions: { handles: ['change'] } },
+  component: SbFormControl,
+  excludeStories: ['SbFormControl'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
 } as Meta;
 
-const CheckboxGroupTemplate: Story = ({
+const CheckboxGroupTemplate = ({
   required,
   error,
   disabled,
@@ -62,10 +65,10 @@ const CheckboxGroupTemplate: Story = ({
   </FormControl>
 );
 
-export const CheckboxGroup = CheckboxGroupTemplate.bind({});
+export const CheckboxGroup: Story = CheckboxGroupTemplate.bind({});
 CheckboxGroup.storyName = 'Checkbox Group';
 
-const CheckboxGroupStatesTemplate: Story = ({ row, pseudo }) => (
+const CheckboxGroupStatesTemplate = ({ row, pseudo }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
     <FormControl component="fieldset">
       <FormLabel component="legend">Group label</FormLabel>
@@ -112,10 +115,12 @@ const CheckboxGroupStatesTemplate: Story = ({ row, pseudo }) => (
   </div>
 );
 
-export const CheckboxGroupColumnStates = CheckboxGroupStatesTemplate.bind({});
+export const CheckboxGroupColumnStates: Story = CheckboxGroupStatesTemplate.bind(
+  {}
+);
 CheckboxGroupColumnStates.storyName = 'Checkbox Group, states, column';
 
-export const CheckboxGroupColumnStatesHover = CheckboxGroupStatesTemplate.bind(
+export const CheckboxGroupColumnStatesHover: Story = CheckboxGroupStatesTemplate.bind(
   {}
 );
 CheckboxGroupColumnStatesHover.storyName =
@@ -123,7 +128,7 @@ CheckboxGroupColumnStatesHover.storyName =
 CheckboxGroupColumnStatesHover.args = { pseudo: true };
 CheckboxGroupColumnStatesHover.parameters = { pseudo: { hover: true } };
 
-export const CheckboxGroupColumnStatesFocus = CheckboxGroupStatesTemplate.bind(
+export const CheckboxGroupColumnStatesFocus: Story = CheckboxGroupStatesTemplate.bind(
   {}
 );
 CheckboxGroupColumnStatesFocus.storyName =
@@ -131,21 +136,27 @@ CheckboxGroupColumnStatesFocus.storyName =
 CheckboxGroupColumnStatesFocus.args = { pseudo: true };
 CheckboxGroupColumnStatesFocus.parameters = { pseudo: { focus: true } };
 
-export const CheckboxGroupRowStates = CheckboxGroupStatesTemplate.bind({});
+export const CheckboxGroupRowStates: Story = CheckboxGroupStatesTemplate.bind(
+  {}
+);
 CheckboxGroupRowStates.storyName = 'Checkbox Group, states, row';
 CheckboxGroupRowStates.args = { row: true };
 
-export const CheckboxGroupRowStatesHover = CheckboxGroupStatesTemplate.bind({});
+export const CheckboxGroupRowStatesHover: Story = CheckboxGroupStatesTemplate.bind(
+  {}
+);
 CheckboxGroupRowStatesHover.storyName = 'Checkbox Group, states, row, hover';
 CheckboxGroupRowStatesHover.args = { pseudo: true, row: true };
 CheckboxGroupRowStatesHover.parameters = { pseudo: { hover: true } };
 
-export const CheckboxGroupRowStatesFocus = CheckboxGroupStatesTemplate.bind({});
+export const CheckboxGroupRowStatesFocus: Story = CheckboxGroupStatesTemplate.bind(
+  {}
+);
 CheckboxGroupRowStatesFocus.storyName = 'Checkbox Group, states, row, focus';
 CheckboxGroupRowStatesFocus.args = { pseudo: true, row: true };
 CheckboxGroupRowStatesFocus.parameters = { pseudo: { focus: true } };
 
-const CheckboxGroupIndeterminateTemplate: Story = ({
+const CheckboxGroupIndeterminateTemplate = ({
   required,
   error,
   disabled,
@@ -216,7 +227,7 @@ const CheckboxGroupIndeterminateTemplate: Story = ({
   );
 };
 
-export const CheckboxGroupIndeterminate = CheckboxGroupIndeterminateTemplate.bind(
+export const CheckboxGroupIndeterminate: Story = CheckboxGroupIndeterminateTemplate.bind(
   {}
 );
 CheckboxGroupIndeterminate.storyName = 'Checkbox Group, indeterminate';

--- a/libs/spark/src/IconButton/IconButton.stories.tsx
+++ b/libs/spark/src/IconButton/IconButton.stories.tsx
@@ -1,23 +1,41 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
-import Box from '../Box';
-import IconButton from './IconButton';
+import { Box, IconButton, IconButtonProps } from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedIconButton = IconButton;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface SbIconButtonProps
+  extends Omit<
+    IconButtonProps,
+    | 'disableFocusRipple'
+    | 'tabIndex'
+    | 'color'
+    | 'centerRipple'
+    | 'disableRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'TouchRippleProps'
+  > {}
+
+export const SbIconButton = (props: SbIconButtonProps) => (
+  <IconButton {...props} />
+);
 
 export default {
   title: '@ps/IconButton',
-  component: TypedIconButton,
-  excludeStories: ['TypedIconButton'],
+  component: SbIconButton,
+  excludeStories: ['SbIconButton'],
   argTypes: {
     children: {
       control: 'select',
       options: ['ChevronDown'],
+      mapping: {
+        ChevronDown: <ChevronDown />,
+      },
     },
   },
   args: {
@@ -25,11 +43,9 @@ export default {
   },
 } as Meta;
 
-const Template: Story = (args) => (
-  <IconButton {...args}>{<ChevronDown />}</IconButton>
-);
+const Template = (args) => <IconButton {...args} />;
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const GridContainer = (props) => (
   <Box
@@ -42,7 +58,7 @@ const GridContainer = (props) => (
   />
 );
 
-const VariantAndSizeTemplate: Story = (args) => (
+const VariantAndSizeTemplate = (args) => (
   <GridContainer>
     <span>Variant / Size</span>
     <span>Large</span>
@@ -86,23 +102,21 @@ const VariantAndSizeTemplate: Story = (args) => (
   </GridContainer>
 );
 
-export const VariantAndSize = VariantAndSizeTemplate.bind({});
+export const VariantAndSize: Story = VariantAndSizeTemplate.bind({});
 
-export const VariantAndSizeDisabled = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeDisabled: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeDisabled.args = { disabled: true };
 
-export const VariantAndSizeHover = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeHover: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeHover.parameters = { pseudo: { hover: true } };
 
-export const VariantAndSizeFocus = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeFocus: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeFocus.parameters = { pseudo: { focus: true } };
 
-export const VariantAndSizeActive = VariantAndSizeTemplate.bind({});
+export const VariantAndSizeActive: Story = VariantAndSizeTemplate.bind({});
 VariantAndSizeActive.parameters = { pseudo: { active: true } };
 
-const IconButtonDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = IconButtonDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'IconButton',
@@ -140,9 +154,7 @@ Documentation.args = {
   },
 };
 
-const IconButtonChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = IconButtonChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Input/Input.stories.tsx
+++ b/libs/spark/src/Input/Input.stories.tsx
@@ -1,59 +1,71 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone, QuestionDuotone } from '@prenda/spark-icons';
-import { default as Input, InputProps } from './Input';
-import InputAdornment from '../InputAdornment';
-import styled from '../styled';
+import { Input, InputAdornment, InputProps, styled } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
 
-export const TypedInput = (props: InputProps) => <Input {...props} />;
+interface SbInputProps extends InputProps {
+  defaultValue?: InputProps['defaultValue'];
+  disabled?: InputProps['disabled'];
+  endAdornment?: InputProps['endAdornment'];
+  error?: InputProps['error'];
+  fullWidth?: InputProps['fullWidth'];
+  id?: InputProps['id'];
+  multiline?: InputProps['multiline'];
+  name?: InputProps['name'];
+  placeholder?: InputProps['placeholder'];
+  readOnly?: InputProps['readOnly'];
+  required?: InputProps['required'];
+  rows?: InputProps['rows'];
+  maxRows?: InputProps['maxRows'];
+  minRows?: InputProps['minRows'];
+  startAdornment?: InputProps['startAdornment'];
+  type?: InputProps['type'];
+  value?: InputProps['value'];
+}
+
+export const SbInput = (props: SbInputProps) => <Input {...props} />;
 
 export default {
   title: '@ps/Input',
-  component: TypedInput,
-  excludeStories: ['TypedInput'],
-  // Misses all props
+  component: SbInput,
+  excludeStories: ['SbInput'],
   argTypes: {
-    placeholder: { control: 'text' },
-    error: { control: 'boolean' },
-    success: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    multiline: { control: 'boolean' },
-    rows: { control: 'number' },
-    startAdornment: { control: 'select', options: [undefined, 'GearDuotone'] },
+    startAdornment: {
+      control: 'select',
+      options: ['undefined', 'GearDuotone'],
+      mapping: {
+        undefined: undefined,
+        GearDuotone: (
+          <InputAdornment position="start">
+            <GearDuotone />
+          </InputAdornment>
+        ),
+      },
+    },
     endAdornment: {
       control: 'select',
-      options: [undefined, 'QuestionDuotone'],
+      options: ['undefined', 'QuestionDuotone'],
+      mapping: {
+        undefined: undefined,
+        QuestionDuotone: (
+          <InputAdornment position="end">
+            <QuestionDuotone />
+          </InputAdornment>
+        ),
+      },
     },
   },
   args: {
     placeholder: 'Placeholder',
-    startAdornment: undefined,
-    endAdornment: undefined,
   },
 } as Meta;
 
-const Template: Story = ({ startAdornment, endAdornment, ...args }) => (
-  <Input
-    startAdornment={
-      startAdornment ? (
-        <InputAdornment position="start">
-          <GearDuotone />
-        </InputAdornment>
-      ) : undefined
-    }
-    endAdornment={
-      endAdornment ? (
-        <InputAdornment position="end">
-          <QuestionDuotone />
-        </InputAdornment>
-      ) : undefined
-    }
-    {...args}
-  />
+const Template = ({ startAdornment, endAdornment, ...args }) => (
+  <Input {...args} />
 );
 
-export const ConfigurableInput = Template.bind({});
+export const ConfigurableInput: Story = Template.bind({});
 
 const OuterGroup = styled('span')({
   display: 'flex',
@@ -70,7 +82,7 @@ const InnerGroup = styled('span')({
   gap: '1rem',
 });
 
-const StatesTemplate: Story = ({ pseudo, ...args }) => (
+const StatesTemplate = ({ pseudo, ...args }) => (
   <OuterGroup>
     <InnerGroup>
       <Input {...args} />
@@ -117,13 +129,13 @@ const StatesTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesFocus = StatesTemplate.bind({});
+export const StatesFocus: Story = StatesTemplate.bind({});
 StatesFocus.args = { pseudo: true };
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
+const AdornmentsTemplate = ({ pseudo, ...args }) => (
   <OuterGroup>
     <InnerGroup>
       <Input {...args} />
@@ -136,27 +148,17 @@ const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const StartAdornment = AdornmentsTemplate.bind({});
+export const StartAdornment: Story = AdornmentsTemplate.bind({});
 StartAdornment.args = {
-  startAdornment: (
-    <InputAdornment position="start">
-      <GearDuotone />
-    </InputAdornment>
-  ),
+  startAdornment: 'GearDuotone',
 };
 
-export const EndAdornment = AdornmentsTemplate.bind({});
+export const EndAdornment: Story = AdornmentsTemplate.bind({});
 EndAdornment.args = {
-  endAdornment: (
-    <InputAdornment position="end">
-      <QuestionDuotone />
-    </InputAdornment>
-  ),
+  endAdornment: 'QuestionDuotone',
 };
 
-const InputChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = InputChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/MenuItem/MenuItem.stories.tsx
+++ b/libs/spark/src/MenuItem/MenuItem.stories.tsx
@@ -1,30 +1,62 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone } from '@prenda/spark-icons';
-import Avatar from '../Avatar';
-import Box from '../Box';
-import Checkbox from '../Checkbox';
-import ListItemAvatar from '../ListItemAvatar';
-import ListItemText from '../ListItemText';
-import ListItemIcon from '../ListItemIcon';
-import { default as MenuItem, MenuItemTypeMap } from './MenuItem';
+import {
+  Avatar,
+  Box,
+  Checkbox,
+  ListItemAvatar,
+  ListItemIcon,
+  ListItemIconProps,
+  ListItemText,
+  ListItemTextProps,
+  MenuItem,
+  MenuItemProps,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
-import type { OverridableComponent } from '../utils';
 
-export const TypedMenuItem: OverridableComponent<MenuItemTypeMap> = (props) => (
-  <MenuItem {...props} />
-);
+// underlying MenuItemProps don't have descriptions
+interface SbMenuItemProps extends MenuItemProps {
+  /**
+   * **[Storybook-only]:** passed to `ListItemText` child.**]**
+   *
+   * The main content element.
+   */
+  sb_ListItemText_primary?: ListItemTextProps['primary'];
+  /**
+   * **[Storybook-only]:** passed to `ListItemIcon` child.**]**
+   *
+   * The content of the component, normally `SvgIcon` or a `@prenda/spark-icons` SVG icon element.
+   */
+  sb_ListItemIcon_children?: ListItemIconProps['children'];
+}
+
+export const SbMenuItem = ({
+  sb_ListItemText_primary,
+  sb_ListItemIcon_children,
+  button,
+  ...other
+}: SbMenuItemProps) => <MenuItem {...other} />;
 
 export default {
   title: '@ps/MenuItem',
-  component: TypedMenuItem,
-  excludeStories: ['TypedMenuItem'],
+  component: SbMenuItem,
+  excludeStories: ['SbMenuItem'],
+  argTypes: {
+    sb_ListItemIcon_children: {
+      type: 'select',
+      options: ['undefined', 'GearDuotone'],
+      mapping: {
+        undefined: undefined,
+        GearDuotone: <GearDuotone />,
+      },
+    },
+  },
   args: {
-    text: 'Menu item',
-    startIcon: false,
+    sb_ListItemText_primary: 'Menu item',
     button: true,
   },
 } as Meta;
@@ -41,22 +73,29 @@ const Container = (props) => (
   />
 );
 
-const Template: Story = ({ text, startIcon, args }) => (
+const Template = ({
+  sb_ListItemText_primary,
+  sb_ListItemIcon_children,
+  args,
+}) => (
   <Container>
     <MenuItem {...args}>
-      {startIcon ? (
-        <ListItemIcon>
-          <GearDuotone />
-        </ListItemIcon>
+      {sb_ListItemIcon_children ? (
+        <ListItemIcon>{sb_ListItemIcon_children}</ListItemIcon>
       ) : null}
-      <ListItemText primary={text} />
+      <ListItemText primary={sb_ListItemText_primary} />
     </MenuItem>
   </Container>
 );
 
 export const Configurable: Story = Template.bind({});
 
-const CompositionsTemplate: Story = ({ startIcon, ...args }) => (
+const CompositionsTemplate = ({
+  startIcon,
+  sb_ListItemText_primary,
+  sb_ListItemIcon_children,
+  ...args
+}) => (
   <Container>
     <MenuItem {...args}>
       <ListItemText primary="Menu item" />
@@ -88,37 +127,37 @@ const CompositionsTemplate: Story = ({ startIcon, ...args }) => (
   </Container>
 );
 
-export const Compositions = CompositionsTemplate.bind({});
+export const Compositions: Story = CompositionsTemplate.bind({});
 
-export const CompositionsHover = CompositionsTemplate.bind({});
+export const CompositionsHover: Story = CompositionsTemplate.bind({});
 CompositionsHover.parameters = { pseudo: { hover: true } };
 
-export const CompositionsFocus = CompositionsTemplate.bind({});
+export const CompositionsFocus: Story = CompositionsTemplate.bind({});
 CompositionsFocus.parameters = { pseudo: { focus: true } };
 
-export const CompositionsActive = CompositionsTemplate.bind({});
+export const CompositionsActive: Story = CompositionsTemplate.bind({});
 CompositionsActive.parameters = { pseudo: { active: true } };
 
-export const CompositionsDisabled = CompositionsTemplate.bind({});
+export const CompositionsDisabled: Story = CompositionsTemplate.bind({});
 CompositionsDisabled.args = { disabled: true };
 
-export const CompositionsSelected = CompositionsTemplate.bind({});
+export const CompositionsSelected: Story = CompositionsTemplate.bind({});
 CompositionsSelected.args = { selected: true };
 
-export const CompositionsSelectedHover = CompositionsTemplate.bind({});
+export const CompositionsSelectedHover: Story = CompositionsTemplate.bind({});
 CompositionsSelectedHover.args = { selected: true };
 CompositionsSelectedHover.parameters = { pseudo: { hover: true } };
 
-export const CompositionsSelectedFocus = CompositionsTemplate.bind({});
+export const CompositionsSelectedFocus: Story = CompositionsTemplate.bind({});
 CompositionsSelectedFocus.args = { selected: true };
 CompositionsSelectedFocus.parameters = { pseudo: { focus: true } };
 
-export const CompositionsSelectedDisabled = CompositionsTemplate.bind({});
+export const CompositionsSelectedDisabled: Story = CompositionsTemplate.bind(
+  {}
+);
 CompositionsSelectedDisabled.args = { selected: true, disabled: true };
 
-const MenuItemDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = MenuItemDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'MenuItem',
@@ -136,9 +175,7 @@ Documentation.args = {
   },
 };
 
-const MenuItemChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = MenuItemChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/MenuList/MenuList.stories.tsx
+++ b/libs/spark/src/MenuList/MenuList.stories.tsx
@@ -1,27 +1,40 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Avatar from '../Avatar';
-import Divider from '../Divider';
-import Checkbox from '../Checkbox';
-import ListItemAvatar from '../ListItemAvatar';
-import ListItemText from '../ListItemText';
-import ListItemIcon from '../ListItemIcon';
-import ListSubheader from '../ListSubheader';
-import MenuItem from '../MenuItem';
-import { default as MenuList, MenuListProps } from './MenuList';
-import Paper from '../Paper';
-import withStyles from '../withStyles';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Avatar,
+  Checkbox,
+  Divider,
+  ListItemAvatar,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+  MenuItem,
+  MenuList,
+  MenuListProps,
+  Paper,
+  withStyles,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedMenuList = (props: MenuListProps) => <MenuList {...props} />;
+// underlying MenuListProps don't have descriptions
+interface SbMenuListProps extends MenuListProps {
+  autoFocus?: MenuListProps['autoFocus'];
+  autoFocusItem?: MenuListProps['autoFocusItem'];
+  children?: MenuListProps['children'];
+  disabledItemsFocusable?: MenuListProps['disabledItemsFocusable'];
+  disableListWrap?: MenuListProps['disableListWrap'];
+  variant?: MenuListProps['variant'];
+}
+
+export const SbMenuList = (props: SbMenuListProps) => <MenuList {...props} />;
 
 export default {
   title: '@ps/MenuList',
-  component: TypedMenuList,
-  excludeStories: ['TypedMenuList'],
+  component: SbMenuList,
+  excludeStories: ['SbMenuList'],
 } as Meta;
 
 const CustomPaper = withStyles((theme) => ({
@@ -35,7 +48,7 @@ const CustomPaper = withStyles((theme) => ({
   },
 }))(Paper);
 
-export const Basic = (args) => (
+export const Basic: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList {...args}>
       {['Profile', 'Resources', 'Menu item', 'Sign out'].map((primary) => (
@@ -47,7 +60,7 @@ export const Basic = (args) => (
   </CustomPaper>
 );
 
-export const Sectioned = (args) => (
+export const Sectioned: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList {...args}>
       {['Profile', 'Resources'].map((primary) => (
@@ -65,7 +78,7 @@ export const Sectioned = (args) => (
   </CustomPaper>
 );
 
-export const Checkboxes = (args) => (
+export const Checkboxes: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList {...args}>
       {[1, 2, 3, 4, 5, 6, 7].map((i) => (
@@ -84,7 +97,7 @@ export const Checkboxes = (args) => (
   </CustomPaper>
 );
 
-export const Avatars = (args) => (
+export const Avatars: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList {...args}>
       {[
@@ -128,7 +141,7 @@ export const Avatars = (args) => (
   </CustomPaper>
 );
 
-export const Scrolling = (args) => (
+export const Scrolling: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList {...args}>
       {Array.from(Array(16).keys()).map((i) => (
@@ -140,7 +153,7 @@ export const Scrolling = (args) => (
   </CustomPaper>
 );
 
-export const SectionTitle = (args) => (
+export const SectionTitle: Story = (args) => (
   <CustomPaper elevation={4}>
     <MenuList
       subheader={
@@ -159,9 +172,7 @@ export const SectionTitle = (args) => (
   </CustomPaper>
 );
 
-const MenuListDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = MenuListDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'MenuList',
@@ -179,9 +190,7 @@ Documentation.args = {
   },
 };
 
-const MenuListChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = MenuListChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/NavBar/NavBar.stories.tsx
+++ b/libs/spark/src/NavBar/NavBar.stories.tsx
@@ -1,26 +1,32 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   BeakerDuotone,
   HomeDuotone,
   InboxFilledDuotone,
   MountainDuotone,
-  UsersDuotone,
   PrendaMonogram,
+  UsersDuotone,
 } from '@prenda/spark-icons';
-import Avatar from '../Avatar';
-import { default as NavBar, NavBarProps } from './NavBar';
-import NavBarButton from '../NavBarButton';
-import Toolbar from '../Toolbar';
-import styled from '../styled';
-import withStyles from '../withStyles';
+import {
+  Avatar,
+  NavBar,
+  NavBarButton,
+  NavBarProps,
+  Toolbar,
+  styled,
+  withStyles,
+} from '..';
 
-export const TypedNavBar = (props: NavBarProps) => <NavBar {...props} />;
+export const SbNavBar = (props: NavBarProps) => <NavBar {...props} />;
 
 export default {
   title: '@ps/NavBar',
-  component: TypedNavBar,
-  excludeStories: ['TypedNavBar'],
+  component: SbNavBar,
+  excludeStories: ['SbNavBar'],
+  args: {
+    color: 'default',
+  },
 } as Meta;
 
 const BluePrendaMonogram = styled(PrendaMonogram)(({ theme }) => ({
@@ -44,7 +50,7 @@ const InboxNavBarButton = withStyles({
   },
 })(NavBarButton);
 
-const Template: Story<NavBarProps> = (args) => (
+const Template = (args: NavBarProps) => (
   <NavBar {...args}>
     <CustomToolbar>
       <BluePrendaMonogram />
@@ -75,4 +81,4 @@ const Template: Story<NavBarProps> = (args) => (
   </NavBar>
 );
 
-export const Basic = Template.bind({});
+export const Basic: Story = Template.bind({});

--- a/libs/spark/src/NavBar/NavBar.tsx
+++ b/libs/spark/src/NavBar/NavBar.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { default as AppBar, AppBarProps } from '@material-ui/core/AppBar';
 import withStyles from '../withStyles';
 
-export interface NavBarProps extends AppBarProps {
+export interface NavBarProps extends Omit<AppBarProps, 'color'> {
+  /**
+   * @default 'default'
+   */
   color?: 'default';
 }
 

--- a/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
+++ b/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
@@ -1,53 +1,60 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { CheckCircleDuotone } from '@prenda/spark-icons';
-import Box from '../Box';
-import { default as NavBarButton, NavBarButtonProps } from './NavBarButton';
+import { Box, NavBarButton, NavBarButtonProps } from '..';
 
-export const TypedNavBarButton = (props: NavBarButtonProps) => (
+interface SbNavBarButtonProps
+  extends Omit<
+    NavBarButtonProps,
+    | 'centerRipple'
+    | 'disableRipple'
+    | 'disableElevation'
+    | 'disableFocusRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'tabIndex'
+    | 'TouchRippleProps'
+  > {
+  /**
+   * **[Storybook-note:** available if `component='a'` or equivalent.**]**
+   */
+  href?: string;
+}
+export const SbNavBarButton = (props: SbNavBarButtonProps) => (
   <NavBarButton {...props} />
 );
 
 export default {
   title: '@ps/NavBarButton',
-  component: TypedNavBarButton,
-  excludeStories: ['TypedNavBarButton'],
+  component: SbNavBarButton,
+  excludeStories: ['SbNavBarButton'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
   argTypes: {
-    onClick: { actions: 'clicked' },
     disabled: { control: 'boolean' },
     startIcon: {
-      control: {
-        type: 'select',
-        options: [undefined, `check-circle-duotone`],
+      control: 'select',
+      options: ['undefined', 'CheckCircleDuotone'],
+      mapping: {
+        undefined: undefined,
+        CheckCircleDuotone: <CheckCircleDuotone />,
       },
     },
     endIcon: {
-      control: {
-        type: 'select',
-        options: [undefined, `check-circle-duotone`],
+      control: 'select',
+      options: ['undefined', 'CheckCircleDuotone'],
+      mapping: {
+        undefined: undefined,
+        CheckCircleDuotone: <CheckCircleDuotone />,
       },
     },
-    href: { control: 'text' },
   },
-  args: {},
+  args: {
+    children: 'Label',
+  },
 } as Meta;
 
-interface TemplateButtonProps
-  extends Omit<NavBarButtonProps, 'startIcon' | 'endIcon'> {
-  startIcon?: typeof CheckCircleDuotone;
-  endIcon?: typeof CheckCircleDuotone;
-}
-
-const Template: Story<TemplateButtonProps> = (args) => (
-  <NavBarButton
-    {...args}
-    startIcon={args.startIcon ? <CheckCircleDuotone /> : undefined}
-    endIcon={args.endIcon ? <CheckCircleDuotone /> : undefined}
-  >
-    Label
-  </NavBarButton>
-);
-export const Configurable = Template.bind({});
+const Template = (args: NavBarButtonProps) => <NavBarButton {...args} />;
+export const Configurable: Story = Template.bind({});
 
 const GridContainer = (props) => (
   <Box
@@ -60,7 +67,7 @@ const GridContainer = (props) => (
   />
 );
 
-const AllTemplate: Story = (args) => (
+const AllTemplate = (args) => (
   <GridContainer>
     <span>
       <NavBarButton {...args}>Label</NavBarButton>
@@ -93,16 +100,16 @@ const AllTemplate: Story = (args) => (
   </GridContainer>
 );
 
-export const All = AllTemplate.bind({});
+export const All: Story = AllTemplate.bind({});
 
-export const AllDisabled = AllTemplate.bind({});
+export const AllDisabled: Story = AllTemplate.bind({});
 AllDisabled.args = { disabled: true };
 
-export const AllHover = AllTemplate.bind({});
+export const AllHover: Story = AllTemplate.bind({});
 AllHover.parameters = { pseudo: { hover: true } };
 
-export const AllFocus = AllTemplate.bind({});
+export const AllFocus: Story = AllTemplate.bind({});
 AllFocus.parameters = { pseudo: { focus: true } };
 
-export const AllActive = AllTemplate.bind({});
+export const AllActive: Story = AllTemplate.bind({});
 AllActive.parameters = { pseudo: { active: true } };

--- a/libs/spark/src/Pagination/Pagination.stories.tsx
+++ b/libs/spark/src/Pagination/Pagination.stories.tsx
@@ -1,30 +1,34 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
-import { default as Pagination, PaginationProps } from './Pagination';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Pagination, PaginationProps } from '..';
 
-export const TypedPagination = (props: PaginationProps) => (
+interface SbPaginationProps extends PaginationProps {
+  boundaryCount?: PaginationProps['boundaryCount'];
+  count?: PaginationProps['count'];
+  defaultPage?: PaginationProps['defaultPage'];
+  disabled?: PaginationProps['disabled'];
+  hideNextButton?: PaginationProps['hideNextButton'];
+  hidePrevButton?: PaginationProps['hidePrevButton'];
+  onChange?: PaginationProps['onChange'];
+  page?: PaginationProps['page'];
+  showFirstButton?: PaginationProps['showFirstButton'];
+  showLastButton?: PaginationProps['showLastButton'];
+  siblingCount?: PaginationProps['siblingCount'];
+}
+export const SbPagination = (props: SbPaginationProps) => (
   <Pagination {...props} />
 );
 
 export default {
   title: '@ps/Pagination',
-  component: TypedPagination,
-  excludeStories: ['TypedPagination'],
-  // Doesn't pick up props
-  argTypes: {
-    count: { control: 'number' },
-    defaultPage: { control: 'number' },
-    siblingCount: { control: 'number' },
-    boundaryCount: { control: 'number' },
-    showFirstButton: { control: 'boolean' },
-    showLastButton: { control: 'boolean' },
-    hideNextButton: { control: 'boolean' },
-    hidePrevButton: { control: 'boolean' },
-  },
+  component: SbPagination,
+  excludeStories: ['SbPagination'],
   args: {
     count: 10,
     defaultPage: 2,
   },
 } as Meta;
 
-export const ConfigurablePagination = (args) => <Pagination {...args} />;
+export const ConfigurablePagination: Story = (args: SbPaginationProps) => (
+  <Pagination {...args} />
+);

--- a/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
+++ b/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
@@ -1,34 +1,34 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import {
-  default as PaginationItem,
-  PaginationItemTypeMap,
-} from './PaginationItem';
-import type { OverridableComponent } from '../utils';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { PaginationItem, PaginationItemProps } from '..';
 
-export const TypedPaginationItem: OverridableComponent<PaginationItemTypeMap> = (
-  props
-) => <PaginationItem {...props} />;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface SbPaginationItemProps
+  extends Omit<PaginationItemProps, 'color' | 'shape' | 'size' | 'variant'> {}
+
+export const SbPaginationItem = (props: SbPaginationItemProps) => (
+  <PaginationItem {...props} />
+);
 
 export default {
   title: '@ps/Pagination Item',
-  component: TypedPaginationItem,
-  excludeStories: ['TypedPaginationItem'],
+  component: SbPaginationItem,
+  excludeStories: ['SbPaginationItem'],
   args: {
     type: 'page',
     page: 1,
   },
 } as Meta;
 
-const Template: Story = (args) => (
+const Template = (args: PaginationItemProps) => (
   <div style={{ margin: '1rem', height: '3rem', aspectRatio: '1' }}>
     <PaginationItem {...args} />
   </div>
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story<PaginationItemProps> = Template.bind({});
 
-const DefaultTemplate: Story = () => (
+const DefaultTemplate = () => (
   <div style={{ margin: '1rem', display: 'flex', gap: '1rem' }}>
     <PaginationItem type="page" page={1} />
     <PaginationItem type="first" />
@@ -40,9 +40,9 @@ const DefaultTemplate: Story = () => (
   </div>
 );
 
-export const Default = DefaultTemplate.bind({});
+export const Default: Story = DefaultTemplate.bind({});
 
-const PseudoTemplate: Story = () => (
+const PseudoTemplate = () => (
   <div style={{ margin: '1rem', display: 'flex', gap: '1rem' }}>
     <PaginationItem type="page" page={1} />
     <PaginationItem type="first" />
@@ -52,22 +52,22 @@ const PseudoTemplate: Story = () => (
   </div>
 );
 
-export const DefaultHover = PseudoTemplate.bind({});
+export const DefaultHover: Story = PseudoTemplate.bind({});
 DefaultHover.parameters = { pseudo: { hover: true } };
 
-export const DefaultFocus = PseudoTemplate.bind({});
+export const DefaultFocus: Story = PseudoTemplate.bind({});
 DefaultFocus.parameters = { pseudo: { focus: true } };
 
-const SelectedTemplate: Story = () => (
+const SelectedTemplate = () => (
   <div style={{ margin: '1rem', display: 'flex', gap: '1rem' }}>
     <PaginationItem type="page" page={1} selected />
   </div>
 );
 
-export const Selected = SelectedTemplate.bind({});
+export const Selected: Story = SelectedTemplate.bind({});
 
-export const SelectedHover = SelectedTemplate.bind({});
+export const SelectedHover: Story = SelectedTemplate.bind({});
 SelectedHover.parameters = { pseudo: { hover: true } };
 
-export const SelectedFocus = SelectedTemplate.bind({});
+export const SelectedFocus: Story = SelectedTemplate.bind({});
 SelectedFocus.parameters = { pseudo: { focus: true } };

--- a/libs/spark/src/Radio/Radio.stories.tsx
+++ b/libs/spark/src/Radio/Radio.stories.tsx
@@ -1,14 +1,28 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import FormControlLabel from '../FormControlLabel';
-import { default as Radio, RadioProps } from './Radio';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { FormControlLabel, Radio, RadioProps } from '..';
 
-export const TypedRadio = (props: RadioProps) => <Radio {...props} />;
+// Doesn't pick up extended SwitchBaseProps
+interface SbRadioProps
+  extends Omit<
+    RadioProps,
+    | 'disableFocusRipple'
+    | 'centerRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'TouchRippleProps'
+  > {
+  checked?: RadioProps['checked'];
+  disabled?: RadioProps['disabled'];
+  value?: RadioProps['value'];
+}
+
+export const SbRadio = (props: SbRadioProps) => <Radio {...props} />;
 
 export default {
   title: '@ps/Radio',
-  component: TypedRadio,
-  excludeStories: ['TypedRadio'],
+  component: SbRadio,
+  excludeStories: ['SbRadio'],
   parameters: { actions: { handles: ['change'] } },
   // Doesn't pick up extended SwitchBaseProps
   argTypes: {
@@ -17,7 +31,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story = (args) => (
+const Template = (args) => (
   <Radio
     // a11y required props when there's no label
     name="Demo"
@@ -27,9 +41,9 @@ const Template: Story = (args) => (
   />
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
-const StatesTemplate: Story = () => (
+const StatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <Radio
       name="nameA"
@@ -58,7 +72,7 @@ const StatesTemplate: Story = () => (
   </div>
 );
 
-const PseudoStatesTemplate: Story = () => (
+const PseudoStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <Radio
       name="nameA"
@@ -74,15 +88,15 @@ const PseudoStatesTemplate: Story = () => (
   </div>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesHover = PseudoStatesTemplate.bind({});
+export const StatesHover: Story = PseudoStatesTemplate.bind({});
 StatesHover.parameters = { pseudo: { hover: true } };
 
-export const StatesFocus = PseudoStatesTemplate.bind({});
+export const StatesFocus: Story = PseudoStatesTemplate.bind({});
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const LabeledStatesTemplate: Story = () => (
+const LabeledStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <FormControlLabel label="Label" control={<Radio />} />
     <FormControlLabel label="Label" control={<Radio />} disabled />
@@ -91,17 +105,17 @@ const LabeledStatesTemplate: Story = () => (
   </div>
 );
 
-const PseudoLabeledStatesTemplate: Story = () => (
+const PseudoLabeledStatesTemplate = () => (
   <div style={{ display: 'flex', gap: '1rem', margin: '1rem' }}>
     <FormControlLabel label="Label" control={<Radio />} />
     <FormControlLabel label="Label" control={<Radio />} checked />
   </div>
 );
 
-export const LabeledStates = LabeledStatesTemplate.bind({});
+export const LabeledStates: Story = LabeledStatesTemplate.bind({});
 
-export const LabeledStatesHover = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesHover: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesHover.parameters = { pseudo: { hover: true } };
 
-export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesFocus: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesFocus.parameters = { pseudo: { focus: true } };

--- a/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
+++ b/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,57 +1,82 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import FormControl from '../FormControl';
-import FormControlLabel from '../FormControlLabel';
-import FormHelperText from '../FormHelperText';
-import FormLabel from '../FormLabel';
-import Radio from '../Radio';
-import { default as RadioGroup, RadioGroupProps } from './RadioGroup';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  FormControl,
+  FormControlProps,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  RadioGroupProps,
+} from '..';
 import { DocumentationTemplate } from '../../stories/templates';
 
-export const TypedRadioGroup = (props: RadioGroupProps) => (
-  <RadioGroup {...props} />
-);
+interface SbRadioGroupProps extends RadioGroupProps {
+  ['aria-label']?: RadioGroupProps['aria-label'];
+  defaultValue?: RadioGroupProps['defaultValue'];
+  name?: RadioGroupProps['name'];
+  onChange?: RadioGroupProps['onChange'];
+  row?: RadioGroupProps['row'];
+  value?: RadioGroupProps['value'];
+  /**
+   * **[Storybook-only:** passed to parent `FormControl`.**]**
+   */
+  sb_FormControl_disabled?: FormControlProps['disabled'];
+  /**
+   * **[Storybook-only:** passed to parent `FormControl`.**]**
+   */
+  sb_FormControl_error?: FormControlProps['error'];
+  /**
+   * **[Storybook-only:** passed to parent `FormControl`.**]**
+   */
+  sb_FormControl_required?: FormControlProps['required'];
+}
+
+export const SbRadioGroup = ({
+  sb_FormControl_disabled,
+  sb_FormControl_error,
+  sb_FormControl_required,
+  ...other
+}: SbRadioGroupProps) => <RadioGroup {...other} />;
 
 export default {
   title: '@ps/RadioGroup',
-  component: TypedRadioGroup,
-  excludeStories: ['TypedRadioGroup'],
-  parameters: { actions: { handles: ['change'] } },
-  // Doesn't pickup props
+  component: SbRadioGroup,
+  excludeStories: ['SbRadioGroup'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
   argTypes: {
     value: {
-      control: { type: 'select' },
+      control: 'select',
       options: ['valueA', 'valueB', 'valueC', 'valueD'],
     },
     defaultValue: {
-      control: { type: 'select' },
+      control: 'select',
       options: ['valueA', 'valueB', 'valueC', 'valueD'],
     },
-    row: { control: 'boolean' },
-    error: { control: 'boolean' },
-    required: { control: 'boolean' },
-    disabled: { control: 'boolean' },
   },
   args: {
     defaultValue: 'valueB',
     'aria-label': 'example group',
     name: 'exampleGroup',
-    row: false,
-    error: false,
-    required: false,
-    disabled: false,
   },
 } as Meta;
 
-const Template: Story = ({ required, error, disabled, value, ...args }) => (
+const Template = ({
+  sb_FormControl_required,
+  sb_FormControl_error,
+  sb_FormControl_disabled,
+  value,
+  ...args
+}) => (
   <FormControl
     component="fieldset"
-    error={error}
-    required={required}
-    disabled={disabled}
+    error={sb_FormControl_error}
+    required={sb_FormControl_required}
+    disabled={sb_FormControl_disabled}
   >
     <FormLabel component="legend">Group label</FormLabel>
-    <RadioGroup value={error ? null : value} {...args}>
+    <RadioGroup value={sb_FormControl_error ? null : value} {...args}>
       <FormControlLabel value="valueA" control={<Radio />} label="Option A" />
       <FormControlLabel value="valueB" control={<Radio />} label="Option B" />
       <FormControlLabel value="valueC" control={<Radio />} label="Option C" />
@@ -63,14 +88,14 @@ const Template: Story = ({ required, error, disabled, value, ...args }) => (
       />
     </RadioGroup>
     <FormHelperText>
-      {error ? 'Please select an option' : 'Helper text'}
+      {sb_FormControl_error ? 'Please select an option' : 'Helper text'}
     </FormHelperText>
   </FormControl>
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
-const StatesTemplate: Story = ({ row, pseudo }) => (
+const StatesTemplate = ({ row, pseudo }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
     <FormControl component="fieldset">
       <FormLabel component="legend">Group label</FormLabel>
@@ -133,28 +158,28 @@ const StatesTemplate: Story = ({ row, pseudo }) => (
   </div>
 );
 
-export const ColumnStates = StatesTemplate.bind({});
+export const ColumnStates: Story = StatesTemplate.bind({});
 
-export const ColumnStatesHover = StatesTemplate.bind({});
+export const ColumnStatesHover: Story = StatesTemplate.bind({});
 ColumnStatesHover.args = { pseudo: true };
 ColumnStatesHover.parameters = { pseudo: { hover: true } };
 
-export const ColumnStatesFocus = StatesTemplate.bind({});
+export const ColumnStatesFocus: Story = StatesTemplate.bind({});
 ColumnStatesFocus.args = { pseudo: true };
 ColumnStatesFocus.parameters = { pseudo: { focus: true } };
 
-export const RowStates = StatesTemplate.bind({});
+export const RowStates: Story = StatesTemplate.bind({});
 RowStates.args = { row: true };
 
-export const RowStatesHover = StatesTemplate.bind({});
+export const RowStatesHover: Story = StatesTemplate.bind({});
 RowStatesHover.args = { pseudo: true, row: true };
 RowStatesHover.parameters = { pseudo: { hover: true } };
 
-export const RowStatesFocus = StatesTemplate.bind({});
+export const RowStatesFocus: Story = StatesTemplate.bind({});
 RowStatesFocus.args = { pseudo: true, row: true };
 RowStatesFocus.parameters = { pseudo: { focus: true } };
 
-export const Documentation = DocumentationTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'RadioGroup',

--- a/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
+++ b/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
@@ -1,44 +1,38 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
-  default as SectionMessage,
+  SectionMessage,
   SectionMessageProps,
-} from './SectionMessage';
-import SectionMessageTitle from '../SectionMessageTitle';
-import styled from '../styled';
+  SectionMessageTitle,
+  styled,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedSectionMessage = (props: SectionMessageProps) => (
+interface SbSectionMessageProps extends SectionMessageProps {
+  severity?: SectionMessageProps['severity'];
+}
+
+export const SbSectionMessage = (props: SbSectionMessageProps) => (
   <SectionMessage {...props} />
 );
 
 export default {
   title: '@ps/SectionMessage',
-  component: TypedSectionMessage,
-  excludeStories: ['TypedSectionMessage'],
-  // Doesn't pick up props
-  argTypes: {
-    severity: {
-      control: 'select',
-      options: ['error', 'info', 'warning', 'success'],
-    },
-  },
-  args: {
-    severity: 'info',
-  },
+  component: SbSectionMessage,
+  excludeStories: ['SbSectionMessage'],
 } as Meta;
 
-const Template: Story = (args) => (
+const Template = (args) => (
   <SectionMessage {...args}>
     <SectionMessageTitle>Section Message</SectionMessageTitle>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   </SectionMessage>
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const Container = styled('div')({
   display: 'flex',
@@ -46,7 +40,7 @@ const Container = styled('div')({
   gap: 16,
 });
 
-const SeverityTemplate: Story = (args) => (
+const SeverityTemplate = (args) => (
   <Container>
     <SectionMessage {...args} severity="info">
       <SectionMessageTitle>Section Message</SectionMessageTitle>
@@ -67,16 +61,16 @@ const SeverityTemplate: Story = (args) => (
   </Container>
 );
 
-export const Severity = SeverityTemplate.bind({});
+export const Severity: Story = SeverityTemplate.bind({});
 
-export const SeverityClose = SeverityTemplate.bind({});
+export const SeverityClose: Story = SeverityTemplate.bind({});
 SeverityClose.args = {
   onClose: () => {
     return;
   },
 };
 
-export const SeverityCloseFocus = SeverityTemplate.bind({});
+export const SeverityCloseFocus: Story = SeverityTemplate.bind({});
 SeverityCloseFocus.args = {
   onClose: () => {
     return;
@@ -84,9 +78,7 @@ SeverityCloseFocus.args = {
 };
 SeverityCloseFocus.parameters = { pseudo: { focus: true } };
 
-const SectionMessageDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = SectionMessageDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Alert',
@@ -110,11 +102,7 @@ Documentation.args = {
   },
 };
 
-const SectionMessageChangelogTemplate = (args) => (
-  <ChangelogTemplate {...args} />
-);
-
-export const Changelog: Story = SectionMessageChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Select/Select.stories.tsx
+++ b/libs/spark/src/Select/Select.stories.tsx
@@ -1,53 +1,58 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone } from '@prenda/spark-icons';
-import { default as Select, SelectProps } from './Select';
-import styled from '../styled';
-import MenuItem from '../MenuItem';
-import InputAdornment from '../InputAdornment';
+import { InputAdornment, MenuItem, Select, SelectProps, styled } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
 
-export const TypedSelect = (props: SelectProps) => <Select {...props} />;
+interface SbSelectProps extends SelectProps {
+  /**
+   * **Note**: the custom `success` styling is delivered through a class name instead of a prop.
+   */
+  className?: SelectProps['className'];
+  disabled?: SelectProps['disabled'];
+  displayEmpty?: SelectProps['displayEmpty'];
+  error?: SelectProps['error'];
+  open?: SelectProps['open'];
+  startAdornment?: SelectProps['startAdornment'];
+  success?: boolean;
+  value?: SelectProps['value'];
+}
+
+export const SbSelect = (props: SbSelectProps) => <Select {...props} />;
 
 export default {
   title: '@ps/Select',
-  component: TypedSelect,
-  excludeStories: ['TypedSelect'],
-  parameters: { actions: { handles: ['change'] } },
+  component: SbSelect,
+  excludeStories: ['SbSelect'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
   // Doesn't pick up props
   argTypes: {
-    value: { control: 'text' },
-    displayEmpty: { control: 'boolean' },
-    error: { control: 'boolean' },
-    success: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    open: { control: 'boolean' },
-    startAdornment: { control: 'select', options: [undefined, 'GearDuotone'] },
+    className: { control: 'select', options: [undefined, 'Spark-success'] },
+    startAdornment: {
+      control: 'select',
+      options: ['undefined', 'GearDuotone'],
+      mapping: {
+        undefined: undefined,
+        GearDuotone: (
+          <InputAdornment position="start">
+            <GearDuotone />
+          </InputAdornment>
+        ),
+      },
+    },
   },
   args: {
     value: '',
-    startAdornment: undefined,
   },
 } as Meta;
 
-const Template: Story = ({ value: propValue, startAdornment, ...args }) => {
+const Template = ({ value: propValue, ...args }) => {
   const [value, setValue] = React.useState(propValue);
 
   const handleChange = (event) => setValue(event.target.value);
 
   return (
-    <Select
-      startAdornment={
-        startAdornment ? (
-          <InputAdornment position="start">
-            <GearDuotone />
-          </InputAdornment>
-        ) : undefined
-      }
-      value={value}
-      {...args}
-      onChange={handleChange}
-    >
+    <Select value={value} {...args} onChange={handleChange}>
       <MenuItem value="" disabled>
         Placeholder
       </MenuItem>
@@ -58,14 +63,14 @@ const Template: Story = ({ value: propValue, startAdornment, ...args }) => {
   );
 };
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 Configurable.decorators = [(Story) => <Story />];
 
-export const Open = Template.bind({});
-Open.decorators = [(Story) => <Story />];
-Open.args = { open: true };
+// export const Open: Story = Template.bind({});
+// Open.decorators = [(Story) => <Story />];
+// Open.args = { open: true };
 
-const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
+const AdornmentsTemplate = ({ pseudo, ...args }) => (
   <OuterGroup>
     <InnerGroup>
       <Template {...args} value="" />
@@ -74,13 +79,9 @@ const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const StartAdornment = AdornmentsTemplate.bind({});
+export const StartAdornment: Story = AdornmentsTemplate.bind({});
 StartAdornment.args = {
-  startAdornment: (
-    <InputAdornment position="start">
-      <GearDuotone />
-    </InputAdornment>
-  ),
+  startAdornment: 'GearDuotone',
 };
 
 const OuterGroup = styled('span')({
@@ -98,7 +99,7 @@ const InnerGroup = styled('span')({
   gap: '1rem',
 });
 
-const StatesTemplate: Story = ({ pseudo, ...args }) => (
+const StatesTemplate = ({ pseudo, ...args }) => (
   <OuterGroup>
     <InnerGroup>
       <Template {...args} value="" />
@@ -121,15 +122,13 @@ const StatesTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesFocus = StatesTemplate.bind({});
+export const StatesFocus: Story = StatesTemplate.bind({});
 StatesFocus.args = { pseudo: true };
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const SelectChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = SelectChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Step/Step.stories.tsx
+++ b/libs/spark/src/Step/Step.stories.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Step, StepButton, StepContent, StepLabel, StepProps } from '..';
 
 interface SbStepProps extends StepProps {
+  active?: StepProps['active'];
+  completed?: StepProps['completed'];
+  disabled?: StepProps['disabled'];
   /**
-   * **[Storybook-only]** Show sample text in step content when `orientation="vertical"` and `active={true}`.
+   * **[Storybook-only:** Show sample text in step content when `orientation="vertical"` and `active={true}`.**]**
    */
   sb_showContent?: boolean;
   /**
-   * **[Storybook-only]** Show sample text in step label.
+   * **[Storybook-only:** Show sample text in step label.**]**
    */
   sb_showLabel?: boolean;
   /**
-   * **[Storybook-only]** Use a `StepButton` instead of `StepLabel`.
+   * **[Storybook-only:** Use a `StepButton` instead of `StepLabel`.**]**
    */
   sb_useButton?: boolean;
 }
@@ -28,11 +31,6 @@ export default {
   title: '@ps/Step',
   component: SbStep,
   excludeStories: ['SbStep'],
-  argTypes: {
-    active: { control: 'boolean' },
-    completed: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-  },
   args: {
     index: 0,
   },

--- a/libs/spark/src/StepButton/StepButton.stories.tsx
+++ b/libs/spark/src/StepButton/StepButton.stories.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepButton, StepButtonProps } from '..';
 
 interface SbStepButtonProps extends StepButtonProps {
   /**
-   * **[Storybook-only]** Show sample text in step label.
+   * **[Storybook-only:** hard-coded options.**]**
    */
-  sb_showLabel?: boolean;
+  children?: React.ReactNode;
 }
 
-export const SbStepButton = ({ sb_showLabel, ...props }: SbStepButtonProps) => (
+export const SbStepButton = (props: SbStepButtonProps) => (
   <StepButton {...props} />
 );
 
@@ -19,6 +19,14 @@ export default {
   component: SbStepButton,
   excludeStories: ['SbStepButton'],
   argTypes: {
+    children: {
+      type: 'select',
+      options: [null, 'Label'],
+      mapping: {
+        null: null,
+        Label: 'Label',
+      },
+    },
     icon: {
       control: 'select',
       options: [1, 2, 3, 'A', 'GearFilled'],
@@ -36,9 +44,7 @@ export default {
   },
 } as Meta;
 
-const Template = ({ sb_showLabel, ...args }: SbStepButtonProps) => (
-  <StepButton {...args}>{sb_showLabel ? 'Label' : null}</StepButton>
-);
+const Template = (args: SbStepButtonProps) => <StepButton {...args} />;
 
 export const Configurable: Story = Template.bind({});
 

--- a/libs/spark/src/StepConnector/StepConnector.stories.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepConnector, StepConnectorProps } from '..';
 
 export default {

--- a/libs/spark/src/StepContent/StepContent.stories.tsx
+++ b/libs/spark/src/StepContent/StepContent.stories.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepContent, StepContentProps, Typography } from '..';
 
-export const SbStepContent = (props: StepContentProps) => (
+// underlying StepContentProps are undocumented
+interface SbStepContentProps extends StepContentProps {
+  active?: boolean;
+  expanded?: boolean;
+  /**
+   * @default 'vertical'
+   */
+  orientation?: 'horizontal' | 'vertical';
+}
+export const SbStepContent = (props: SbStepContentProps) => (
   <StepContent {...props} />
 );
 
@@ -10,13 +19,7 @@ export default {
   title: '@ps/StepContent',
   component: SbStepContent,
   excludeStories: ['SbStepContent'],
-  argTypes: {
-    active: { control: 'boolean' },
-    expanded: { control: 'boolean' },
-    orientation: { control: 'radio', options: ['horizontal', 'vertical'] },
-  },
   args: {
-    orientation: 'vertical',
     expanded: true,
   },
 } as Meta;

--- a/libs/spark/src/StepIcon/StepIcon.stories.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepIcon, StepIconProps } from '..';
 
@@ -57,28 +57,28 @@ TextActiveError.args = { active: true, error: true, icon: '1' };
 TextActiveError.storyName = 'Text active error';
 
 export const Icon: Story = Template.bind({});
-Icon.args = { icon: <GearFilled /> };
+Icon.args = { icon: 'GearFilled' };
 
 export const IconActive: Story = Template.bind({});
-IconActive.args = { active: true, icon: <GearFilled /> };
+IconActive.args = { active: true, icon: 'GearFilled' };
 IconActive.storyName = 'Icon active';
 
 export const IconCompleted: Story = Template.bind({});
-IconCompleted.args = { completed: true, icon: <GearFilled /> };
+IconCompleted.args = { completed: true, icon: 'GearFilled' };
 IconCompleted.storyName = 'Icon completed';
 
 export const IconError: Story = Template.bind({});
-IconError.args = { error: true, icon: <GearFilled /> };
+IconError.args = { error: true, icon: 'GearFilled' };
 IconError.storyName = 'Icon error';
 
 export const IconActiveCompleted: Story = Template.bind({});
 IconActiveCompleted.args = {
   active: true,
   completed: true,
-  icon: <GearFilled />,
+  icon: 'GearFilled',
 };
 IconActiveCompleted.storyName = 'Icon active completed';
 
 export const IconActiveError: Story = Template.bind({});
-IconActiveError.args = { active: true, error: true, icon: <GearFilled /> };
+IconActiveError.args = { active: true, error: true, icon: 'GearFilled' };
 IconActiveError.storyName = 'Icon active error';

--- a/libs/spark/src/StepLabel/StepLabel.stories.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.stories.tsx
@@ -1,17 +1,37 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepLabel, StepLabelProps } from '..';
 
+// some underlying StepLabelProps are undocumented
+interface SbStepLabelProps extends StepLabelProps {
+  /**
+   * Mark the step as active.
+   */
+  active?: boolean;
+  /**
+   * If `true`, positions the label under the icon.
+   */
+  alternativeLabel?: boolean;
+  /**
+   * Mark the step as completed.
+   */
+  completed?: boolean;
+  children?: StepLabelProps['children'];
+  disabled?: StepLabelProps['disabled'];
+  error?: StepLabelProps['error'];
+  icon?: StepLabelProps['icon'];
+}
+
+export const SbStepLabel = (props: SbStepLabelProps) => (
+  <StepLabel {...props} />
+);
+
 export default {
   title: '@ps/StepLabel',
-  component: StepLabel,
+  component: SbStepLabel,
+  excludeStories: ['SbStepLabel'],
   argTypes: {
-    active: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    completed: { control: 'boolean' },
-    error: { control: 'boolean' },
-    alternativeLabel: { control: 'boolean' },
     icon: {
       control: 'select',
       options: ['1', '2', '3', 'GearFilled'],

--- a/libs/spark/src/Stepper/Stepper.stories.tsx
+++ b/libs/spark/src/Stepper/Stepper.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
-  Orientation,
   Step,
   StepButton,
   StepContent,
@@ -11,34 +10,22 @@ import {
 } from '..';
 
 interface SbStepperProps extends StepperProps {
+  activeStep?: StepperProps['activeStep'];
+  alternativeLabel?: StepperProps['alternativeLabel'];
+  nonLinear?: StepperProps['nonLinear'];
+  orientation?: StepperProps['orientation'];
   /**
-   * **[Storybook-only]** Show sample text in step labels.
+   * **[Storybook-only:** Show sample text in step labels.**]**
    */
   sb_showLabel?: boolean;
   /**
-   * **[Storybook-only]** Show sample text in step content when `orientation="vertical"` and `active={true}`.
+   * **[Storybook-only:** Show sample text in step content when `orientation="vertical"` and `active={true}`.**]**
    */
   sb_showContent?: boolean;
   /**
-   * **[Storybook-only]** Use a `StepButton` instead of `StepLabel`.
+   * **[Storybook-only:** Use a `StepButton` instead of `StepLabel`.**]**
    */
   sb_useButton?: boolean;
-  /**
-   * Set the active step (zero based index). Set to `-1` to disable all the steps.
-   */
-  activeStep?: number;
-  /**
-   * If set to `true` and `orientation="horizontal"`, then the step label will be positioned under the icon.
-   */
-  alternativeLabel?: boolean;
-  /**
-   * If set the `Stepper` will not assist in controlling steps for linear flow.
-   */
-  nonLinear?: boolean;
-  /**
-   * The stepper orientation (layout flow direction).
-   */
-  orientation?: Orientation;
 }
 
 export const SbStepper = ({

--- a/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   AlertCircle,
   AlertCircleFilled,
   AlertCircleDuotone,
 } from '@prenda/spark-icons';
-import SvgIcon from './SvgIcon';
-import styled from '../styled';
-import theme from '../theme';
+import { SvgIcon, styled, theme } from '..';
 import { capitalize } from '../utils';
 
 export const SbSvgIcon = SvgIcon;

--- a/libs/spark/src/Switch/Switch.stories.tsx
+++ b/libs/spark/src/Switch/Switch.stories.tsx
@@ -1,38 +1,42 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Card from '../Card';
-import FormControlLabel from '../FormControlLabel';
-import List from '../List';
-import ListItem from '../ListItem';
-import ListItemIcon from '../ListItemIcon';
-import ListItemText from '../ListItemText';
-import Switch from './Switch';
-import styled from '../styled';
-import withStyles from '../withStyles';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Card,
+  FormControlLabel,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Switch,
+  SwitchProps,
+  styled,
+  withStyles,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedSwitch = Switch;
+// Trying to omit /*ripple*/ props breaks all other props ???
+interface SbSwitchProps extends SwitchProps {
+  checked?: SwitchProps['checked'];
+  disabled?: SwitchProps['disabled'];
+}
+
+export const SbSwitch = (props: SbSwitchProps) => <Switch {...props} />;
 
 export default {
   title: '@ps/Switch',
-  component: TypedSwitch,
-  excludeStories: ['TypedSwitch'],
-  parameters: { actions: { handles: ['change'] } },
-  // Doesn't pick up all props
-  argTypes: {
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-  },
+  component: SbSwitch,
+  excludeStories: ['SbSwitch'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
   args: {
     checked: false,
     disabled: false,
   },
 } as Meta;
 
-const Template: Story = (args) => (
+const Template = (args) => (
   <Switch
     // a11y required props when there's no label
     name="Demo"
@@ -42,7 +46,7 @@ const Template: Story = (args) => (
   />
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const Container = styled('div')({
   display: 'flex',
@@ -51,7 +55,7 @@ const Container = styled('div')({
   width: 'min-content',
 });
 
-const StatesTemplate: Story = () => (
+const StatesTemplate = () => (
   <>
     <Container>
       <Switch
@@ -112,7 +116,7 @@ const StatesTemplate: Story = () => (
   </>
 );
 
-const PseudoStatesTemplate: Story = () => (
+const PseudoStatesTemplate = () => (
   <>
     <Container>
       <Switch
@@ -145,15 +149,15 @@ const PseudoStatesTemplate: Story = () => (
   </>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesHover = PseudoStatesTemplate.bind({});
+export const StatesHover: Story = PseudoStatesTemplate.bind({});
 StatesHover.parameters = { pseudo: { hover: true } };
 
-export const StatesFocus = PseudoStatesTemplate.bind({});
+export const StatesFocus: Story = PseudoStatesTemplate.bind({});
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const LabeledStatesTemplate: Story = () => (
+const LabeledStatesTemplate = () => (
   <>
     <Container>
       <FormControlLabel label="Label" control={<Switch />} />
@@ -229,22 +233,17 @@ const LabeledStatesTemplate: Story = () => (
   </>
 );
 
-const PseudoLabeledStatesTemplate: Story = (args) => (
+const PseudoLabeledStatesTemplate = () => (
   <>
     <Container>
-      <FormControlLabel label="Label" control={<Switch />} {...args} />
-      <FormControlLabel label="Label" control={<Switch checked />} {...args} />
+      <FormControlLabel label="Label" control={<Switch />} />
+      <FormControlLabel label="Label" control={<Switch checked />} />
     </Container>
     <Container>
-      <FormControlLabel
-        label="Label"
-        control={<Switch size="large" />}
-        {...args}
-      />
+      <FormControlLabel label="Label" control={<Switch size="large" />} />
       <FormControlLabel
         label="Label"
         control={<Switch size="large" checked />}
-        {...args}
       />
     </Container>
     <Container>
@@ -252,13 +251,11 @@ const PseudoLabeledStatesTemplate: Story = (args) => (
         label="Label"
         labelPlacement="start"
         control={<Switch />}
-        {...args}
       />
       <FormControlLabel
         label="Label"
         labelPlacement="start"
         control={<Switch checked />}
-        {...args}
       />
     </Container>
     <Container>
@@ -266,24 +263,22 @@ const PseudoLabeledStatesTemplate: Story = (args) => (
         label="Label"
         labelPlacement="start"
         control={<Switch size="large" />}
-        {...args}
       />
       <FormControlLabel
         label="Label"
         labelPlacement="start"
         control={<Switch size="large" checked />}
-        {...args}
       />
     </Container>
   </>
 );
 
-export const LabeledStates = LabeledStatesTemplate.bind({});
+export const LabeledStates: Story = LabeledStatesTemplate.bind({});
 
-export const LabeledStatesHover = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesHover: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesHover.parameters = { pseudo: { hover: true } };
 
-export const LabeledStatesFocus = PseudoLabeledStatesTemplate.bind({});
+export const LabeledStatesFocus: Story = PseudoLabeledStatesTemplate.bind({});
 LabeledStatesFocus.parameters = { pseudo: { focus: true } };
 
 const CustomCard = withStyles({
@@ -314,7 +309,7 @@ const RightAlignedListItemText = withStyles({
   },
 })(ListItemText);
 
-const LabeledInListTemplate: Story = (args) => (
+export const LabeledInList: Story = () => (
   // `width: min-content` will shrink the cards, so set 2 card widths + gap.
   <Container style={{ width: 256 * 2 + 16 }}>
     <CustomCard>
@@ -325,7 +320,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="end"
               inputProps={{ 'aria-labelledby': 'switch-list-label-1' }}
-              {...args}
             />
           </ListItemEndIcon>
         </PaddedListItem>
@@ -335,7 +329,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="end"
               inputProps={{ 'aria-labelledby': 'switch-list-label-2' }}
-              {...args}
             />
           </ListItemEndIcon>
         </PaddedListItem>
@@ -345,7 +338,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="end"
               inputProps={{ 'aria-labelledby': 'switch-list-label-3' }}
-              {...args}
             />
           </ListItemEndIcon>
         </PaddedListItem>
@@ -358,7 +350,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="start"
               inputProps={{ 'aria-labelledby': 'switch-list-label-4' }}
-              {...args}
             />
           </ListItemIcon>
           <RightAlignedListItemText
@@ -371,7 +362,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="start"
               inputProps={{ 'aria-labelledby': 'switch-list-label-5' }}
-              {...args}
             />
           </ListItemIcon>
           <RightAlignedListItemText
@@ -384,7 +374,6 @@ const LabeledInListTemplate: Story = (args) => (
             <Switch
               edge="start"
               inputProps={{ 'aria-labelledby': 'switch-list-label-6' }}
-              {...args}
             />
           </ListItemIcon>
           <RightAlignedListItemText
@@ -397,11 +386,7 @@ const LabeledInListTemplate: Story = (args) => (
   </Container>
 );
 
-export const LabeledInList = LabeledInListTemplate.bind({});
-
-const SwitchDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = SwitchDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Switch',
@@ -436,9 +421,7 @@ Documentation.args = {
   },
 };
 
-const SwitchChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = SwitchChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Tab/Tab.stories.tsx
+++ b/libs/spark/src/Tab/Tab.stories.tsx
@@ -1,27 +1,30 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { ExtendButtonBase } from '../ButtonBase';
-import { default as Tab, TabTypeMap } from './Tab';
-import styled from '../styled';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Tab, TabProps, styled } from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedTab: ExtendButtonBase<TabTypeMap> = Tab;
+// underlying TabProps lack descriptions
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface SbTabProps
+  extends Omit<
+    TabProps,
+    | 'disableRipple'
+    | 'disableFocusRipple'
+    | 'centerRipple'
+    | 'disableTouchRipple'
+    | 'focusRipple'
+    | 'TouchRippleProps'
+  > {}
+
+export const SbTab = (props: SbTabProps) => <Tab {...props} />;
 
 export default {
   title: '@ps/Tab',
-  component: TypedTab,
-  excludeStories: ['TypedTab'],
-  // Doesn't pick up any props
-  argTypes: {
-    disabled: { control: 'boolean' },
-    label: { control: 'text' },
-    onClick: { actions: 'clicked' },
-    selected: { control: 'boolean' },
-    value: { control: 'text' },
-  },
+  component: SbTab,
+  excludeStories: ['SbTab'],
   args: {
     label: 'Label',
     value: 'value',
@@ -33,9 +36,9 @@ export default {
   },
 } as Meta;
 
-const Template: Story = (args) => <Tab {...args} />;
+const Template = (args) => <Tab {...args} />;
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const Container = styled('div')({
   display: 'flex',
@@ -51,23 +54,21 @@ const StatesTemplate = (args) => (
   </Container>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesDisabled = StatesTemplate.bind({});
+export const StatesDisabled: Story = StatesTemplate.bind({});
 StatesDisabled.args = { disabled: true };
 
-export const StatesHover = StatesTemplate.bind({});
+export const StatesHover: Story = StatesTemplate.bind({});
 StatesHover.parameters = { pseudo: { hover: true } };
 
-export const StatesFocus = StatesTemplate.bind({});
+export const StatesFocus: Story = StatesTemplate.bind({});
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-export const StatesActive = StatesTemplate.bind({});
+export const StatesActive: Story = StatesTemplate.bind({});
 StatesActive.parameters = { pseudo: { active: true } };
 
-const TabDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = TabDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Tab',
@@ -85,9 +86,7 @@ Documentation.args = {
   },
 };
 
-const TabChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = TabChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/TabContext/TabContext.stories.tsx
+++ b/libs/spark/src/TabContext/TabContext.stories.tsx
@@ -1,36 +1,52 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Box from '../Box';
-import Tab from '../Tab';
-import { default as TabContext, TabContextProps } from './TabContext';
-import TabList from '../TabList';
-import TabPanel from '../TabPanel';
-import Typography from '../Typography';
-import withStyles from '../withStyles';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import {
+  Box,
+  Tab,
+  TabContext,
+  TabContextProps,
+  TabList,
+  TabListProps,
+  TabPanel,
+  Typography,
+  withStyles,
+} from '..';
 import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
 
-export const TypedTabContext = (props: TabContextProps) => (
-  <TabContext {...props} />
-);
+interface SbTabContextProps extends TabContextProps {
+  value: TabContextProps['value'];
+  /**
+   * **[Storybook-only:** passed to `TabList` child.**]**
+   */
+  ['sb_TabList_aria-label']?: TabListProps['aria-label'];
+  /**
+   * **[Storybook-only:** passed to `TabList` child.**]**
+   */
+  sb_TabList_onChange?: TabListProps['onChange'];
+}
+
+export const SbTabContext = ({
+  'sb_TabList_aria-label': sb_TabList_ariaLabel,
+  sb_TabList_onChange,
+  ...props
+}: SbTabContextProps) => <TabContext {...props} />;
 
 export default {
   title: '@ps/TabContext',
-  component: TypedTabContext,
-  excludeStories: ['TypedTabContext'],
+  component: SbTabContext,
+  excludeStories: ['SbTabContext'],
   // Doesn't pick up any props
   argTypes: {
-    'aria-label': { control: 'text' },
-    onChange: { actions: 'changed' },
     value: {
       control: 'select',
       options: ['value-1', 'value-2', 'value-3', 'value-4'],
     },
   },
   args: {
-    'aria-label': 'tabs story',
+    'sb_TabList_aria-label': 'tabs story',
     value: 'value-1',
   },
 } as Meta;
@@ -39,13 +55,20 @@ const CodeSnippet = withStyles({
   root: { display: 'inline' },
 })((props) => <Typography variant="code-md" {...props} />);
 
-const Template: Story = (args) => {
+const Template = ({
+  'sb_TabList_aria-label': sb_TabList_ariaLabel,
+  sb_TabList_onChange,
+  ...args
+}) => {
   const [value, setValue] = React.useState(args.value);
 
   return (
     <>
-      <TabContext value={value}>
-        <TabList {...args} onChange={(event, newValue) => setValue(newValue)}>
+      <TabContext {...args} value={value}>
+        <TabList
+          aria-label={sb_TabList_ariaLabel}
+          onChange={(event, newValue) => setValue(newValue)}
+        >
           <Tab value="value-1" label="Label" />
           <Tab value="value-2" label="Label" />
           <Tab value="value-3" label="Label" />
@@ -79,12 +102,10 @@ const Template: Story = (args) => {
   );
 };
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 Configurable.decorators = [(Story) => <Story />];
 
-const TabDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = TabDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'TabList (Tabs)',
@@ -102,9 +123,7 @@ Documentation.args = {
   },
 };
 
-const TabChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = TabChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Tag/Tag.stories.tsx
+++ b/libs/spark/src/Tag/Tag.stories.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import Box from '../Box';
-import Tag from './Tag';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Box, Tag } from '..';
 import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
 
-export const TypedTag = Tag;
-
-const handleDelete = () => {
-  return;
-};
+export const SbTag = Tag;
 
 export default {
   title: '@ps/Tag',
-  component: TypedTag,
-  excludeStories: ['TypedTag'],
+  component: SbTag,
+  excludeStories: ['SbTag'],
   parameters: {
     actions: {
       // override default actions regex
@@ -26,23 +21,25 @@ export default {
     },
   },
   argTypes: {
-    onDelete: { control: 'select', options: [undefined, handleDelete] },
+    onDelete: {
+      control: 'select',
+      options: ['undefined', 'handleDelete'],
+      mapping: {
+        undefined: undefined,
+        handleDelete: () => {
+          return;
+        },
+      },
+    },
   },
   args: {
-    onDelete: undefined,
+    label: 'Label',
   },
 } as Meta;
 
 const Template = (args) => (
   <Box p={1}>
-    <Tag
-      label="Label"
-      // onDelete={(() => {
-      //   console.log(onDelete);
-      //   return onDelete ? handleDelete : undefined;
-      // })()}
-      {...args}
-    />
+    <Tag {...args} />
   </Box>
 );
 
@@ -120,24 +117,22 @@ const ColorAndVariantTemplate = (args) => (
 export const ColorAndVariant: Story = ColorAndVariantTemplate.bind({});
 
 export const ColorVariantDelete: Story = ColorAndVariantTemplate.bind({});
-ColorVariantDelete.args = { onDelete: handleDelete };
+ColorVariantDelete.args = { onDelete: 'handleDelete' };
 
 export const ColorVariantDeleteHover: Story = ColorAndVariantTemplate.bind({});
-ColorVariantDeleteHover.args = { onDelete: handleDelete };
+ColorVariantDeleteHover.args = { onDelete: 'handleDelete' };
 ColorVariantDeleteHover.parameters = { pseudo: { hover: true } };
 
 export const ColorVariantDeleteFocus: Story = ColorAndVariantTemplate.bind({});
-ColorVariantDeleteFocus.args = { onDelete: handleDelete };
+ColorVariantDeleteFocus.args = { onDelete: 'handleDelete' };
 ColorVariantDeleteFocus.parameters = { pseudo: { focus: true } };
 
 export const ColorVariantDeleteDisabled: Story = ColorAndVariantTemplate.bind(
   {}
 );
-ColorVariantDeleteDisabled.args = { onDelete: handleDelete, disabled: true };
+ColorVariantDeleteDisabled.args = { onDelete: 'handleDelete', disabled: true };
 
-const AvatarDocTemplate = (args) => <DocumentationTemplate {...args} />;
-
-export const Documentation: Story = AvatarDocTemplate.bind({});
+export const Documentation: Story = DocumentationTemplate.bind({});
 Documentation.args = {
   underlyingComponent: {
     name: 'Chip',
@@ -191,9 +186,7 @@ Documentation.args = {
   },
 };
 
-const AvatarChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = AvatarChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/TextField/TextField.stories.tsx
+++ b/libs/spark/src/TextField/TextField.stories.tsx
@@ -1,69 +1,105 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone, QuestionDuotone } from '@prenda/spark-icons';
-import InputAdornment from '../InputAdornment';
-import MenuItem from '../MenuItem';
-import { default as TextField, TextFieldProps } from './TextField';
-import styled from '../styled';
+import {
+  InputAdornment,
+  MenuItem,
+  TextField,
+  StandardTextFieldProps,
+  styled,
+} from '..';
 import { ChangelogTemplate } from '../../stories/templates';
 
-export const TypedTextField = (props: TextFieldProps) => (
-  <TextField {...props} />
+interface SbTextFieldProps extends StandardTextFieldProps {
+  /**
+   * **Note**: the custom `success` styling is delivered through a class name instead of a prop.
+   */
+  className?: StandardTextFieldProps['className'];
+  defaultValue?: StandardTextFieldProps['defaultValue'];
+  disabled?: StandardTextFieldProps['disabled'];
+  error?: StandardTextFieldProps['error'];
+  fullWidth?: StandardTextFieldProps['fullWidth'];
+  helperText?: StandardTextFieldProps['helperText'];
+  label?: StandardTextFieldProps['label'];
+  multiline?: StandardTextFieldProps['multiline'];
+  placeholder?: StandardTextFieldProps['placeholder'];
+  maxRows?: StandardTextFieldProps['maxRows'];
+  minRows?: StandardTextFieldProps['minRows'];
+  select?: StandardTextFieldProps['select'];
+  value?: StandardTextFieldProps['value'];
+  InputProps?: StandardTextFieldProps['InputProps'];
+  /**
+   * **[Storybook-only:** broken out from `props.InputProps`.**]**
+   */
+  'sb_InputProps.endAdornment'?: StandardTextFieldProps['InputProps']['endAdornment'];
+  /**
+   * **[Storybook-only:** broken out from `props.InputProps`.**]**
+   */
+  'sb_InputProps.startAdornment'?: StandardTextFieldProps['InputProps']['startAdornment'];
+}
+
+export const SbTextField = ({
+  'sb_InputProps.endAdornment': endAdornment,
+  'sb_InputProps.startAdornment': startAdornment,
+  ...props
+}: SbTextFieldProps) => (
+  <TextField InputProps={{ endAdornment, startAdornment }} {...props} />
 );
 
 export default {
   title: '@ps/TextField',
-  component: TypedTextField,
-  excludeStories: ['TypedTextField'],
+  component: SbTextField,
+  excludeStories: ['SbTextField'],
   // Doesn't pick up most props
   argTypes: {
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    helperText: { control: 'text' },
-    defaultValue: { control: 'text' },
-    value: { control: 'text' },
-    error: { control: 'boolean' },
-    success: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    select: { control: 'boolean' },
-    multiline: { control: 'boolean' },
-    rows: { control: 'number' },
-    rowsMax: { control: 'number' },
-    fullWidth: { control: 'boolean' },
-    startAdornment: { control: 'select', options: [undefined, 'GearDuotone'] },
-    endAdornment: {
+    className: { control: 'select', options: [undefined, 'Spark-success'] },
+    'sb_InputProps.endAdornment': {
       control: 'select',
-      options: [undefined, 'QuestionDuotone'],
+      options: ['undefined', 'QuestionDuotone'],
+      mapping: {
+        undefined: undefined,
+        QuestionDuotone: (
+          <InputAdornment position="end">
+            <QuestionDuotone />
+          </InputAdornment>
+        ),
+      },
+    },
+    'sb_InputProps.startAdornment': {
+      control: 'select',
+      options: ['undefined', 'GearDuotone'],
+      mapping: {
+        undefined: undefined,
+        GearDuotone: (
+          <InputAdornment position="start">
+            <GearDuotone />
+          </InputAdornment>
+        ),
+      },
     },
   },
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     helperText: 'Helper text',
-    startAdornment: undefined,
-    endAdornment: undefined,
   },
 } as Meta;
 
-const Template: Story = ({ startAdornment, endAdornment, ...args }) => (
+const Template = ({
+  'sb_InputProps.endAdornment': endAdornment,
+  'sb_InputProps.startAdornment': startAdornment,
+  ...args
+}) => (
   <TextField
     InputProps={{
-      startAdornment: startAdornment ? (
-        <InputAdornment position="start">
-          <GearDuotone />
-        </InputAdornment>
-      ) : undefined,
-      endAdornment: endAdornment ? (
-        <InputAdornment position="end">
-          <QuestionDuotone />
-        </InputAdornment>
-      ) : undefined,
+      startAdornment,
+      endAdornment,
     }}
     {...args}
   />
 );
 
-export const Configurable = Template.bind({});
+export const Configurable: Story = Template.bind({});
 
 const OuterGroup = styled('span')({
   display: 'flex',
@@ -80,7 +116,12 @@ const InnerGroup = styled('span')({
   gap: '1rem',
 });
 
-const StatesTemplate: Story = ({ pseudo, ...args }) => (
+const StatesTemplate = ({
+  pseudo,
+  'sb_InputProps.endAdornment': endAdornment,
+  'sb_InputProps.startAdornment': startAdornment,
+  ...args
+}) => (
   <OuterGroup>
     <InnerGroup>
       <TextField {...args} />
@@ -199,13 +240,18 @@ const StatesTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const States = StatesTemplate.bind({});
+export const States: Story = StatesTemplate.bind({});
 
-export const StatesFocus = StatesTemplate.bind({});
+export const StatesFocus: Story = StatesTemplate.bind({});
 StatesFocus.args = { pseudo: true };
 StatesFocus.parameters = { pseudo: { focus: true } };
 
-const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
+const AdornmentsTemplate = ({
+  pseudo,
+  'sb_InputProps.endAdornment': endAdornment,
+  'sb_InputProps.startAdornment': startAdornment,
+  ...args
+}) => (
   <OuterGroup>
     <InnerGroup>
       <TextField {...args} />
@@ -238,31 +284,21 @@ const AdornmentsTemplate: Story = ({ pseudo, ...args }) => (
   </OuterGroup>
 );
 
-export const StartAdornment = AdornmentsTemplate.bind({});
+export const StartAdornment: Story = AdornmentsTemplate.bind({});
 StartAdornment.args = {
   InputProps: {
-    startAdornment: (
-      <InputAdornment position="start">
-        <GearDuotone />
-      </InputAdornment>
-    ),
+    startAdornment: 'GearDuotone',
   },
 };
 
-export const EndAdornment = AdornmentsTemplate.bind({});
+export const EndAdornment: Story = AdornmentsTemplate.bind({});
 EndAdornment.args = {
   InputProps: {
-    endAdornment: (
-      <InputAdornment position="end">
-        <QuestionDuotone />
-      </InputAdornment>
-    ),
+    endAdornment: 'QuestionDuotone',
   },
 };
 
-const TextFieldChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = TextFieldChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/Typography/Typography.stories.tsx
+++ b/libs/spark/src/Typography/Typography.stories.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { default as Typography, TypographyProps } from './Typography';
-import styled from '../styled';
-import withStyles from '../withStyles';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Typography, TypographyProps, styled, withStyles } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
 
-export const TypedTypography = (props: TypographyProps) => (
+export const SbTypography = (props: TypographyProps) => (
   <Typography {...props} />
 );
 
 export default {
   title: '@ps/Typography',
-  component: TypedTypography,
-  excludeStories: ['TypedTypography'],
+  component: SbTypography,
+  excludeStories: ['SbTypography'],
 } as Meta;
 
 type TextKey =
@@ -46,10 +44,10 @@ function getText(variant: string): string {
   return text[variant.split('-')[0] as TextKey] || text.paragraph;
 }
 
-const Template: Story<TypographyProps> = (args) => (
+const Template = (args: TypographyProps) => (
   <Typography {...args}>{getText(String(args.variant))}</Typography>
 );
-export const ConfigurableTypography = Template.bind({});
+export const ConfigurableTypography: Story = Template.bind({});
 
 enum Bases {
   Display = 'Display',
@@ -316,7 +314,7 @@ const TypogPage = ({ variantBase }: TypogPageProps) => {
   );
 };
 
-export const Overview = () => (
+export const Overview: Story = () => (
   <div>
     <TypogPage variantBase={Bases.Display} />
     <TypogPage variantBase={Bases.Heading} />
@@ -327,9 +325,7 @@ export const Overview = () => (
   </div>
 );
 
-const TypographyChangelogTemplate = (args) => <ChangelogTemplate {...args} />;
-
-export const Changelog: Story = TypographyChangelogTemplate.bind({});
+export const Changelog: Story = ChangelogTemplate.bind({});
 Changelog.args = {
   history: [
     {

--- a/libs/spark/src/theme/colors.stories.tsx
+++ b/libs/spark/src/theme/colors.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
-import styled from '../styled';
-import useTheme from '../useTheme';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { styled, useTheme } from '..';
 
 interface ColorBoxProps {
   color: string;
@@ -40,7 +39,7 @@ export default {
   component: ColorBox,
 } as Meta;
 
-export const PrendaColors = () => {
+export const PrendaColors: Story = () => {
   const theme = useTheme();
 
   return (

--- a/libs/spark/stories/Illustrations.stories.tsx
+++ b/libs/spark/stories/Illustrations.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   BookIllustration,
   CollaborateIllustration,
@@ -17,7 +17,7 @@ const Container = styled('div')({
   justifyContent: 'space-between',
 });
 
-export const Art = () => (
+export const Art: Story = () => (
   <Container>
     <BookIllustration style={{ fontSize: '120px' }} />
     <CollaborateIllustration style={{ fontSize: '120px' }} />

--- a/libs/spark/stories/Logos.stories.tsx
+++ b/libs/spark/stories/Logos.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   PrendaWordmark,
   PrendaMonogram,
@@ -66,7 +66,7 @@ const LightBlueSpark = styled(Spark)(({ theme }) => ({
   fill: theme.palette.blue[1],
 }));
 
-export const Logos = () => (
+export const Logos: Story = () => (
   <GridContainer>
     <ColumnContainer>
       <CellContainer>

--- a/libs/spark/stories/anron-icons/AlertCircle.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircle.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircle } from '@prenda/spark-icons';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   component: AlertCircle,
 } as Meta;
 
-const Template: Story = (args) => <AlertCircle {...args} />;
+const Template = (args) => <AlertCircle {...args} />;
 
-export const AlertCircleStory = Template.bind({});
+export const AlertCircleStory: Story = Template.bind({});
 AlertCircleStory.storyName = 'AlertCircle';

--- a/libs/spark/stories/anron-icons/AlertCircleDuotone.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircleDuotone.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircleDuotone } from '@prenda/spark-icons';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   component: AlertCircleDuotone,
 } as Meta;
 
-const Template: Story = (args) => <AlertCircleDuotone {...args} />;
+const Template = (args) => <AlertCircleDuotone {...args} />;
 
-export const AlertCircleDuotoneStory = Template.bind({});
+export const AlertCircleDuotoneStory: Story = Template.bind({});
 AlertCircleDuotoneStory.storyName = 'AlertCircleDuotone';

--- a/libs/spark/stories/anron-icons/AlertCircleFilled.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircleFilled.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircleFilled } from '@prenda/spark-icons';
 
 export default {
@@ -7,7 +7,7 @@ export default {
   component: AlertCircleFilled,
 } as Meta;
 
-const Template: Story = (args) => <AlertCircleFilled {...args} />;
+const Template = (args) => <AlertCircleFilled {...args} />;
 
-export const AlertCircleFilledStory = Template.bind({});
+export const AlertCircleFilledStory: Story = Template.bind({});
 AlertCircleFilledStory.storyName = 'AlertCircleFilled';


### PR DESCRIPTION
Bunch of chores for story files

- Change `import { Meta ...` to `import type { Meta ...`
- Import from `/src` index (`... from '..';`) to simplify imports (storybook/webpack tree-shakes and this is cleared from bundling)
- Correct `: Story` typing; exported stories should receive the type, not non-exported templates.
- Remove unnecessary re-templating of `ChangelogTemplate` and `DocumentationTemplate`.
- Change re-typing variable names `Typed<ComponentName>` -> `Sb<ComponentName>` (short for "Storybook", the prefix we already use for Storybook-custom docs props.
- Where Storybook's auto-docs doesn't pick up props or their descriptions, re-declare props and re-use original definitions where possible (descriptions are also picked up through this reuse). Also, remove excess ripple props where possible.
- Change "Storybook-only" comment format.
- Change some "Storybook-only" prop name formats; where applicable, the name references the component it's passed to if it's not the component to which the story belongs to (ex: `sb_TabList_onChange` because it's under `TabContext`).
- When a prop is of type `React.ReactNode`, implement a custom mapping in the `Meta['argTypes']`, and eliminate conditional logic in template renders.