### PR TITLE
feat(utils): add unstable_createSvgIcon

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 _This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
 
+- **unstable_createSvgIcon**
+  - No longer internal, exported in package root for consumer user.
 - **Unstable_Link**
   - Initial implementation of `Link` replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -230,6 +230,8 @@ export * from './styled';
 export { default as theme } from './theme';
 export * from './theme';
 
+export { default as unstable_createSvgIcon } from './unstable_createSvgIcon';
+
 export { default as useMediaQuery } from './useMediaQuery';
 
 export { default as useTheme } from './useTheme';

--- a/libs/spark/src/unstable_createSvgIcon.tsx
+++ b/libs/spark/src/unstable_createSvgIcon.tsx
@@ -1,0 +1,42 @@
+// Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui/src/utils/createSvgIcon.js
+//  Changes made since
+
+import * as React from 'react';
+import Unstable_SvgIcon, { Unstable_SvgIconProps } from './Unstable_SvgIcon';
+
+const unstable_createSvgIcon = (
+  path: React.ReactNode,
+  displayName: string,
+  viewBox?: string,
+  width?: string,
+  height?: string
+): typeof Unstable_SvgIcon => {
+  const Component = (
+    props: Unstable_SvgIconProps,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ref: any
+  ) => (
+    <Unstable_SvgIcon
+      data-testid={`${displayName}Icon`}
+      ref={ref}
+      viewBox={viewBox}
+      width={width}
+      height={height}
+      {...props}
+    >
+      {path}
+    </Unstable_SvgIcon>
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  Component.muiName = 'Unstable_SvgIcon';
+
+  return React.memo(React.forwardRef(Component)) as typeof Unstable_SvgIcon;
+};
+
+export default unstable_createSvgIcon;


### PR DESCRIPTION
The same function as before, but using the new `Unstable_SvgIcon`. Also, notably, the utility is defined and exported like a public function, not like an internal one -- the changelog advertises that. I've found that almost all consumers need this at one point or another for some unanticipated one-off.