### PR TITLE
fix(theme): make unstable theme properties available on default theme

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,9 +2,35 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.2...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+The term "unstable / unstable preview" replaces "next" and the prefix "`unstable_`" replaces "`__next__`".
+
+- **theme**
+  - Renamed unstable properties.
+  - Migration:
+    - `theme.__next__palette` -> `theme.unstable_palette`
+    - `theme.__next__typography` -> `theme.unstable_typography`
+- **unstable_fontFaces**
+  - Renamed.
+  - Migration:
+    - `__next__fontFaces` -> `unstable_fontFaces`
+- **unstable_palette**
+  - Renamed.
+  - Migration:
+    - `__next__palette` -> `unstable_palette`
+- **unstable_typography**
+  - Renamed.
+  - Migration:
+    - `__next__typography` -> `unstable_typography`
+
 ## [v1.0.0-alpha.2](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) (2022-02-25)
 
 ### **next**
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
 
 - **\_\_next\_\_typography**
   - Added `font-feature-settings` for "body" and "description" variants.
@@ -40,8 +66,13 @@ Transitioned to new version format for pre-1.0 releases: `v1.0.0-alpha.XXX` wher
 
 ### **next**
 
-_This section details previous of breaking changes or experimental features and are subject to breaking changes at any time._
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
 
+- **theme**
+  - Attached preview properties: `theme.
+  - Migration:
+    - `theme.__next__palette`
+    - `theme.__next__typography`
 - **\_\_next\_\_fontFaces**
   - Implemented according to PDS v2.
   - As a consumer, you should serve the contents of `libs/spark/public/fonts/` directory on your server at the same path, `fonts/`. Do not change any file or directory names and structure, as they are exactly what is expected by the injected font face declarations.

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -14,15 +14,21 @@ The term "unstable / unstable preview" replaces "next" and the prefix "`unstable
     - `theme.__next__palette` -> `theme.unstable_palette`
     - `theme.__next__typography` -> `theme.unstable_typography`
 - **unstable_fontFaces**
-  - Renamed.
+  - Renamed, see below.
+- **unstable_palette**
+  - Renamed, see below.
+- **unstable_typography**
+  - Renamed, see below.
+- **\_\_next\_\_fontFaces**
+  - Removed.
   - Migration:
     - `__next__fontFaces` -> `unstable_fontFaces`
-- **unstable_palette**
-  - Renamed.
+- **\_\_next\_\_palette**
+  - Removed.
   - Migration:
     - `__next__palette` -> `unstable_palette`
-- **unstable_typography**
-  - Renamed.
+- **\_\_next\_\_typography**
+  - Removed.
   - Migration:
     - `__next__typography` -> `unstable_typography`
 

--- a/libs/spark/src/theme/initialTheme.ts
+++ b/libs/spark/src/theme/initialTheme.ts
@@ -2,9 +2,16 @@ import { default as createTheme } from '@material-ui/core/styles/createTheme';
 import palette from './palette';
 import shadows from './shadows';
 import typography from './typography';
+import unstable_palette from './unstable_palette';
+import unstable_typography from './unstable_typography';
 
