### PR TITLE
feat(Unstable_InputLabel): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -78,8 +78,20 @@ _This section details previews of breaking changes or experimental features that
   - CSS API Changes:
     - Removed all class keys _except `"root"`_.
   - Props API Changes:
-    - `classes`
-      - Removed all class keys _except `"root"`_.
+    - `classes`: Removed all class keys _except `"root"`_.
+- **Unstable_InputLabel**
+  - Initial implementation of **InputLabel** replacement according to PDS v2.
+  - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
+  - CSS API Changes:
+    - Removed all class keys _except `"root"`_.
+  - Props API Changes:
+    - `classes`: Removed all class keys _except `"root"`_.
+    - `color`: Removed.
+    - `disableAnimation`: Removed.
+    - `filled`: Removed.
+    - `margin`: Removed.
+    - `shrink`: Removed.
+    - `variant`: Removed.
 - **Unstable_Link**
   - Initial implementation of `Link` replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.stories.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.stories.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Unstable_InputLabel, Unstable_InputLabelProps } from '..';
+import { sparkThemeProvider } from '../../stories';
+
+interface Sb_Unstable_InputLabelProps extends Unstable_InputLabelProps {
+  children?: Unstable_InputLabelProps['children'];
+  disabled?: Unstable_InputLabelProps['disabled'];
+  error?: Unstable_InputLabelProps['error'];
+  focused?: Unstable_InputLabelProps['focused'];
+  required?: Unstable_InputLabelProps['required'];
+}
+
+// underlying props don't have descriptions
+export const Sb_Unstable_InputLabel = (props: Sb_Unstable_InputLabelProps) => (
+  <Unstable_InputLabel {...props} />
+);
+
+export default {
+  title: '@ps/Unstable_InputLabel',
+  component: Sb_Unstable_InputLabel,
+  excludeStories: ['Sb_Unstable_InputLabel'],
+  args: {
+    children: 'Label',
+  },
+} as Meta;
+
+const Template = (args) => <Unstable_InputLabel {...args} />;
+
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
+
+export const SparkThemeProvider: Story = Template.bind({});
+SparkThemeProvider.decorators = [sparkThemeProvider];
+SparkThemeProvider.storyName = '(SparkThemeProvider)';
+
+export const Disabled: Story = Template.bind({});
+Disabled.args = { disabled: true };
+Disabled.storyName = 'disabled';
+
+export const Error: Story = Template.bind({});
+Error.args = { error: true };
+Error.storyName = 'error';
+
+export const Focused: Story = Template.bind({});
+Focused.args = { focused: true };
+Focused.storyName = 'focused';
+
+export const Required: Story = Template.bind({});
+Required.args = { required: true };
+Required.storyName = 'required';

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.test.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_InputLabel from './Unstable_InputLabel';
+
+describe('Unstable_InputLabel', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<Unstable_InputLabel />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import MuiInputLabel, {
+  InputLabelProps as MuiInputLabelProps,
+} from '@material-ui/core/InputLabel';
+import clsx from 'clsx';
+import makeStyles from '../makeStyles';
+import { StyledComponentProps } from '../utils';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unstable_InputLabelProps
+  extends Omit<
+      MuiInputLabelProps,
+      | 'classes'
+      | 'color'
+      | 'disableAnimation'
+      | 'filled'
+      | 'margin'
+      | 'shrink'
+      | 'variant'
+    >,
+    StyledComponentProps<Unstable_InputLabelClassKey> {}
+
+export type Unstable_InputLabelClassKey = 'root';
+
+const useStyles = makeStyles<Unstable_InputLabelClassKey>(
+  (theme) => ({
+    root: {
+      ...theme.unstable_typography.label,
+      color: theme.unstable_palette.neutral[600],
+      marginBottom: 4,
+      marginLeft: 4, // match margin of Input
+      '&.Mui-disabled': {
+        color: theme.unstable_palette.neutral[100],
+      },
+      '&.Mui-error': {
+        color: theme.unstable_palette.neutral[600],
+      },
+      '&.Mui-focused': {
+        color: theme.unstable_palette.neutral[600],
+      },
+      // underlying class
+      '&.MuiInputLabel-formControl': {
+        transform: 'none',
+        position: 'relative',
+      },
+    },
+  }),
+  { name: 'MuiSparkUnstable_InputLabel' }
+);
+
+const Unstable_InputLabel = React.forwardRef(function Unstable_InputLabel(
+  props: Unstable_InputLabelProps,
+  ref: React.RefObject<HTMLLabelElement>
+) {
+  const { classes: classesProp, ...other } = props;
+
+  const classes = useStyles();
+
+  return (
+    <MuiInputLabel
+      classes={{ root: clsx(classes.root, classesProp?.root) }}
+      disableAnimation
+      ref={ref}
+      {...other}
+      shrink={false}
+    />
+  );
+});
+
+export default Unstable_InputLabel;

--- a/libs/spark/src/Unstable_InputLabel/index.ts
+++ b/libs/spark/src/Unstable_InputLabel/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_InputLabel';
+export * from './Unstable_InputLabel';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -221,6 +221,9 @@ export { default as Unstable_FontFacesBaseline } from './Unstable_FontFacesBasel
 export { default as Unstable_InputAdornment } from './Unstable_InputAdornment';
 export * from './Unstable_InputAdornment';
 
+export { default as Unstable_InputLabel } from './Unstable_InputLabel';
+export * from './Unstable_InputLabel';
+
 export { default as Unstable_Link } from './Unstable_Link';
 export * from './Unstable_Link';
 

--- a/libs/spark/src/utils/StandardProps.ts
+++ b/libs/spark/src/utils/StandardProps.ts
@@ -1,5 +1,7 @@
 import { StyledComponentProps } from '../withStyles';
 
+export { StyledComponentProps };
+
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
  * certain `classes`, on which one can also set a top-level `className` and inline


### PR DESCRIPTION
Part of #350 .

Necessary pre-req for Input / Select / TextField.

Aside: From now-on, I think Props API changelog entries should just be one line if it would only be a single list item. Doesn't really make sense to have sub-lists when its not a list, just a single item.