### PR TITLE
chore: remove SparkThemeProvider as global decorator

### DIFF
--- a/libs/spark/.storybook/preview.js
+++ b/libs/spark/.storybook/preview.js
@@ -3,7 +3,6 @@ import { addDecorator } from '@storybook/react';
 import {
   CssBaseline,
   FontFacesBaseline,
-  SparkThemeProvider,
   Unstable_FontFacesBaseline,
 } from '../src';
 
@@ -13,9 +12,7 @@ addDecorator((Story) => (
     <FontFacesBaseline />
     <Unstable_FontFacesBaseline />
 
-    <SparkThemeProvider>
-      <Story />
-    </SparkThemeProvider>
+    <Story />
   </Fragment>
 ));
 

--- a/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
+++ b/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
@@ -12,12 +12,14 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 export default {
   title: '@ps/Autocomplete',
   component: Autocomplete,
   argTypes: {},
   args: {},
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const reasons = [

--- a/libs/spark/src/Avatar/Avatar.stories.tsx
+++ b/libs/spark/src/Avatar/Avatar.stories.tsx
@@ -6,6 +6,7 @@ import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbAvatar = Avatar;
 
@@ -16,6 +17,7 @@ export default {
   args: {
     src: '/img/guide-1.png',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = ({ src, alt, ...other }) => (

--- a/libs/spark/src/Banner/Banner.stories.tsx
+++ b/libs/spark/src/Banner/Banner.stories.tsx
@@ -5,6 +5,7 @@ import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbBannerProps extends BannerProps {
   closeText?: BannerProps['closeText'];
@@ -23,6 +24,7 @@ export default {
     onDetails: null,
     onClose: null,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const messages: Record<BannerProps['severity'], string> = {

--- a/libs/spark/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/libs/spark/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Breadcrumbs, BreadcrumbsProps, Link } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbBreadcrumbs = (props: BreadcrumbsProps) => (
   <Breadcrumbs {...props} />
@@ -10,6 +11,7 @@ export default {
   title: '@ps/Breadcrumbs',
   component: SbBreadcrumbs,
   excludeStories: ['SbBreadcrumbs'],
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/Button/Button.stories.tsx
+++ b/libs/spark/src/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
 import { Box, Button, ButtonProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface SbButtonProps
@@ -45,6 +46,7 @@ export default {
   args: {
     children: 'Label',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => <Button {...args} />;

--- a/libs/spark/src/Card/Card.stories.tsx
+++ b/libs/spark/src/Card/Card.stories.tsx
@@ -13,11 +13,13 @@ import {
   styled,
   withStyles,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export default {
   title: '@ps/Card',
   component: Card,
   excludeStories: ['Card'],
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const CustomCard = withStyles({

--- a/libs/spark/src/Checkbox/Checkbox.stories.tsx
+++ b/libs/spark/src/Checkbox/Checkbox.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Checkbox, CheckboxProps, FormControlLabel } from '..';
 import { DocumentationTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // Doesn't pick up extended SwitchBaseProps
 interface SbCheckboxProps
@@ -26,6 +27,7 @@ export default {
   component: SbCheckbox,
   excludeStories: ['SbCheckbox'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/Collapse/Collapse.stories.tsx
+++ b/libs/spark/src/Collapse/Collapse.stories.tsx
@@ -10,6 +10,7 @@ import {
   makeStyles,
   styled,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbCollapseProps extends CollapseProps {
   collapsedSize?: CollapseProps['collapsedSize'];
@@ -27,6 +28,7 @@ export default {
     collapsedSize: '0px',
     orientation: 'vertical',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const useIconStyles = makeStyles((theme) => ({

--- a/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
@@ -16,6 +16,7 @@ import {
   ListItemText,
   MenuItem,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbDropdownContextProps extends DropdownContextProps {
   /**
@@ -69,6 +70,7 @@ export default {
     sb_DropdownAnchor_component: 'Button',
     sb_DropdownMenu_placement: 'bottom-left',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const ConfigurableTemplate = ({

--- a/libs/spark/src/FormControl/FormControl.stories.tsx
+++ b/libs/spark/src/FormControl/FormControl.stories.tsx
@@ -10,6 +10,7 @@ import {
   FormHelperText,
   FormLabel,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbFormControl = (props: FormControlProps) => (
   <FormControl {...props} />
@@ -20,6 +21,7 @@ export default {
   component: SbFormControl,
   excludeStories: ['SbFormControl'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const CheckboxGroupTemplate = ({

--- a/libs/spark/src/IconButton/IconButton.stories.tsx
+++ b/libs/spark/src/IconButton/IconButton.stories.tsx
@@ -6,6 +6,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface SbIconButtonProps
@@ -41,6 +42,7 @@ export default {
   args: {
     children: 'ChevronDown',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => <IconButton {...args} />;

--- a/libs/spark/src/Input/Input.stories.tsx
+++ b/libs/spark/src/Input/Input.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone, QuestionDuotone } from '@prenda/spark-icons';
 import { Input, InputAdornment, InputProps, styled } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbInputProps extends InputProps {
   defaultValue?: InputProps['defaultValue'];
@@ -59,6 +60,7 @@ export default {
   args: {
     placeholder: 'Placeholder',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = ({ startAdornment, endAdornment, ...args }) => (

--- a/libs/spark/src/Link/Link.stories.tsx
+++ b/libs/spark/src/Link/Link.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Link, LinkProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // underlying props don't have descriptions
 export const SbLink = (props: LinkProps) => <Link {...props} />;
@@ -12,6 +13,7 @@ export default {
   args: {
     href: '#',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => <Link {...args}>Text</Link>;

--- a/libs/spark/src/MenuItem/MenuItem.stories.tsx
+++ b/libs/spark/src/MenuItem/MenuItem.stories.tsx
@@ -17,6 +17,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // underlying MenuItemProps don't have descriptions
 interface SbMenuItemProps extends MenuItemProps {
@@ -59,6 +60,7 @@ export default {
     sb_ListItemText_primary: 'Menu item',
     button: true,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Container = (props) => (

--- a/libs/spark/src/MenuList/MenuList.stories.tsx
+++ b/libs/spark/src/MenuList/MenuList.stories.tsx
@@ -18,6 +18,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // underlying MenuListProps don't have descriptions
 interface SbMenuListProps extends MenuListProps {
@@ -35,6 +36,7 @@ export default {
   title: '@ps/MenuList',
   component: SbMenuList,
   excludeStories: ['SbMenuList'],
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const CustomPaper = withStyles((theme) => ({

--- a/libs/spark/src/NavBar/NavBar.stories.tsx
+++ b/libs/spark/src/NavBar/NavBar.stories.tsx
@@ -17,6 +17,7 @@ import {
   styled,
   withStyles,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbNavBar = (props: NavBarProps) => <NavBar {...props} />;
 
@@ -27,6 +28,7 @@ export default {
   args: {
     color: 'default',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const BluePrendaMonogram = styled(PrendaMonogram)(({ theme }) => ({

--- a/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
+++ b/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { CheckCircleDuotone } from '@prenda/spark-icons';
 import { Box, NavBarButton, NavBarButtonProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbNavBarButtonProps
   extends Omit<
@@ -51,6 +52,7 @@ export default {
   args: {
     children: 'Label',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: NavBarButtonProps) => <NavBarButton {...args} />;

--- a/libs/spark/src/Pagination/Pagination.stories.tsx
+++ b/libs/spark/src/Pagination/Pagination.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Pagination, PaginationProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbPaginationProps extends PaginationProps {
   boundaryCount?: PaginationProps['boundaryCount'];
@@ -27,6 +28,7 @@ export default {
     count: 10,
     defaultPage: 2,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 export const ConfigurablePagination: Story = (args: SbPaginationProps) => (

--- a/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
+++ b/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { PaginationItem, PaginationItemProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface SbPaginationItemProps
@@ -18,6 +19,7 @@ export default {
     type: 'page',
     page: 1,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: PaginationItemProps) => (

--- a/libs/spark/src/Radio/Radio.stories.tsx
+++ b/libs/spark/src/Radio/Radio.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { FormControlLabel, Radio, RadioProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // Doesn't pick up extended SwitchBaseProps
 interface SbRadioProps
@@ -29,6 +30,7 @@ export default {
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
+++ b/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
@@ -11,6 +11,7 @@ import {
   RadioGroupProps,
 } from '..';
 import { DocumentationTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbRadioGroupProps extends RadioGroupProps {
   ['aria-label']?: RadioGroupProps['aria-label'];
@@ -60,6 +61,7 @@ export default {
     'aria-label': 'example group',
     name: 'exampleGroup',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = ({

--- a/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
+++ b/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
@@ -10,6 +10,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbSectionMessageProps extends SectionMessageProps {
   severity?: SectionMessageProps['severity'];
@@ -26,6 +27,7 @@ export default {
   args: {
     severity: 'info',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/Select/Select.stories.tsx
+++ b/libs/spark/src/Select/Select.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone } from '@prenda/spark-icons';
 import { InputAdornment, MenuItem, Select, SelectProps, styled } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbSelectProps extends SelectProps {
   /**
@@ -44,6 +45,7 @@ export default {
   args: {
     value: '',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = ({ value: propValue, ...args }) => {

--- a/libs/spark/src/Select/defaults.tsx
+++ b/libs/spark/src/Select/defaults.tsx
@@ -5,7 +5,7 @@ import type { StyleRules } from '../withStyles';
 
 export const MuiSelectDefaultProps: Partial<SelectProps> = {
   displayEmpty: true,
-  IconComponent: ChevronDown,
+  IconComponent: (props) => <ChevronDown fontSize="medium" {...props} />,
   MenuProps: {
     getContentAnchorEl: null,
     anchorOrigin: {

--- a/libs/spark/src/Step/Step.stories.tsx
+++ b/libs/spark/src/Step/Step.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Step, StepButton, StepContent, StepLabel, StepProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbStepProps extends StepProps {
   active?: StepProps['active'];
@@ -34,6 +35,7 @@ export default {
   args: {
     index: 0,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const horizontalStyles = {

--- a/libs/spark/src/StepButton/StepButton.stories.tsx
+++ b/libs/spark/src/StepButton/StepButton.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepButton, StepButtonProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbStepButtonProps extends StepButtonProps {
   /**
@@ -42,6 +43,7 @@ export default {
   args: {
     icon: 1,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: SbStepButtonProps) => <StepButton {...args} />;

--- a/libs/spark/src/StepConnector/StepConnector.stories.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.stories.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepConnector, StepConnectorProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export default {
   title: '@ps/StepConnector',
   component: StepConnector,
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: StepConnectorProps) => <StepConnector {...args} />;

--- a/libs/spark/src/StepContent/StepContent.stories.tsx
+++ b/libs/spark/src/StepContent/StepContent.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepContent, StepContentProps, Typography } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // underlying StepContentProps are undocumented
 interface SbStepContentProps extends StepContentProps {
@@ -22,6 +23,7 @@ export default {
   args: {
     expanded: true,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: StepContentProps) => (

--- a/libs/spark/src/StepIcon/StepIcon.stories.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepIcon, StepIconProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 export default {
   title: '@ps/StepIcon',
@@ -23,6 +24,7 @@ export default {
     icon: '1',
     titleAccess: 'Step one',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: StepIconProps) => (

--- a/libs/spark/src/StepLabel/StepLabel.stories.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepLabel, StepLabelProps } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 // some underlying StepLabelProps are undocumented
 interface SbStepLabelProps extends StepLabelProps {
@@ -47,6 +48,7 @@ export default {
     icon: '1',
     children: 'Label',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args: StepLabelProps) => <StepLabel {...args} />;

--- a/libs/spark/src/Stepper/Stepper.stories.tsx
+++ b/libs/spark/src/Stepper/Stepper.stories.tsx
@@ -8,6 +8,7 @@ import {
   Stepper,
   StepperProps,
 } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbStepperProps extends StepperProps {
   activeStep?: StepperProps['activeStep'];
@@ -51,6 +52,7 @@ export default {
     alternativeLabel: false,
     nonLinear: false,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const content =

--- a/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '@prenda/spark-icons';
 import { SvgIcon, styled, theme } from '..';
 import { capitalize } from '../utils';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbSvgIcon = SvgIcon;
 
@@ -20,6 +21,7 @@ export default {
     color: 'inherit',
     fontSize: 'inherit',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Container = styled('div')({

--- a/libs/spark/src/Switch/Switch.stories.tsx
+++ b/libs/spark/src/Switch/Switch.stories.tsx
@@ -16,6 +16,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // Trying to omit /*ripple*/ props breaks all other props ???
 interface SbSwitchProps extends SwitchProps {
@@ -34,6 +35,7 @@ export default {
     checked: false,
     disabled: false,
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/Tab/Tab.stories.tsx
+++ b/libs/spark/src/Tab/Tab.stories.tsx
@@ -5,6 +5,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 // underlying TabProps lack descriptions
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -34,6 +35,7 @@ export default {
     // should explicitly set it
     textColor: 'primary',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => <Tab {...args} />;

--- a/libs/spark/src/TabContext/TabContext.stories.tsx
+++ b/libs/spark/src/TabContext/TabContext.stories.tsx
@@ -15,6 +15,7 @@ import {
   ChangelogTemplate,
   DocumentationTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbTabContextProps extends TabContextProps {
   value: TabContextProps['value'];
@@ -49,6 +50,7 @@ export default {
     'sb_TabList_aria-label': 'tabs story',
     value: 'value-1',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const CodeSnippet = withStyles({

--- a/libs/spark/src/Tag/Tag.stories.tsx
+++ b/libs/spark/src/Tag/Tag.stories.tsx
@@ -5,6 +5,7 @@ import {
   DocumentationTemplate,
   ChangelogTemplate,
 } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbTag = Tag;
 
@@ -35,6 +36,7 @@ export default {
   args: {
     label: 'Label',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = (args) => (

--- a/libs/spark/src/TextField/TextField.stories.tsx
+++ b/libs/spark/src/TextField/TextField.stories.tsx
@@ -9,6 +9,7 @@ import {
   styled,
 } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 interface SbTextFieldProps extends StandardTextFieldProps {
   /**
@@ -83,6 +84,7 @@ export default {
     placeholder: 'Placeholder',
     helperText: 'Helper text',
   },
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 const Template = ({

--- a/libs/spark/src/Typography/Typography.stories.tsx
+++ b/libs/spark/src/Typography/Typography.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Typography, TypographyProps, styled, withStyles } from '..';
 import { ChangelogTemplate } from '../../stories/templates';
+import { sparkThemeProvider } from '../../stories';
 
 export const SbTypography = (props: TypographyProps) => (
   <Typography {...props} />
@@ -11,6 +12,7 @@ export default {
   title: '@ps/Typography',
   component: SbTypography,
   excludeStories: ['SbTypography'],
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 type TextKey =

--- a/libs/spark/src/theme/palette.stories.tsx
+++ b/libs/spark/src/theme/palette.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { styled, useTheme } from '..';
+import { sparkThemeProvider } from '../../stories';
 
 interface ColorBoxProps {
   color: string;
@@ -37,6 +38,7 @@ function ColorBox(props: ColorBoxProps) {
 export default {
   title: '@ps/theme/palette',
   component: ColorBox,
+  decorators: [sparkThemeProvider],
 } as Meta;
 
 export const PrendaColors: Story = () => {

--- a/libs/spark/src/theme/typography.ts
+++ b/libs/spark/src/theme/typography.ts
@@ -72,7 +72,7 @@ export function buildVariant(
     // convert to unit-less
     lineHeight: `${lineHeight / fontSize}`,
     fontWeight,
-    ...(letterSpacing ? { letterSpacing: `${letterSpacing}em` } : {}),
+    letterSpacing: letterSpacing ? `${letterSpacing}em` : 0,
     ...(textTransform ? { textTransform } : {}),
   };
 }

--- a/libs/spark/src/theme/unstable_fontFaces.stories.tsx
+++ b/libs/spark/src/theme/unstable_fontFaces.stories.tsx
@@ -9,6 +9,7 @@ export default {
 
 const FontsBaseline = withStyles({
   root: {
+    letterSpacing: 0,
     '@global': {
       '@font-face': [
         {

--- a/libs/spark/src/theme/unstable_palette.stories.tsx
+++ b/libs/spark/src/theme/unstable_palette.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { styled, useTheme, Theme } from '..';
+import { styled, theme, Theme } from '..';
 
 export default {
   title: '@ps/theme/unstable_palette',
@@ -49,8 +49,6 @@ const PaletteColor = styled(function PaletteColor(props: {
   field: string;
 }) {
   const { name, field, ...other } = props;
-
-  const theme = useTheme();
 
   return (
     <div {...other}>

--- a/libs/spark/src/theme/unstable_typography.stories.tsx
+++ b/libs/spark/src/theme/unstable_typography.stories.tsx
@@ -9,6 +9,7 @@ export default {
 
 const FontsBaseline = withStyles({
   root: {
+    letterSpacing: 0,
     '@global': {
       '@font-face': [
         {

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -1,0 +1,11 @@
+import { DecoratorFn } from '@storybook/react';
+import { SparkThemeProvider } from '../src';
+
+/**
+ * [Internal] Wrap a story in the `SparkThemeProvider`.
+ */
+export const sparkThemeProvider: DecoratorFn = (Story) => (
+  <SparkThemeProvider>
+    <Story />
+  </SparkThemeProvider>
+);

--- a/libs/spark/stories/index.ts
+++ b/libs/spark/stories/index.ts
@@ -1,0 +1,1 @@
+export * from './decorators';


### PR DESCRIPTION
Blocked by #380, #381 

Will help us develop PDS v2 / `Unstable_*` components. If an underlying component relies on the overrides/default props through the `theme`, then the `ThemeProvider` acts behind-the-scenes. This avoids that and _ensures correct styling_ with `SparkThemeProvider` being an ancestory, like stated in the CHANGELOG. 

Of course, we need to ALSO make sure it renders the same WITH `SparkThemeProvider` being an ancestor, so I'm planning to make a single "(ThemeProvider)" story for each v2 component and do some manual QA during dev.