### PR TITLE
refactor(Unstable_Typography): remove unnecessary `classes` spread

### DIFF
--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -149,7 +149,6 @@ const Unstable_Typography = React.forwardRef(function Unstable_Typography<
   return (
     <MuiTypography
       classes={{
-        ...classes,
         root: clsx(classes.root, classesProp?.root),
       }}
       component={component || defaultVariantMapping[variant]}


### PR DESCRIPTION
There are no other classes!