### PR TITLE
feat(__next__palette): PDS v2 palette

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -78,12 +78,12 @@ _This section details previous of breaking changes or experimental features and 
       - `palette.info.main` -> removed (\_note: if you require this alias, use `palette.blue[600]`)
       - `palette.success.main` -> removed (\_note: if you require this alias, use `palette.green[600]`)
     - "neutrals":
-      - `palette.common.white` -> `palette.neutrals[0]`
-      - `palette.grey.lighter` -> `palette.neutrals[60]`
-      - `palette.grey.light` -> `palette.neutrals[70]`
-      - `palette.grey.medium` -> `palette.neutrals[80]`
-      - `palette.grey.dark` -> `palette.neutrals[90]`
-      - `palette.blue[5]` -> `palette.neutrals[600]`
+      - `palette.common.white` -> `palette.neutral[0]`
+      - `palette.grey.lighter` -> `palette.neutral[60]`
+      - `palette.grey.light` -> `palette.neutral[70]`
+      - `palette.grey.medium` -> `palette.neutral[80]`
+      - `palette.grey.dark` -> `palette.neutral[90]`
+      - `palette.blue[5]` -> `palette.neutral[600]`
     - "background":
       - `palette.common.white` -> `palette.background.default`
       - `palette.background.lightGrey` -> `palette.background.alternative`

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -16,6 +16,86 @@
 - **Link**
   - Re-exported with custom styles and props.
 
+### **next**
+
+_This section details previous of breaking changes or experimental features and are subject to breaking changes at any time._
+
+- \***\*next**palette\*\*
+  - Implemented according to PDS v2.
+  - Changes from current `palette` (PDS v1):
+    - "tertiary":
+      - renamed to just "colors".
+      - removed "orange".
+      - added "teal", "magenta".
+      - expanded from 5 to 7 options.
+    - "brand":
+      - renamed "peach" to "lightOrange".
+    - "neutrals":
+      - replaced descriptive field names with numeric keys.
+    - "background":
+      - removed "lightBlue" option.
+      - replaced color references with aliases.
+    - "text":
+      - replaced color type ("light", "dark") references with semantic aliases ("heading", "body", "subdued", ..., "inverseHeading", ...).
+      - expanded from 4 to 12 options.
+    - "tones":
+      - New! for skin tones.
+      - added "warm", "neutral", "cool" -- each with 5 options.
+  - Preview: `theme.__next__palette.*`
+  - Planned migration:
+    - "brand":
+      - `palette.brand.peach` -> `palette.__next__.brand.lightOrange`
+    - "full palette" / "tertiary" colors / "colors":
+      - `palette.red[1]` -> `palette.red[100]`
+      - `palette.red[2]` -> `palette.red[300]`
+      - `palette.red[3]` -> `palette.red[500]`
+      - `palette.red[4]` -> `palette.red[600]`
+      - `palette.red[5]` -> `palette.red[700]`
+      - `palette.orange[1...5]` -> **removed**
+      - `palette.yellow[1]` -> `palette.yellow[100]`
+      - `palette.yellow[2]` -> `palette.yellow[300]`
+      - `palette.yellow[3]` -> `palette.yellow[500]`
+      - `palette.yellow[4]` -> `palette.yellow[600]`
+      - `palette.yellow[5]` -> `palette.yellow[700]`
+      - `palette.blue[1]` -> `palette.blue[100]`
+      - `palette.blue[2]` -> `palette.blue[300]`
+      - `palette.blue[3]` -> `palette.blue[500]`
+      - `palette.blue[4]` -> `palette.blue[600]`
+      - `palette.blue[5]` -> `palette.blue[700]`
+      - `palette.purple[1]` -> `palette.purple[100]`
+      - `palette.purple[2]` -> `palette.purple[300]`
+      - `palette.purple[3]` -> `palette.purple[500]`
+      - `palette.purple[4]` -> `palette.purple[600]`
+      - `palette.purple[5]` -> `palette.purple[700]`
+      - `palette.green[1]` -> `palette.green[100]`
+      - `palette.green[2]` -> `palette.green[400]` (_note: 400, not 300_)
+      - `palette.green[3]` -> `palette.green[500]`
+      - `palette.green[4]` -> `palette.green[600]`
+      - `palette.green[5]` -> `palette.green[700]`
+    - "product colors" or "condition state" colors:
+      - `palette.error.main` -> removed (\_note: if you require this alias, use `palette.red[700]`)
+      - `palette.warning.main` -> removed (\_note: if you require this alias, use `palette.yellow[500]`)
+      - `palette.info.main` -> removed (\_note: if you require this alias, use `palette.blue[600]`)
+      - `palette.success.main` -> removed (\_note: if you require this alias, use `palette.green[600]`)
+    - "neutrals":
+      - `palette.common.white` -> `palette.neutrals[0]`
+      - `palette.grey.lighter` -> `palette.neutrals[60]`
+      - `palette.grey.light` -> `palette.neutrals[70]`
+      - `palette.grey.medium` -> `palette.neutrals[80]`
+      - `palette.grey.dark` -> `palette.neutrals[90]`
+      - `palette.blue[5]` -> `palette.neutrals[600]`
+    - "background":
+      - `palette.common.white` -> `palette.background.default`
+      - `palette.background.lightGrey` -> `palette.background.alternative`
+      - `palette.background.lightBlue` -> **removed**
+      - `palette.background.blue` -> `palette.background.brand`
+      - `palette.background.navy` -> `palette.background.inverse`
+    - "text":
+      - `palette.text.dark` -> `palette.text.(heading|body|icon)` (_use judgement_)
+      - `palette.text.darkLowContrast` -> `palette.text.(subdued|secondaryIcon)` (_use judgement_)
+      - `palette.text.light` -> `palette.text.(inverseHeading|inverseBody|inverseIcon)` (_use judgement_)
+      - `palette.text.lightLowContrast` -> `palette.text.(inverseSubdued|inverseSecondaryIcon)` (_use judgement_)
+
 ## [v0.16.0](https://github.com/prenda-school/prenda-spark/compare/v0.15.0...v0.16.0) (2021-10-29)
 
 No changes.

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 _This section details previous of breaking changes or experimental features and are subject to breaking changes at any time._
 