-export default createTheme({
+const initialTheme = createTheme({
   palette,
   shadows,
   typography,
 });
+
+initialTheme.unstable_palette = unstable_palette;
+initialTheme.unstable_typography = unstable_typography;
+
+export default initialTheme;

--- a/libs/spark/src/theme/overrides.ts
+++ b/libs/spark/src/theme/overrides.ts
@@ -1,7 +1,7 @@
 import type {} from '@material-ui/lab/themeAugmentation';
 import type { Theme } from '@material-ui/core';
 import type { Overrides } from '@material-ui/core/styles/overrides';
-import __next__fontFaces from './__next__fontFaces';
+import unstable_fontFaces from './unstable_fontFaces';
 import fontFaces from './fontFaces';
 import { MuiAutocompleteStyleOverrides } from '../Autocomplete/defaults';
 import { MuiButtonStyleOverrides } from '../Button/defaults';
@@ -44,7 +44,7 @@ const overrides = (theme: Theme): Overrides => ({
         fontFamily: theme.typography.fontFamily,
         fontSize: theme.typography.fontSize,
       },
-      '@font-face': fontFaces.concat(__next__fontFaces),
+      '@font-face': fontFaces.concat(unstable_fontFaces),
     },
   },
   MuiCard: MuiCardStyleOverrides,

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -3,14 +3,14 @@ import initialTheme from './initialTheme';
 import overrides from './overrides';
 import props from './props';
 import type {} from './themeAugmentation';
-import __next__palette, { __next__Palette } from './__next__palette';
-import __next__typography, {
-  __next__TypographyOptions,
-} from './__next__typography';
+import unstable_palette, { Unstable_Palette } from './unstable_palette';
+import unstable_typography, {
+  Unstable_TypographyOptions,
+} from './unstable_typography';
 
 export interface Theme extends MuiTheme {
-  __next__palette: __next__Palette;
-  __next__typography: __next__TypographyOptions;
+  unstable_palette: Unstable_Palette;
+  unstable_typography: Unstable_TypographyOptions;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -22,7 +22,7 @@ const theme = createTheme({
   overrides: overrides(initialTheme),
 });
 
-theme.__next__palette = __next__palette;
-theme.__next__typography = __next__typography;
+theme.unstable_palette = unstable_palette;
+theme.unstable_typography = unstable_typography;
 
 export default theme;

--- a/libs/spark/src/theme/themeAugmentation.ts
+++ b/libs/spark/src/theme/themeAugmentation.ts
@@ -14,8 +14,8 @@ import type { TypographyClassKey } from '../Typography';
 import type { PaletteTertiaryColor, TypeBrand } from './palette';
 import type { Theme } from './theme';
 import type { SparkVariant } from './typography';
-import type { __next__Palette } from './__next__palette';
-import type { __next__TypographyOptions } from './__next__typography';
+import type { Unstable_Palette } from './unstable_palette';
+import type { Unstable_TypographyOptions } from './unstable_typography';
 
 // Augment global interfaces so consumers TS can recognize the customizations
 
@@ -23,21 +23,21 @@ import type { __next__TypographyOptions } from './__next__typography';
 
 declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
-    __next__palette: __next__Palette;
-    __next__typography: __next__TypographyOptions;
+    unstable_palette: Unstable_Palette;
+    unstable_typography: Unstable_TypographyOptions;
   }
 }
 
 declare module '@material-ui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface DefaultTheme extends Theme {
