### PR TITLE
chore(eslint): fix and error on no-unused-vars rule

### DIFF
--- a/libs/spark/.eslintrc.json
+++ b/libs/spark/.eslintrc.json
@@ -11,7 +11,9 @@
         ]
       },
       "rules": {
-        "react/jsx-pascal-case": "off"
+        "react/jsx-pascal-case": "off",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error"]
       }
     },
     {

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
@@ -6,7 +6,6 @@ import {
   styled,
   withStyles,
 } from '..';
-import { Unstable_TypographyVariant } from '../theme/unstable_typography';
 import { capitalize } from '../utils';
 
 export const SbUnstable_Typography = (props: Unstable_TypographyProps) => (


### PR DESCRIPTION
I noticed the linting was not error'ing on an unused import in a recent file -- not sure why not. This fixes that.