-- \***\*next**palette\*\*
+- **\_\_next\_\_palette**
   - Implemented according to PDS v2.
   - Changes from current `palette` (PDS v1):
     - "tertiary":
@@ -44,7 +44,7 @@ _This section details previous of breaking changes or experimental features and 
   - Preview: `theme.__next__palette.*`
   - Planned migration:
     - "brand":
-      - `palette.brand.peach` -> `palette.__next__.brand.lightOrange`
+      - `palette.brand.peach` -> `palette.brand.lightOrange`
     - "full palette" / "tertiary" colors / "colors":
       - `palette.red[1]` -> `palette.red[100]`
       - `palette.red[2]` -> `palette.red[300]`
@@ -73,10 +73,10 @@ _This section details previous of breaking changes or experimental features and 
       - `palette.green[4]` -> `palette.green[600]`
       - `palette.green[5]` -> `palette.green[700]`
     - "product colors" or "condition state" colors:
-      - `palette.error.main` -> removed (\_note: if you require this alias, use `palette.red[700]`)
-      - `palette.warning.main` -> removed (\_note: if you require this alias, use `palette.yellow[500]`)
-      - `palette.info.main` -> removed (\_note: if you require this alias, use `palette.blue[600]`)
-      - `palette.success.main` -> removed (\_note: if you require this alias, use `palette.green[600]`)
+      - `palette.error.main` -> removed (_note: if you require this alias, use `palette.red[700]`_)
+      - `palette.warning.main` -> removed (_note: if you require this alias, use `palette.yellow[500]`_)
+      - `palette.info.main` -> removed (_note: if you require this alias, use `palette.blue[600]`_)
+      - `palette.success.main` -> removed (_note: if you require this alias, use `palette.green[600]`_)
     - "neutrals":
       - `palette.common.white` -> `palette.neutral[0]`
       - `palette.grey.lighter` -> `palette.neutral[60]`

--- a/libs/spark/src/theme/__next__palette.stories.tsx
+++ b/libs/spark/src/theme/__next__palette.stories.tsx
@@ -213,6 +213,49 @@ export const Primary: Story = () => (
         },
       ]}
     />
+    <SmallSpacer />
+    <H3>Background</H3>
+    <Body>
+      <em>experimental</em>
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'Default', field: 'background.default' },
+        { name: 'Alternative', field: 'background.alternative' },
+        { name: 'Brand', field: 'background.brand' },
+        { name: 'Inverse', field: 'background.inverse' },
+      ]}
+    />
+    <SmallSpacer />
+    <H3>Text</H3>
+    <Body>
+      <em>experimental</em>
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'Heading', field: 'text.heading' },
+        { name: 'Body', field: 'text.body' },
+        { name: 'Icon', field: 'text.icon' },
+        { name: 'Subdued', field: 'text.subdued' },
+        { name: 'Secondary Icon', field: 'text.secondaryIcon' },
+        { name: 'Disabled', field: 'text.disabled' },
+      ]}
+    />
+    <SmallSpacer />
+    <H3>Inverse Text</H3>
+    <Body>
+      <em>experimental</em>
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'Inverse Heading', field: 'text.inverseHeading' },
+        { name: 'Inverse Body', field: 'text.inverseBody' },
+        { name: 'Inverse Icon', field: 'text.inverseIcon' },
+        { name: 'Inverse Subdued', field: 'text.inverseSubdued' },
+        { name: 'Inverse Secondary Icon', field: 'text.inverseSecondaryIcon' },
+        { name: 'Inverse Disabled', field: 'text.inverseDisabled' },
+      ]}
+    />
   </Root>
 );
 