-    __next__palette: __next__Palette;
-    __next__typography: __next__TypographyOptions;
+    unstable_palette: Unstable_Palette;
+    unstable_typography: Unstable_TypographyOptions;
   }
 }
 
 declare module '@material-ui/core/styles/createPalette' {
-  // :__next__: use when stable
+  // :unstable_: use when stable
   // interface TypeText {
   //   heading: string;
   //   body: string;
@@ -147,7 +147,7 @@ declare module '@material-ui/core/styles/overrides' {
 
 // Augment global interface at top level
 declare module '@material-ui/core/index' {
-  // :__next__: replace `SparkVariant` with `__next__TypographyVariant`
+  // :unstable_: replace `SparkVariant` with `unstable_TypographyVariant`
   /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
   interface TypographyOptions
     extends TypographyUtils,
@@ -155,14 +155,14 @@ declare module '@material-ui/core/index' {
         Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
       > {}
 
-  // :__next__: replace `SparkVariant` with `__next__TypographyVariant`
+  // :unstable_: replace `SparkVariant` with `unstable_TypographyVariant`
   /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
   interface Typography extends Record<SparkVariant, TypographyStyle> {}
 }
 
 // Augment global interface at source -- affects Theme interface
 declare module '@material-ui/core/styles/createTypography' {
-  // :__next__: replace `SparkVariant` with `__next__TypographyVariant`
+  // :unstable_: replace `SparkVariant` with `unstable_TypographyVariant`
   /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
   interface TypographyOptions
     extends TypographyUtils,
@@ -170,7 +170,7 @@ declare module '@material-ui/core/styles/createTypography' {
         Record<SparkVariant, TypographyStyleOptions> & FontStyleOptions
       > {}
 
-  // :__next__: replace `SparkVariant` with `__next__TypographyVariant`
+  // :unstable_: replace `SparkVariant` with `unstable_TypographyVariant`
   /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
   interface Typography extends Record<SparkVariant, TypographyStyle> {}
 }

--- a/libs/spark/src/theme/unstable_fontFaces.stories.tsx
+++ b/libs/spark/src/theme/unstable_fontFaces.stories.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ScopedCssBaseline, styled, withStyles } from '..';
-import { VariantUseFor } from './__next__typography.stories';
+import { VariantUseFor } from './unstable_typography.stories';
 
 export default {
-  title: '@ps/theme/__next__fonts',
+  title: '@ps/theme/unstable_fonts',
 } as Meta;
 
 const FontsBaseline = withStyles({
@@ -154,7 +154,7 @@ const Root = styled('div')({
 });
 const Heading = styled('h1')(({ theme }) => ({
   fontFamily: '"Poppins"',
-  fontSize: theme.__next__typography.pxToRem(32),
+  fontSize: theme.unstable_typography.pxToRem(32),
   fontWeight: 500,
   letterSpacing: '-0.04em',
   lineHeight: 48 / 32,
@@ -163,17 +163,17 @@ const Description = styled('p')(({ theme }) => ({
   margin: 0, // reset
   marginBottom: 16,
   fontFamily: '"Inter"',
-  fontSize: theme.__next__typography.pxToRem(18),
+  fontSize: theme.unstable_typography.pxToRem(18),
   lineHeight: 28 / 18,
 }));
 const Code = styled('span')(({ theme }) => ({
   margin: 0, // reset
   display: 'inline',
   backgroundColor: '#f4f5f7',
-  color: theme.__next__palette.neutral[500],
+  color: theme.unstable_palette.neutral[500],
   paddingRight: 4,
   paddingLeft: 4,
-  ...theme.__next__typography.code,
+  ...theme.unstable_typography.code,
 }));
 
 export const Guide: Story = () => (
@@ -299,7 +299,7 @@ const Showcase = styled('div')({
   gridGap: 64,
 });
 const Hr = styled('hr')(({ theme }) => ({
-  background: theme.__next__palette.neutral[600],
+  background: theme.unstable_palette.neutral[600],
   marginTop: 24,
   marginBottom: 48,
   opacity: 0.32,
@@ -311,9 +311,9 @@ const LargeDisplay = styled(({ fontFamily, fontWeight, ...other }) => (
 ))(
   // @ts-expect-error ts(2339)
   ({ fontFamily = '"Poppins"', fontWeight = 700, theme }) => ({
-    color: theme.__next__palette.neutral[600],
+    color: theme.unstable_palette.neutral[600],
     fontFamily,
-    fontSize: theme.__next__typography.pxToRem(64),
+    fontSize: theme.unstable_typography.pxToRem(64),
     fontWeight,
     lineHeight: 72 / 64,
     margin: 0, // reset
@@ -322,7 +322,7 @@ const LargeDisplay = styled(({ fontFamily, fontWeight, ...other }) => (
 const Body = styled('p')(({ theme }) => ({
   marginTop: 16,
   marginBottom: 32,
-  ...theme.__next__typography.body,
+  ...theme.unstable_typography.body,
 }));
 const WeightWaterfall = styled(({ fontFamily, ...other }) => (
   <div {...other} />
@@ -334,7 +334,7 @@ const WeightWaterfall = styled(({ fontFamily, ...other }) => (
     gap: 32,
     '& > *': {
       fontFamily,
-      fontSize: theme.__next__typography.pxToRem(48),
+      fontSize: theme.unstable_typography.pxToRem(48),
       letterSpacing: '-0.02em',
       lineHeight: 40 / 48,
       // inline `fontWeight`

--- a/libs/spark/src/theme/unstable_fontFaces.ts
+++ b/libs/spark/src/theme/unstable_fontFaces.ts
@@ -126,7 +126,7 @@ const robotoMonoItalic: CSS.AtRule.FontFace = {
   ].join(', '),
 };
 
-const __next__fontFaces: Array<CSS.AtRule.FontFace> = [
+const unstable_fontFaces: Array<CSS.AtRule.FontFace> = [
   poppinsExtrabold,
   poppinsExtraboldItalic,
   poppinsBold,
@@ -141,4 +141,4 @@ const __next__fontFaces: Array<CSS.AtRule.FontFace> = [
   robotoMonoItalic,
 ];
 
-export default __next__fontFaces;
+export default unstable_fontFaces;

--- a/libs/spark/src/theme/unstable_palette.stories.tsx
+++ b/libs/spark/src/theme/unstable_palette.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { styled, useTheme, Theme } from '..';
 
 export default {
-  title: '@ps/theme/__next__palette',
+  title: '@ps/theme/unstable_palette',
 } as Meta;
 
 /**
@@ -15,7 +15,7 @@ export default {
 function getValue(theme: Theme, field: string): string {
   const fields = field.split('.');
 
-  let walk = theme.__next__palette;
+  let walk = theme.unstable_palette;
   let value;
   for (let i = 0; i < fields.length; i++) {
     if (i === fields.length - 1) {
@@ -75,7 +75,7 @@ const PaletteColor = styled(function PaletteColor(props: {
       fontSize: theme.typography.pxToRem(16),
       lineHeight: 20 / 16,
       fontWeight: 600,
-      color: theme.__next__palette.text.body,
+      color: theme.unstable_palette.text.body,
       marginBottom: 8,
     },
     '& .value': {
@@ -83,14 +83,14 @@ const PaletteColor = styled(function PaletteColor(props: {
       fontSize: theme.typography.pxToRem(14),
       lineHeight: 20 / 14,
       fontWeight: 400,
-      color: theme.__next__palette.text.subdued,
+      color: theme.unstable_palette.text.subdued,
     },
     '& .field': {
       // fontFamily: 'Inter',
       fontSize: theme.typography.pxToRem(14),
       lineHeight: 20 / 14,
       fontWeight: 400,
-      color: theme.__next__palette.text.subdued,
+      color: theme.unstable_palette.text.subdued,
     },
   })
 );
@@ -119,13 +119,13 @@ const PaletteSwatch = styled(function PaletteSwatch(props: {
 const Root = styled('div')({
   paddingLeft: 8,
 });
-// :__next__: replace with __next__Typography
+// :unstable_: replace with unstable_Typography
 const H1 = styled('h1')(({ theme }) => ({
   // fontFamily: 'Inter',
   fontSize: theme.typography.pxToRem(28),
   lineHeight: 40 / 28,
   fontWeight: 600,
-  color: theme.__next__palette.text.heading,
+  color: theme.unstable_palette.text.heading,
   marginBottom: 8,
 }));
 const H2 = styled('h2')(({ theme }) => ({
@@ -133,7 +133,7 @@ const H2 = styled('h2')(({ theme }) => ({
   fontSize: theme.typography.pxToRem(24),
   lineHeight: 32 / 24,
   fontWeight: 600,
-  color: theme.__next__palette.text.heading,
+  color: theme.unstable_palette.text.heading,
   marginBottom: 8,
   marginTop: 8,
 }));
@@ -142,7 +142,7 @@ const H3 = styled('h3')(({ theme }) => ({
   fontSize: theme.typography.pxToRem(20),
   lineHeight: 32 / 24,
   fontWeight: 600,
-  color: theme.__next__palette.text.heading,
+  color: theme.unstable_palette.text.heading,
   marginBottom: 8,
   marginTop: 8,
 }));
@@ -151,7 +151,7 @@ const Body = styled('p')(({ theme }) => ({
   fontSize: theme.typography.pxToRem(16),
   lineHeight: 24 / 16,
   fontWeight: 400,
-  color: theme.__next__palette.text.body,
+  color: theme.unstable_palette.text.body,
   marginBottom: 16,
 }));
 const Spacer = styled('div')({

--- a/libs/spark/src/theme/unstable_palette.ts
+++ b/libs/spark/src/theme/unstable_palette.ts
@@ -3,7 +3,7 @@ import * as CSS from 'csstype';
 // Global tokens
 // see https://spectrum.adobe.com/page/design-tokens/#Global-tokens
 const globalTokens: Pick<
-  __next__Palette,
+  Unstable_Palette,
   | 'brand'
   | 'red'
   | 'yellow'
@@ -124,7 +124,7 @@ const globalTokens: Pick<
 
 // Alias tokens, composed of global tokens
 // see https://spectrum.adobe.com/page/design-tokens/#Alias-tokens
-const aliasTokens: Pick<__next__Palette, 'background' | 'text' | 'action'> = {
+const aliasTokens: Pick<Unstable_Palette, 'background' | 'text' | 'action'> = {
   background: {
     default: globalTokens.neutral[0],
     alternative: globalTokens.neutral[60],
@@ -150,12 +150,12 @@ const aliasTokens: Pick<__next__Palette, 'background' | 'text' | 'action'> = {
   },
 };
 
-const __next__palette = {
+const unstable_palette = {
   ...globalTokens,
   ...aliasTokens,
 };
 
-export default __next__palette;
+export default unstable_palette;
 
 // ***************
 // ***  TYPES  ***
@@ -234,7 +234,7 @@ export interface PaletteAction {
   focusBoxShadow: CSS.Property.BoxShadow;
 }
 
-export interface __next__Palette {
+export interface Unstable_Palette {
   brand: PaletteBrand;
   red: Color;
   yellow: Color;

--- a/libs/spark/src/theme/unstable_typography.stories.tsx
+++ b/libs/spark/src/theme/unstable_typography.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ScopedCssBaseline, styled, withStyles } from '..';
 
 export default {
-  title: '@ps/theme/__next__typography',
+  title: '@ps/theme/unstable_typography',
   excludeStories: ['VariantUseFor'],
 } as Meta;
 
@@ -43,11 +43,11 @@ const VariantInfo = styled('div')(({ theme }) => ({
   '& > :nth-child(1)': {
     fontFamily: '"Poppins"',
     fontWeight: 900,
-    fontSize: theme.__next__typography.pxToRem(20),
+    fontSize: theme.unstable_typography.pxToRem(20),
     lineHeight: 32 / 20,
   },
   '& > :nth-child(2)': {
-    ...theme.__next__typography.code,
+    ...theme.unstable_typography.code,
   },
 }));
 
@@ -60,8 +60,8 @@ const FlexBox = styled('div')({
 const VariantSwagger = styled(({ variant, ...other }) => <div {...other} />)(
   // @ts-expect-error ts(2339)
   ({ theme, variant }) => ({
-    ...theme.__next__typography[variant],
-    color: theme.__next__palette.neutral[500],
+    ...theme.unstable_typography[variant],
+    color: theme.unstable_palette.neutral[500],
   })
 );
 export const VariantUseFor = styled('span')(({ theme }) => ({
@@ -70,15 +70,15 @@ export const VariantUseFor = styled('span')(({ theme }) => ({
   flexDirection: 'column',
   gap: 8,
   padding: 8,
-  color: theme.__next__palette.neutral[500],
-  ...theme.__next__typography.code,
+  color: theme.unstable_palette.neutral[500],
+  ...theme.unstable_typography.code,
   '& > :nth-child(1)': {
     fontWeight: 700,
   },
 }));
 
 const Root = styled('div')(({ theme }) => ({
-  color: theme.__next__palette.neutral[500],
+  color: theme.unstable_palette.neutral[500],
   display: 'grid',
   gridGap: 32,
   gridTemplateColumns: '186px auto',

--- a/libs/spark/src/theme/unstable_typography.ts
+++ b/libs/spark/src/theme/unstable_typography.ts
@@ -6,7 +6,7 @@ import type {
 } from '@material-ui/core/styles/createTypography';
 import { buildVariant } from './typography';
 
-export type __next__TypographyVariant =
+export type Unstable_TypographyVariant =
   | 'display'
   | 'T32'
   | 'T28'
@@ -19,10 +19,10 @@ export type __next__TypographyVariant =
   | 'description'
   | 'code';
 
-export interface __next__TypographyOptions
+export interface Unstable_TypographyOptions
   extends TypographyUtils,
     Partial<
-      Record<__next__TypographyVariant, TypographyStyleOptions> &
+      Record<Unstable_TypographyVariant, TypographyStyleOptions> &
         FontStyleOptions
     > {}
 
@@ -32,7 +32,7 @@ const headingFontFamily = '"Poppins", sans-serif';
 const defaultFontSize = 16;
 const pxToRem = (px: number) => `${px / defaultFontSize}rem`;
 
-const customVariants: Record<__next__TypographyVariant, TypographyStyle> = {
+const customVariants: Record<Unstable_TypographyVariant, TypographyStyle> = {
   display: buildVariant(800, 48, 52, -0.01, undefined, headingFontFamily),
   T32: buildVariant(700, 32, 40, -0.01, undefined, headingFontFamily),
   T28: buildVariant(700, 28, 36, -0.01, undefined, headingFontFamily),
@@ -69,14 +69,14 @@ const customVariants: Record<__next__TypographyVariant, TypographyStyle> = {
   code: buildVariant(400, 14, 24, undefined, undefined, codeFontFamily),
 };
 
-const __next__typography: __next__TypographyOptions = {
+const unstable_typography: Unstable_TypographyOptions = {
   // override default Roboto
   fontFamily: defaultFontFamily,
   // override default 14px
   fontSize: defaultFontSize,
   // override default division by 14
   pxToRem,
-  // :__next__: uncomment once merged
+  // :unstable_: uncomment once merged
   // specify all mui defaults (some Mui components rely on these by default)
   // h1: customVariants['T28'],
   // h2: customVariants['T22'],
@@ -95,4 +95,4 @@ const __next__typography: __next__TypographyOptions = {
   ...customVariants,
 };
 
-export default __next__typography;
+export default unstable_typography;


### PR DESCRIPTION
Fixes `unstable_palette` and `unstable_typography` not being available on the default theme set for the styling utilities. That theme is the `initialTheme` variable, not the final `theme` variable because the latter includes props and classes default that the utilities are required for (circular dep).

The end result is that consumers will be able to access these properties through styling utilities **without** having to render a `ThemeProvider` as an ancestor.