--- a/libs/spark/src/theme/__next__palette.stories.tsx
+++ b/libs/spark/src/theme/__next__palette.stories.tsx
@@ -1,0 +1,435 @@
+import * as React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { styled, useTheme, Theme } from '..';
+
+export default {
+  title: '@ps/theme/__next__palette',
+} as Meta;
+
+/**
+ * Get theme value of given chain.case field.
+ * @example
+ *  getValue(theme, 'brand.blue'); // returns '#0a4872'
+ *  getValue(theme, 'tones.warm.400'); // returns '#733f2a'
+ */
+function getValue(theme: Theme, field: string): string {
+  const fields = field.split('.');
+
+  let walk = theme.__next__palette;
+  let value;
+  for (let i = 0; i < fields.length; i++) {
+    if (i === fields.length - 1) {
+      value = walk[fields[i]];
+    } else {
+      walk = walk[fields[i]];
+    }
+  }
+
+  return value;
+}
+
+/**
+ * @example
+ *  getDisplayField('neutral.600'); // returns 'neutral[600]'
+ *  getDisplayField('tones.warm.400'); // returns 'tones.warm[400]'
+ */
+function getDisplayField(field: string): string {
+  const fields = field.split('.');
+
+  const prefix = fields.slice(0, -1).join('.');
+  let suffix = fields.slice(-1)[0];
+  // @ts-expect-error ts(2345) what a silly typing
+  suffix = !isNaN(suffix) ? `[${suffix}]` : `.${suffix}`;
+
+  return prefix.concat(suffix);
+}
+
+const PaletteColor = styled(function PaletteColor(props: {
+  name: string;
+  field: string;
+}) {
+  const { name, field, ...other } = props;
+
+  const theme = useTheme();
+
+  return (
+    <div {...other}>
+      <div className="color" />
+      <div className="name">{name}</div>
+      <div className="value">{getValue(theme, field)}</div>
+      <div className="field">palette.{getDisplayField(field)}</div>
+    </div>
+  );
+})(
+  // @ts-expect-error ts(2339)
+  ({ theme, field }) => ({
+    '& .color': {
+      backgroundColor: getValue(theme, field),
+      borderRadius: 16,
+      height: 104,
+      width: 177,
+      marginBottom: 16,
+    },
+    '& .name': {
+      // fontFamily: 'Inter',
+      fontSize: theme.typography.pxToRem(16),
+      lineHeight: 20 / 16,
+      fontWeight: 600,
+      color: theme.__next__palette.text.body,
+      marginBottom: 8,
+    },
+    '& .value': {
+      // fontFamily: 'Inter',
+      fontSize: theme.typography.pxToRem(14),
+      lineHeight: 20 / 14,
+      fontWeight: 400,
+      color: theme.__next__palette.text.subdued,
+    },
+    '& .field': {
+      // fontFamily: 'Inter',
+      fontSize: theme.typography.pxToRem(14),
+      lineHeight: 20 / 14,
+      fontWeight: 400,
+      color: theme.__next__palette.text.subdued,
+    },
+  })
+);
+
+const PaletteSwatch = styled(function PaletteSwatch(props: {
+  colors: Array<{
+    name: string;
+    field: string;
+  }>;
+}) {
+  const { colors, ...other } = props;
+
+  return (
+    <div {...other}>
+      {colors.map((color) => (
+        <PaletteColor key={color.name} name={color.name} field={color.field} />
+      ))}
+    </div>
+  );
+})({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 24,
+});
+
+const Root = styled('div')({
+  paddingLeft: 8,
+});
+// :__next__: replace with __next__Typography
+const H1 = styled('h1')(({ theme }) => ({
+  // fontFamily: 'Inter',
+  fontSize: theme.typography.pxToRem(28),
+  lineHeight: 40 / 28,
+  fontWeight: 600,
+  color: theme.__next__palette.text.heading,
+  marginBottom: 8,
+}));
+const H2 = styled('h2')(({ theme }) => ({
+  // fontFamily: 'Inter',
+  fontSize: theme.typography.pxToRem(24),
+  lineHeight: 32 / 24,
+  fontWeight: 600,
+  color: theme.__next__palette.text.heading,
+  marginBottom: 8,
+  marginTop: 8,
+}));
+const H3 = styled('h3')(({ theme }) => ({
+  // fontFamily: 'Inter',
+  fontSize: theme.typography.pxToRem(20),
+  lineHeight: 32 / 24,
+  fontWeight: 600,
+  color: theme.__next__palette.text.heading,
+  marginBottom: 8,
+  marginTop: 8,
+}));
+const Body = styled('p')(({ theme }) => ({
+  // fontFamily: 'Inter',
+  fontSize: theme.typography.pxToRem(16),
+  lineHeight: 24 / 16,
+  fontWeight: 400,
+  color: theme.__next__palette.text.body,
+  marginBottom: 16,
+}));
+const Spacer = styled('div')({
+  height: 48,
+});
+const SmallSpacer = styled('div')({
+  height: 32,
+});
+
+export const Primary: Story = () => (
+  <Root>
+    <H1>Primary palette</H1>
+    <Body>
+      Color distinguishes our brand and helps us create consistent experiences
+      across product.
+    </Body>
+    <H2>Prenda Brand</H2>
+    <Body>Core brand palette that represents Prenda.</Body>
+    <PaletteSwatch
+      colors={[
+        {
+          name: 'Prenda Blue',
+          field: 'brand.blue',
+        },
+        {
+          name: 'Prenda Light Blue',
+          field: 'brand.lightBlue',
+        },
+        {
+          name: 'Prenda Orange',
+          field: 'brand.orange',
+        },
+        {
+          name: 'Prenda Light Orange',
+          field: 'brand.lightOrange',
+        },
+      ]}
+    />
+    <Spacer />
+    <H2>Functional palette</H2>
+    <Body>
+      We use Prenda Blue for primary actions and for buttons indicating progress
+      and representing authentication. Neutral (N600) is used primarily for body
+      text and headings, and white (N0) is used for backgrounds.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        {
+          name: 'Prenda Blue',
+          field: 'brand.blue',
+        },
+        {
+          name: 'N600',
+          field: 'neutral.600',
+        },
+        {
+          name: 'N0',
+          field: 'neutral.0',
+        },
+      ]}
+    />
+  </Root>
+);
+
+export const Extended: Story = () => (
+  <Root>
+    <H1>Primary palette</H1>
+    <Body>
+      The extended palette consists of all the useable tints and shades of each
+      color in the palette. They are all numbered for easy reference. Usage of
+      these colors varies depending on the touch point, but they come in handy
+      for illustrations and components in product.
+    </Body>
+    <H2>Neutrals</H2>
+    <Body>
+      Neutrals have varying degrees of saturation that allow for the appropriate
+      level of warmth across marketing and product. Typically they are used for
+      text and subtle backgrounds when we don't want to draw too much attention
+      to a particular touchpoint or convey information such as "to do" or
+      "disabled".
+    </Body>
+    <H3>Dark Neutrals</H3>
+    <Body>
+      Dark neutrals are very effective for creating contrast and are therefore
+      the primary color used for typography. Occasionally the dark neutrals are
+      found in illustration but they rarely dominate the palette. Some
+      exceptions are dark mode UI elements and illustrations.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'N600', field: 'neutral.600' },
+        { name: 'N500', field: 'neutral.500' },
+        { name: 'N400', field: 'neutral.400' },
+        { name: 'N300', field: 'neutral.300' },
+        { name: 'N200', field: 'neutral.200' },
+        { name: 'N100', field: 'neutral.100' },
+      ]}
+    />
+    <SmallSpacer />
+    <H3>Light Neutrals</H3>
+    <Body>
+      We use light neutrals as subtle backgrounds to indicate various
+      interactive states such as hover and disabled, or simply to create
+      secondary attention towards a component. You'll find light neutrals in
+      buttons, text fields, tags, and illustrations. Light neutrals are helpful
+      for offsetting content in a primarily white layout without losing warmth
+      and cleanliness and are therefore often used as a background color. Their
+      subtlety allows for them to be helpful in creating subtle shadows or
+      depth.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'N90', field: 'neutral.90' },
+        { name: 'N80', field: 'neutral.80' },
+        { name: 'N70', field: 'neutral.70' },
+        { name: 'N60', field: 'neutral.60' },
+        { name: 'N00', field: 'neutral.00' },
+      ]}
+    />
+    <Spacer />
+    <H3>Red - Error</H3>
+    <Body>
+      Red is mainly used for backgrounds in messages and in error states to draw
+      attention to important information or actions that are destructive or
+      block workflow. You'll find red used in components such as lozenges,
+      banner, flag messages, buttons, illustrations, and typography.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'R700', field: 'red.700' },
+        { name: 'R600', field: 'red.600' },
+        { name: 'R500', field: 'red.500' },
+        { name: 'R400', field: 'red.400' },
+        { name: 'R300', field: 'red.300' },
+        { name: 'R200', field: 'red.200' },
+        { name: 'R100', field: 'red.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Yellow - Warning</H3>
+    <Body>
+      Typically used for warning. Yellow feels right at home in components like
+      lozenges, banners, flag messages, and illustrations. Can also be used to
+      signal success in icons and animations.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'Y700', field: 'yellow.700' },
+        { name: 'Y600', field: 'yellow.600' },
+        { name: 'Y500', field: 'yellow.500' },
+        { name: 'Y400', field: 'yellow.400' },
+        { name: 'Y300', field: 'yellow.300' },
+        { name: 'Y200', field: 'yellow.200' },
+        { name: 'Y100', field: 'yellow.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Green - Success</H3>
+    <Body>
+      We use green to indicate success or to celebrate a win. Green goes well
+      with lozenges, badges, toggles, messages, and illustrations.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'G700', field: 'green.700' },
+        { name: 'G600', field: 'green.600' },
+        { name: 'G500', field: 'green.500' },
+        { name: 'G400', field: 'green.400' },
+        { name: 'G300', field: 'green.300' },
+        { name: 'G200', field: 'green.200' },
+        { name: 'G100', field: 'green.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Blue - Progress</H3>
+    <Body>
+      Blue is used to indicate authentication, connectivity, or progress. You'll
+      find blue in messages, buttons, navigation, lozenges, badges, tabs, and
+      the progress tracker.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'B700', field: 'blue.700' },
+        { name: 'B600', field: 'blue.600' },
+        { name: 'B500', field: 'blue.500' },
+        { name: 'B400', field: 'blue.400' },
+        { name: 'B300', field: 'blue.300' },
+        { name: 'B200', field: 'blue.200' },
+        { name: 'B100', field: 'blue.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Teal - Exploration</H3>
+    <Body>
+      Teal can typically be found in illustrations or as an accent color for
+      components such a tags.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'T700', field: 'teal.700' },
+        { name: 'T600', field: 'teal.600' },
+        { name: 'T500', field: 'teal.500' },
+        { name: 'T400', field: 'teal.400' },
+        { name: 'T300', field: 'teal.300' },
+        { name: 'T200', field: 'teal.200' },
+        { name: 'T100', field: 'teal.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Purple - Learning</H3>
+    <Body>
+      Purple indicates help and support and is used as an accent color in
+      illustration and icons.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'P700', field: 'purple.700' },
+        { name: 'P600', field: 'purple.600' },
+        { name: 'P500', field: 'purple.500' },
+        { name: 'P400', field: 'purple.400' },
+        { name: 'P300', field: 'purple.300' },
+        { name: 'P200', field: 'purple.200' },
+        { name: 'P100', field: 'purple.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Magenta - Start with Heart</H3>
+    <Body>
+      Magenta can typically be found in illustrations or as an accent color for
+      components such a tags.
+    </Body>
+    <PaletteSwatch
+      colors={[
+        { name: 'M700', field: 'magenta.700' },
+        { name: 'M600', field: 'magenta.600' },
+        { name: 'M500', field: 'magenta.500' },
+        { name: 'M400', field: 'magenta.400' },
+        { name: 'M300', field: 'magenta.300' },
+        { name: 'M200', field: 'magenta.200' },
+        { name: 'M100', field: 'magenta.100' },
+      ]}
+    />
+  </Root>
+);
+
+export const Tones: Story = () => (
+  <Root>
+    <H3>Warm Skin Tones</H3>
+    <PaletteSwatch
+      colors={[
+        { name: 'Treacle', field: 'tones.warm.500' },
+        { name: 'Roasted', field: 'tones.warm.400' },
+        { name: 'Honey', field: 'tones.warm.300' },
+        { name: 'Tan', field: 'tones.warm.200' },
+        { name: 'Fair', field: 'tones.warm.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Neutral Skin Tones</H3>
+    <PaletteSwatch
+      colors={[
+        { name: 'Espresso', field: 'tones.neutral.500' },
+        { name: 'Bronze', field: 'tones.neutral.400' },
+        { name: 'Golden', field: 'tones.neutral.300' },
+        { name: 'Sand', field: 'tones.neutral.200' },
+        { name: 'Ivory', field: 'tones.neutral.100' },
+      ]}
+    />
+    <Spacer />
+    <H3>Cool Skin Tones</H3>
+    <PaletteSwatch
+      colors={[
+        { name: 'Chocolate', field: 'tones.cool.500' },
+        { name: 'Latte', field: 'tones.cool.400' },
+        { name: 'Cliffside', field: 'tones.cool.300' },
+        { name: 'Wood', field: 'tones.cool.200' },
+        { name: 'Porcelain', field: 'tones.cool.100' },
+      ]}
+    />
+  </Root>
+);

--- a/libs/spark/src/theme/__next__palette.stories.tsx
+++ b/libs/spark/src/theme/__next__palette.stories.tsx
@@ -311,7 +311,7 @@ export const Extended: Story = () => (
         { name: 'N80', field: 'neutral.80' },
         { name: 'N70', field: 'neutral.70' },
         { name: 'N60', field: 'neutral.60' },
-        { name: 'N00', field: 'neutral.00' },
+        { name: 'N0', field: 'neutral.0' },
       ]}
     />
     <Spacer />

--- a/libs/spark/src/theme/__next__palette.ts
+++ b/libs/spark/src/theme/__next__palette.ts
@@ -12,7 +12,7 @@ const globalTokens: Pick<
   | 'purple'
   | 'teal'
   | 'magenta'
-  | 'neutrals'
+  | 'neutral'
   | 'tones'
 > = {
   brand: {
@@ -84,7 +84,7 @@ const globalTokens: Pick<
     600: '#d0355b',
     700: '#b2103a',
   },
-  neutrals: {
+  neutral: {
     0: '#ffffff',
     60: '#fafbfc',
     70: '#ebecf0',
@@ -126,24 +126,24 @@ const globalTokens: Pick<
 // see https://spectrum.adobe.com/page/design-tokens/#Alias-tokens
 const aliasTokens: Pick<__next__Palette, 'background' | 'text' | 'action'> = {
   background: {
-    default: globalTokens.neutrals[0],
-    alternative: globalTokens.neutrals[60],
+    default: globalTokens.neutral[0],
+    alternative: globalTokens.neutral[60],
     brand: globalTokens.brand.blue,
-    inverse: globalTokens.neutrals[600],
+    inverse: globalTokens.neutral[600],
   },
   text: {
-    heading: globalTokens.neutrals[600],
-    body: globalTokens.neutrals[500],
-    subdued: globalTokens.neutrals[400],
-    disabled: globalTokens.neutrals[100],
-    icon: globalTokens.neutrals[500],
-    secondaryIcon: globalTokens.neutrals[300],
-    inverseHeading: globalTokens.neutrals[0],
-    inverseBody: globalTokens.neutrals[60],
-    inverseSubdued: globalTokens.neutrals[70],
-    inverseDisabled: globalTokens.neutrals[90],
-    inverseIcon: globalTokens.neutrals[60],
-    inverseSecondaryIcon: globalTokens.neutrals[80],
+    heading: globalTokens.neutral[600],
+    body: globalTokens.neutral[500],
+    subdued: globalTokens.neutral[400],
+    disabled: globalTokens.neutral[100],
+    icon: globalTokens.neutral[500],
+    secondaryIcon: globalTokens.neutral[300],
+    inverseHeading: globalTokens.neutral[0],
+    inverseBody: globalTokens.neutral[60],
+    inverseSubdued: globalTokens.neutral[70],
+    inverseDisabled: globalTokens.neutral[90],
+    inverseIcon: globalTokens.neutral[60],
+    inverseSecondaryIcon: globalTokens.neutral[80],
   },
   action: {
     focusBoxShadow: `0 0 2px 4px ${globalTokens.teal[300]}`,
@@ -179,7 +179,7 @@ export interface PaletteBrand {
   lightOrange: string;
 }
 
-export interface PaletteNeutrals {
+export interface PaletteNeutral {
   0: string;
   60: string;
   70: string;
@@ -243,7 +243,7 @@ export interface __next__Palette {
   teal: Color;
   purple: Color;
   magenta: Color;
-  neutrals: PaletteNeutrals;
+  neutral: PaletteNeutral;
   tones: PaletteTones;
   background: PaletteBackground;
   text: PaletteText;

--- a/libs/spark/src/theme/__next__palette.ts
+++ b/libs/spark/src/theme/__next__palette.ts
@@ -1,0 +1,251 @@
+import * as CSS from 'csstype';
+
+// Global tokens
+// see https://spectrum.adobe.com/page/design-tokens/#Global-tokens
+const globalTokens: Pick<
+  __next__Palette,
+  | 'brand'
+  | 'red'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'teal'
+  | 'magenta'
+  | 'neutrals'
+  | 'tones'
+> = {
+  brand: {
+    blue: '#0a4872',
+    lightBlue: '#d7f3ff',
+    orange: '#f34700',
+    lightOrange: '#ffb78f',
+  },
+  red: {
+    100: '#ffebe6',
+    200: '#ffbdad',
+    300: '#ff8f73',
+    400: '#ff7452',
+    500: '#f34700',
+    600: '#de350b',
+    700: '#a72100',
+  },
+  yellow: {
+    100: '#ffae6',
+    200: '#fff0b3',
+    300: '#ffe380',
+    400: '#ffc400',
+    500: '#ffab00',
+    600: '#ff991f',
+    700: '#ff8b00',
+  },
+  green: {
+    100: '#e3fcef',
+    200: '#abf5d1',
+    300: '#79f2c0',
+    400: '#57d9a3',
+    500: '#36b37e',
+    600: '#00875a',
+    700: '#006644',
+  },
+  blue: {
+    100: '#deebff',
+    200: '#b3d4ff',
+    300: '#4c9aff',
+    400: '#2684ff',
+    500: '#0065ff',
+    600: '#0052cc',
+    700: '#0747a6',
+  },
+  teal: {
+    100: '#e6fcff',
+    200: '#b3f5ff',
+    300: '#79e2f2',
+    400: '#00c7e6',
+    500: '#00b8d9',
+    600: '#00a3bf',
+    700: '#008da6',
+  },
+  purple: {
+    100: '#eae6ff',
+    200: '#c0b6f2',
+    300: '#998dd9',
+    400: '#8777d9',
+    500: '#6554c0',
+    600: '#5243aa',
+    700: '#403294',
+  },
+  magenta: {
+    100: '#fff1f4',
+    200: '#f7d2da',
+    300: '#f399af',
+    400: '#ea7793',
+    500: '#de5173',
+    600: '#d0355b',
+    700: '#b2103a',
+  },
+  neutrals: {
+    0: '#ffffff',
+    60: '#fafbfc',
+    70: '#ebecf0',
+    80: '#dfe1e6',
+    90: '#c1c7d0',
+    100: '#5e6c84',
+    200: '#536c84',
+    300: '#505f79',
+    400: '#42526e',
+    500: '#253858',
+    600: '#091e42',
+  },
+  tones: {
+    warm: {
+      100: '#efc088',
+      200: '#efc088',
+      300: '#b06a49',
+      400: '#7e3f2a',
+      500: '#58280c',
+    },
+    neutral: {
+      100: '#fde6ca',
+      200: '#dbbc96',
+      300: '#ad7951',
+      400: '#623a19',
+      500: '#301e12',
+    },
+    cool: {
+      100: '#ecd4ca',
+      200: '#c19a8c',
+      300: '#8a605c',
+      400: '#6d5049',
+      500: '#402225',
+    },
+  },
+};
+
+// Alias tokens, composed of global tokens
+// see https://spectrum.adobe.com/page/design-tokens/#Alias-tokens
+const aliasTokens: Pick<__next__Palette, 'background' | 'text' | 'action'> = {
+  background: {
+    default: globalTokens.neutrals[0],
+    alternative: globalTokens.neutrals[60],
+    brand: globalTokens.brand.blue,
+    inverse: globalTokens.neutrals[600],
+  },
+  text: {
+    heading: globalTokens.neutrals[600],
+    body: globalTokens.neutrals[500],
+    subdued: globalTokens.neutrals[400],
+    disabled: globalTokens.neutrals[100],
+    icon: globalTokens.neutrals[500],
+    secondaryIcon: globalTokens.neutrals[300],
+    inverseHeading: globalTokens.neutrals[0],
+    inverseBody: globalTokens.neutrals[60],
+    inverseSubdued: globalTokens.neutrals[70],
+    inverseDisabled: globalTokens.neutrals[90],
+    inverseIcon: globalTokens.neutrals[60],
+    inverseSecondaryIcon: globalTokens.neutrals[80],
+  },
+  action: {
+    focusBoxShadow: `0 0 2px 4px ${globalTokens.teal[300]}`,
+  },
+};
+
+const __next__palette = {
+  ...globalTokens,
+  ...aliasTokens,
+};
+
+export default __next__palette;
+
+// ***************
+// ***  TYPES  ***
+// ***************
+
+// Global token types
+export interface Color {
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+  600: string;
+  700: string;
+}
+
+export interface PaletteBrand {
+  blue: string;
+  lightBlue: string;
+  orange: string;
+  lightOrange: string;
+}
+
+export interface PaletteNeutrals {
+  0: string;
+  60: string;
+  70: string;
+  80: string;
+  90: string;
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+  600: string;
+}
+
+type Tone = {
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+};
+
+export interface PaletteTones {
+  warm: Tone;
+  neutral: Tone;
+  cool: Tone;
+}
+
+// Alias token types
+export interface PaletteBackground {
+  default: string;
+  alternative: string;
+  brand: string;
+  inverse: string;
+}
+
+export interface PaletteText {
+  heading: string;
+  body: string;
+  subdued: string;
+  disabled: string;
+  icon: string;
+  secondaryIcon: string;
+  inverseHeading: string;
+  inverseBody: string;
+  inverseSubdued: string;
+  inverseDisabled: string;
+  inverseIcon: string;
+  inverseSecondaryIcon: string;
+}
+
+export interface PaletteAction {
+  focusBoxShadow: CSS.Property.BoxShadow;
+}
+
+export interface __next__Palette {
+  brand: PaletteBrand;
+  red: Color;
+  yellow: Color;
+  green: Color;
+  blue: Color;
+  teal: Color;
+  purple: Color;
+  magenta: Color;
+  neutrals: PaletteNeutrals;
+  tones: PaletteTones;
+  background: PaletteBackground;
+  text: PaletteText;
+  action: PaletteAction;
+}

--- a/libs/spark/src/theme/overrides.ts
+++ b/libs/spark/src/theme/overrides.ts
@@ -3,8 +3,6 @@ import type { Theme } from '@material-ui/core';
 import type { Overrides } from '@material-ui/core/styles/overrides';
 import fontFaces from './fontFaces';
 import { MuiAutocompleteStyleOverrides } from '../Autocomplete/defaults';
-import type { AvatarClassKey } from '../Avatar';
-import type { BannerClassKey } from '../Banner';
 import { MuiButtonStyleOverrides } from '../Button/defaults';
 import { MuiCardStyleOverrides } from '../Card/defaults';
 import { MuiCardActionsStyleOverrides } from '../CardActions/defaults';
@@ -14,7 +12,6 @@ import { MuiDividerStyleOverrides } from '../Divider/defaults';
 import { MuiFormControlLabelStyleOverrides } from '../FormControlLabel/defaults';
 import { MuiFormHelperTextStyleOverrides } from '../FormHelperText/defaults';
 import { MuiFormLabelStyleOverrides } from '../FormLabel/defaults';
-import type { IconButtonClassKey } from '../IconButton';
 import { MuiInputStyleOverrides } from '../Input/defaults';
 import { MuiInputAdornmentStylesOverrides } from '../InputAdornment/defaults';
 import { MuiInputBaseStyleOverrides } from '../InputBase/defaults';
@@ -31,27 +28,11 @@ import { MuiMenuItemStyleOverrides } from '../MenuItem/defaults';
 import { MuiPaginationStyleOverrides } from '../Pagination/defaults';
 import { MuiPaginationItemStyleOverrides } from '../PaginationItem/defaults';
 import { MuiRadioStyleOverrides } from '../Radio/defaults';
-import type { SectionMessageClassKey } from '../SectionMessage';
-import type { SectionMessageTitleClassKey } from '../SectionMessageTitle';
 import { MuiSelectStylesOverrides } from '../Select/defaults';
 import { MuiSwitchStyleOverrides } from '../Switch/defaults';
 import { MuiTabStyleOverrides } from '../Tab/defaults';
 import { MuiTabsStyleOverrides } from '../Tabs/defaults';
 import { MuiTabPanelStyleOverrides } from '../TabPanel/defaults';
-import type { TagClassKey } from '../Tag';
-import type { TypographyClassKey } from '../Typography';
-
-declare module '@material-ui/core/styles/overrides' {
-  interface ComponentNameToClassKey {
-    MuiSparkAvatar: AvatarClassKey;
-    MuiSparkBanner: BannerClassKey;
-    MuiSparkIconButton: IconButtonClassKey;
-    MuiSparkSectionMessage: SectionMessageClassKey;
-    MuiSparkSectionTitleMessage: SectionMessageTitleClassKey;
-    MuiSparkTag: TagClassKey;
-    MuiSparkTypography: TypographyClassKey;
-  }
-}
 
 const overrides = (theme: Theme): Overrides => ({
   MuiAutocomplete: MuiAutocompleteStyleOverrides(theme),

--- a/libs/spark/src/theme/palette.stories.tsx
+++ b/libs/spark/src/theme/palette.stories.tsx
@@ -35,7 +35,7 @@ function ColorBox(props: ColorBoxProps) {
 }
 
 export default {
-  title: '@ps/Colors',
+  title: '@ps/theme/palette',
   component: ColorBox,
 } as Meta;
 

--- a/libs/spark/src/theme/palette.ts
+++ b/libs/spark/src/theme/palette.ts
@@ -1,72 +1,3 @@
-import createPalette from '@material-ui/core/styles/createPalette';
-
-// Custom types
-interface PaletteTertiaryColor {
-  1: string;
-  2: string;
-  3: string;
-  4: string;
-  5: string;
-}
-
-interface TypeBrand {
-  blue: string;
-  lightBlue: string;
-  orange: string;
-  peach: string;
-}
-
-// Augment global interfaces so that modules outside of this one can
-//  recognize the customizations
-declare module '@material-ui/core/index' {
-  // Only need to declare custom properties here; extending will throw
-  interface Color {
-    lighter: string;
-    light: string;
-    medium: string;
-    dark: string;
-  }
-}
-
-declare module '@material-ui/core/styles/createPalette' {
-  // Only need to declare custom properties here; extending will throw
-  interface TypeText {
-    dark: string;
-    darkLowContrast: string;
-    light: string;
-    lightLowContrast: string;
-  }
-
-  interface TypeBackground {
-    navy: string;
-    blue: string;
-    lightGrey: string;
-    lightBlue: string;
-  }
-
-  interface Palette {
-    text: TypeText;
-    background: TypeBackground;
-    brand: TypeBrand;
-    red: PaletteTertiaryColor;
-    orange: PaletteTertiaryColor;
-    yellow: PaletteTertiaryColor;
-    green: PaletteTertiaryColor;
-    blue: PaletteTertiaryColor;
-    purple: PaletteTertiaryColor;
-  }
-
-  interface PaletteOptions {
-    brand: TypeBrand;
-    red: PaletteTertiaryColor;
-    orange: PaletteTertiaryColor;
-    yellow: PaletteTertiaryColor;
-    green: PaletteTertiaryColor;
-    blue: PaletteTertiaryColor;
-    purple: PaletteTertiaryColor;
-  }
-}
-
 // Palette properties with repeatedly used values are extracted
 const red = {
   1: '#f7d2da',
@@ -139,7 +70,7 @@ const text = {
 
 // Only customizations are specified, view all other default theme.palette properties
 //  at https://v4.mui.com/customization/default-theme/?expand-path=$.palette
-const palette = createPalette({
+const palette = {
   // Mui default properties, only customizations specified
   error: {
     main: red[3],
@@ -174,6 +105,25 @@ const palette = createPalette({
   green,
   blue,
   purple,
-});
+};
 
 export default palette;
+
+// ***************
+// ***  TYPES  ***
+// ***************
+
+export interface PaletteTertiaryColor {
+  1: string;
+  2: string;
+  3: string;
+  4: string;
+  5: string;
+}
+
+export interface TypeBrand {
+  blue: string;
+  lightBlue: string;
+  orange: string;
+  peach: string;
+}

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -1,22 +1,22 @@
-import {
-  default as createTheme,
-  Theme,
-} from '@material-ui/core/styles/createTheme';
+import { createTheme, Theme as MuiTheme } from '@material-ui/core/styles';
 import initialTheme from './initialTheme';
 import overrides from './overrides';
 import props from './props';
+import __next__palette, { __next__Palette } from './__next__palette';
 
-export type { Theme } from '@material-ui/core/styles/createTheme';
+export interface Theme extends MuiTheme {
+  __next__palette: __next__Palette;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DefaultTheme extends Theme {}
 
-declare module '@material-ui/styles/defaultTheme' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface DefaultTheme extends Theme {}
-}
-export default createTheme({
+const theme = createTheme({
   ...initialTheme,
   props,
   overrides: overrides(initialTheme),
 });
+
+theme.__next__palette = __next__palette;
+
+export default theme;

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -2,6 +2,7 @@ import { createTheme, Theme as MuiTheme } from '@material-ui/core/styles';
 import initialTheme from './initialTheme';
 import overrides from './overrides';
 import props from './props';
+import type {} from './themeAugmentation';
 import __next__palette, { __next__Palette } from './__next__palette';
 
 export interface Theme extends MuiTheme {

--- a/libs/spark/src/theme/themeAugmentation.ts
+++ b/libs/spark/src/theme/themeAugmentation.ts
@@ -1,0 +1,167 @@
+import type {
+  TypographyUtils,
+  TypographyStyle,
+  TypographyStyleOptions,
+  FontStyleOptions,
+} from '@material-ui/core/styles/createTypography';
+import type { AvatarClassKey } from '../Avatar';
+import type { BannerClassKey } from '../Banner';
+import type { IconButtonClassKey } from '../IconButton';
+import type { SectionMessageClassKey } from '../SectionMessage';
+import type { SectionMessageTitleClassKey } from '../SectionMessageTitle';
+import type { TagClassKey } from '../Tag';
+import type { TypographyClassKey } from '../Typography';
+import type { PaletteTertiaryColor, TypeBrand } from './palette';
+import type { Theme } from './theme';
+import type { SparkVariant } from './typography';
+import type { __next__Palette } from './__next__palette';
+
+// Augment global interfaces so consumers TS can recognize the customizations
+
+// Note: when augmenting, only need to declare custom properties; overriding or re-declaring will throw.
+
+declare module '@material-ui/core/styles/createTheme' {
+  interface Theme {
+    __next__palette: __next__Palette;
+  }
+}
+
+declare module '@material-ui/styles/defaultTheme' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends Theme {}
+}
+
+declare module '@material-ui/core/styles/createPalette' {
+  // :__next__: use when stable
+  // interface TypeText {
+  //   heading: string;
+  //   body: string;
+  //   subdued: string;
+  //   // disabled exists
+  //   // icon exists
+  //   secondaryIcon: string;
+  //   inverseHeading: string;
+  //   inverseBody: string;
+  //   inverseSubdued: string;
+  //   inverseDisabled: string;
+  //   inverseIcon: string;
+  //   inverseSecondaryIcon: string;
+  // }
+  // interface TypeBackground {
+  //   default: string;
+  //   alternative: string;
+  //   brand: string;
+  //   inverse: string;
+  // }
+  // interface TypeAction {
+  //   focusBoxShadow: CSS.Property.BoxShadow;
+  // }
+  // interface Palette {
+  //   text: TypeText;
+  //   background: TypeBackground;
+  //   brand: TypeBrand;
+  //   red: Color;
+  //   yellow: Color;
+  //   green: Color;
+  //   blue: Color;
+  //   purple: Color;
+  //   teal: Color;
+  //   magenta: Color;
+  // }
+  // interface PaletteOptions {
+  //   text: TypeText;
+  //   background: TypeBackground;
+  //   brand: TypeBrand;
+  //   red: Color;
+  //   yellow: Color;
+  //   green: Color;
+  //   blue: Color;
+  //   purple: Color;
+  //   teal: Color;
+  //   magenta: Color;
+  // }
+
+  interface TypeText {
+    dark: string;
+    darkLowContrast: string;
+    light: string;
+    lightLowContrast: string;
+  }
+
+  interface TypeBackground {
+    navy: string;
+    blue: string;
+    lightGrey: string;
+    lightBlue: string;
+  }
+
+  interface Palette {
+    text: TypeText;
+    background: TypeBackground;
+    brand: TypeBrand;
+    red: PaletteTertiaryColor;
+    orange: PaletteTertiaryColor;
+    yellow: PaletteTertiaryColor;
+    green: PaletteTertiaryColor;
+    blue: PaletteTertiaryColor;
+    purple: PaletteTertiaryColor;
+  }
+
+  interface PaletteOptions {
+    brand: TypeBrand;
+    red: PaletteTertiaryColor;
+    orange: PaletteTertiaryColor;
+    yellow: PaletteTertiaryColor;
+    green: PaletteTertiaryColor;
+    blue: PaletteTertiaryColor;
+    purple: PaletteTertiaryColor;
+  }
+}
+
+declare module '@material-ui/core/index' {
+  // Only need to declare custom properties here; extending will throw
+  interface Color {
+    lighter: string;
+    light: string;
+    medium: string;
+    dark: string;
+  }
+}
+
+declare module '@material-ui/core/styles/overrides' {
+  interface ComponentNameToClassKey {
+    MuiSparkAvatar: AvatarClassKey;
+    MuiSparkBanner: BannerClassKey;
+    MuiSparkIconButton: IconButtonClassKey;
+    MuiSparkSectionMessage: SectionMessageClassKey;
+    MuiSparkSectionTitleMessage: SectionMessageTitleClassKey;
+    MuiSparkTag: TagClassKey;
+    MuiSparkTypography: TypographyClassKey;
+  }
+}
+
+// Augment global interface at top level
+declare module '@material-ui/core/index' {
+  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+  interface TypographyOptions
+    extends TypographyUtils,
+      Partial<
+        Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
+      > {}
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+  interface Typography extends Record<SparkVariant, TypographyStyle> {}
+}
+
+// Augment global interface at source -- affects Theme interface
+declare module '@material-ui/core/styles/createTypography' {
+  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+  interface TypographyOptions
+    extends TypographyUtils,
+      Partial<
+        Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
+      > {}
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+  interface Typography extends Record<SparkVariant, TypographyStyle> {}
+}

--- a/libs/spark/src/theme/themeAugmentation.ts
+++ b/libs/spark/src/theme/themeAugmentation.ts
@@ -28,7 +28,9 @@ declare module '@material-ui/core/styles/createTheme' {
 
 declare module '@material-ui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface DefaultTheme extends Theme {}
+  interface DefaultTheme extends Theme {
+    __next__palette: __next__Palette;
+  }
 }
 
 declare module '@material-ui/core/styles/createPalette' {

--- a/libs/spark/src/theme/typography.ts
+++ b/libs/spark/src/theme/typography.ts
@@ -38,32 +38,6 @@ interface SparkTypographyOptions
     TypographyUtils,
     Partial<Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions> {}
 
-// Augment global interface at top level
-declare module '@material-ui/core/index' {
-  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-  interface TypographyOptions
-    extends TypographyUtils,
-      Partial<
-        Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
-      > {}
-
-  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-  interface Typography extends Record<SparkVariant, TypographyStyle> {}
-}
-
-// Augment global interface at source -- affects Theme interface
-declare module '@material-ui/core/styles/createTypography' {
-  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-  interface TypographyOptions
-    extends TypographyUtils,
-      Partial<
-        Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
-      > {}
-
-  /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
-  interface Typography extends Record<SparkVariant, TypographyStyle> {}
-}
-
 const defaultFontFamily = '"Nunito", Avenir, sans-serif';
 const codeFontFamily =
   '"Source Code Pro", Consolas, "Andale Mono WT", "Lucida Console", Courier, monospace';


### PR DESCRIPTION
Closes #322

Implements the new palette on a very-clearly experimental field on theme: `theme.__next__palette`. The idea is that when all internal dependencies on `theme.palette` are removed, then the `__next__` will take over. In the meantime, consumers who need this PDS v2 palette will have experimental access to it -- avoiding having to create their own sources of truth.

I reference `globalTokens` and `aliasTokens` based on my reading of Adobe Spectrum's Foundation explainer on design tokens: https://spectrum.adobe.com/page/design-tokens/ . I recommend reading every item under "Foundation", but a particularly enlightening one is International design - Colors https://spectrum.adobe.com/page/international-design/#Colors . I believe that from this, you can see where `aliasTokens` come in. They're composed of (probably) global tokens, that are indisputably correct (red is red to everyone), but are a named abstraction (error is error to everyone, but different colors to some). From this, we get `background` and `text` on our palette as functional aliases. I've described them as "experimental" in their respective stories, because they aren't officially reflected in the Figma spec, and are kind-of ad-hoc for now.

In the changelog, I've detailed the "Planned Migration" that I have confidence will work for our consumers. Feedback appreciated.

Also if you could take the time to tediously double-check I've typed in all the hex values correctly, that'd be great.