### PR TITLE
feat(Unstable_Tag): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.5...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_Tag**
+  - Initial implementation of `Tag` replacement according to PDS v2.
+  - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
+  - CSS API Changes:
+    - Removed all class keys _except `"root", "label", "deleteIcon", "avatar", "icon"`_.
+  - Props API Changes:
+    - `classes`
+      - Removed all values except `"root", "label", "deleteIcon", "avatar", "icon"`.
+    - `color`
+      - Removed value: `"default"`.
+      - Added value: `"neutral"` (default).
+  - Planned migration from current `Tag`:
+    - `color="default"` -> `color="neutral"` (or omit)
+
 ## [v1.0.0-alpha.5](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2022-04-25)
 
 ### Fixes

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -48,7 +48,7 @@ export type Unstable_ButtonClassKey =
   | 'endIcon'
   | 'label';
 
-// Extracted as we dont have a unstable_variant
+// extracted since there's not an equivalent typography variant
 const buttonFontVariantSmall = buildVariant(
   500,
   14,

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
@@ -1,0 +1,251 @@
+import * as React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Unstable_Tag, unstable_createSvgIcon } from '..';
+import { sparkThemeProvider } from '../../stories';
+import { Unstable_TagProps } from './Unstable_Tag';
+
+export const SbUnstable_Tag = Unstable_Tag;
+
+const Filter = unstable_createSvgIcon(
+  <path d="M2.25 6A.75.75 0 0 1 3 5.25h18a.75.75 0 0 1 0 1.5H3A.75.75 0 0 1 2.25 6Zm3 6a.75.75 0 0 1 .75-.75h12a.75.75 0 0 1 0 1.5H6a.75.75 0 0 1-.75-.75ZM10 17.25a.75.75 0 0 0 0 1.5h4a.75.75 0 0 0 0-1.5h-4Z" />,
+  'Sb_Filter'
+);
+
+const emptyFn = () => {
+  return;
+};
+
+export default {
+  title: '@ps/Unstable_Tag',
+  component: SbUnstable_Tag,
+  excludeStories: ['SbUnstable_Tag'],
+  parameters: {
+    actions: {
+      // override default actions regex
+      //  deleteIcon rendering is based on onDelete being supplied, so substitute
+      //  custom argType control below.
+      argTypesRegex: '^on(?!Delete).*',
+    },
+  },
+  argTypes: {
+    icon: {
+      control: 'select',
+      options: ['undefined', '$', 'Filter'],
+      mapping: {
+        undefined: undefined,
+        $: '$',
+        Filter: <Filter />,
+      },
+    },
+    onClick: {
+      control: 'select',
+      options: ['undefined', 'handleClick'],
+      mapping: {
+        undefined: undefined,
+        handleClick: emptyFn,
+      },
+    },
+    onDelete: {
+      control: 'select',
+      options: ['undefined', 'handleDelete'],
+      mapping: {
+        undefined: undefined,
+        handleDelete: emptyFn,
+      },
+    },
+  },
+  args: {
+    onClick: 'undefined',
+    onDelete: 'undefined',
+  },
+} as Meta;
+
+const Template = (args) => <Unstable_Tag {...args} />;
+
+export const Label: Story = Template.bind({});
+Label.args = { label: 'Label' };
+Label.storyName = 'label';
+
+export const SparkThemeProviderLabel: Story = Template.bind({});
+SparkThemeProviderLabel.args = { label: 'Label' };
+SparkThemeProviderLabel.decorators = [sparkThemeProvider];
+SparkThemeProviderLabel.storyName = '(SparkThemeProvider) label';
+
+export const LabelDisabled: Story = Template.bind({});
+LabelDisabled.args = { label: 'Label', disabled: true };
+LabelDisabled.storyName = 'label disabled';
+
+export const LabelIcon: Story = Template.bind({});
+LabelIcon.args = { label: 'Label', icon: 'Filter' };
+LabelIcon.storyName = 'label icon';
+
+export const LabelOnDelete: Story = Template.bind({});
+LabelOnDelete.args = { label: 'Label', onDelete: 'handleDelete' };
+LabelOnDelete.storyName = 'label onDelete';
+
+export const LabelOnDeleteActive: Story = Template.bind({});
+LabelOnDeleteActive.args = { label: 'Label', onDelete: 'handleDelete' };
+LabelOnDeleteActive.parameters = { pseudo: { active: true } };
+LabelOnDeleteActive.storyName = 'label onDelete :active';
+
+export const LabelOnDeleteFocus: Story = Template.bind({});
+LabelOnDeleteFocus.args = { label: 'Label', onDelete: 'handleDelete' };
+LabelOnDeleteFocus.parameters = { pseudo: { focus: true } };
+LabelOnDeleteFocus.storyName = 'label onDelete :focus';
+
+export const LabelOnDeleteFocusVisible: Story = Template.bind({});
+LabelOnDeleteFocusVisible.args = { label: 'Label', onDelete: 'handleDelete' };
+LabelOnDeleteFocusVisible.parameters = { pseudo: { focusVisible: true } };
+LabelOnDeleteFocusVisible.storyName = 'label onDelete :focus-visible';
+
+export const LabelOnDeleteHover: Story = Template.bind({});
+LabelOnDeleteHover.args = { label: 'Label', onDelete: 'handleDelete' };
+LabelOnDeleteHover.parameters = { pseudo: { hover: true } };
+LabelOnDeleteHover.storyName = 'label onDelete :hover';
+
+const colors: Array<Unstable_TagProps['color']> = [
+  'neutral',
+  'red',
+  'yellow',
+  'teal',
+  'green',
+  'blue',
+  'purple',
+];
+
+const ColorBySizeByVariantTemplate = ({ color, size, variant, ...other }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+    <div style={{ display: 'flex', gap: '8px' }}>
+      {colors.map((color) => (
+        <Unstable_Tag
+          color={color}
+          size="medium"
+          variant="bold"
+          {...other}
+          key={color}
+        />
+      ))}
+    </div>
+    <div style={{ display: 'flex', gap: '8px' }}>
+      {colors.map((color) => (
+        <Unstable_Tag
+          color={color}
+          size="small"
+          variant="bold"
+          {...other}
+          key={color}
+        />
+      ))}
+    </div>
+    <div style={{ display: 'flex', gap: '8px' }}>
+      {colors.map((color) => (
+        <Unstable_Tag
+          color={color}
+          size="medium"
+          variant="subtle"
+          {...other}
+          key={color}
+        />
+      ))}
+    </div>
+    <div style={{ display: 'flex', gap: '8px' }}>
+      {colors.map((color) => (
+        <Unstable_Tag
+          color={color}
+          size="small"
+          variant="subtle"
+          {...other}
+          key={color}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export const Label_CxSxV: Story = ColorBySizeByVariantTemplate.bind({});
+Label_CxSxV.args = { label: 'Label' };
+Label_CxSxV.storyName = 'label color ⨯ size ⨯ variant';
+
+export const Label_CxSxV_onDelete: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onDelete.args = { label: 'Label', onDelete: 'handleDelete' };
+Label_CxSxV_onDelete.storyName = 'label color ⨯ size ⨯ variant onDelete';
+
+export const Label_CxSxV_onDeleteActive: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onDeleteActive.args = { label: 'Label', onDelete: 'handleDelete' };
+Label_CxSxV_onDeleteActive.parameters = { pseudo: { active: true } };
+Label_CxSxV_onDeleteActive.storyName =
+  'label color ⨯ size ⨯ variant onDelete :active';
+
+export const Label_CxSxV_onDeleteHover: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onDeleteHover.args = { label: 'Label', onDelete: 'handleDelete' };
+Label_CxSxV_onDeleteHover.parameters = { pseudo: { hover: true } };
+Label_CxSxV_onDeleteHover.storyName =
+  'label color ⨯ size ⨯ variant onDelete :hover';
+
+export const Label_CxSxV_onDeleteFocus: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onDeleteFocus.args = { label: 'Label', onDelete: 'handleDelete' };
+Label_CxSxV_onDeleteFocus.parameters = { pseudo: { focus: true } };
+Label_CxSxV_onDeleteFocus.storyName =
+  'label color ⨯ size ⨯ variant onDelete :focus';
+
+export const Label_CxSxV_onDeleteFocusVisible: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onDeleteFocusVisible.args = {
+  label: 'Label',
+  onDelete: 'handleDelete',
+};
+Label_CxSxV_onDeleteFocusVisible.parameters = {
+  pseudo: { focusVisible: true },
+};
+Label_CxSxV_onDeleteFocusVisible.storyName =
+  'label color ⨯ size ⨯ variant onDelete :focus-visible';
+
+export const Label_CxSxV_onClick: Story = ColorBySizeByVariantTemplate.bind({});
+Label_CxSxV_onClick.args = { label: 'Label', onClick: 'handleClick' };
+Label_CxSxV_onClick.storyName = 'label color ⨯ size ⨯ variant onClick';
+
+export const Label_CxSxV_onClickActive: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onClickActive.args = { label: 'Label', onClick: 'handleClick' };
+Label_CxSxV_onClickActive.parameters = { pseudo: { active: true } };
+Label_CxSxV_onClickActive.storyName =
+  'label color ⨯ size ⨯ variant onClick :active';
+
+export const Label_CxSxV_onClickHover: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onClickHover.args = { label: 'Label', onClick: 'handleClick' };
+Label_CxSxV_onClickHover.parameters = { pseudo: { hover: true } };
+Label_CxSxV_onClickHover.storyName =
+  'label color ⨯ size ⨯ variant onClick :hover';
+
+export const Label_CxSxV_onClickFocus: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onClickFocus.args = { label: 'Label', onClick: 'handleClick' };
+Label_CxSxV_onClickFocus.parameters = { pseudo: { focus: true } };
+Label_CxSxV_onClickFocus.storyName =
+  'label color ⨯ size ⨯ variant onClick :focus';
+
+export const Label_CxSxV_onClickFocusVisible: Story = ColorBySizeByVariantTemplate.bind(
+  {}
+);
+Label_CxSxV_onClickFocusVisible.args = {
+  label: 'Label',
+  onClick: 'handleClick',
+};
+Label_CxSxV_onClickFocusVisible.parameters = {
+  pseudo: { focusVisible: true },
+};
+Label_CxSxV_onClickFocusVisible.storyName =
+  'label color ⨯ size ⨯ variant onClick :focus-visible';

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
@@ -30,10 +30,9 @@ export default {
   argTypes: {
     icon: {
       control: 'select',
-      options: ['undefined', '$', 'Filter'],
+      options: ['undefined', 'Filter'],
       mapping: {
         undefined: undefined,
-        $: '$',
         Filter: <Filter />,
       },
     },

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -1,0 +1,285 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import {
+  default as MuiChip,
+  ChipProps as MuiChipProps,
+} from '@material-ui/core/Chip';
+import { Unstable_CrossSmall } from '../internal';
+import makeStyles from '../makeStyles';
+import { OverridableComponent, OverrideProps } from '../utils';
+import { buildVariant } from '../theme/typography';
+import { alpha, darken } from '@material-ui/core/styles';
+
+export interface Unstable_TagTypeMap<
+  P = Record<string, unknown>,
+  D extends React.ElementType = 'div'
+> {
+  props: P &
+    Omit<
+      MuiChipProps,
+      'classes' | 'clickable' | 'color' | 'size' | 'variant'
+    > & {
+      /**
+       * The color of the tag.
+       */
+      color?:
+        | 'neutral'
+        | 'red'
+        | 'yellow'
+        | 'teal'
+        | 'green'
+        | 'blue'
+        | 'purple';
+      /**
+       * The size of the tag.
+       */
+      size?: 'medium' | 'small';
+      /**
+       * The variant of the tag.
+       */
+      variant?: 'subtle' | 'bold';
+    };
+  defaultComponent: D;
+  classKey: Unstable_TagClassKey;
+}
+
+export type Unstable_TagProps<
+  D extends React.ElementType = Unstable_TagTypeMap['defaultComponent'],
+  P = Record<string, unknown>
+> = OverrideProps<Unstable_TagTypeMap<P, D>, D>;
+
+export type Unstable_TagClassKey =
+  | 'root'
+  | 'label'
+  | 'deleteIcon'
+  | 'icon'
+  | 'avatar';
+
+// extracted since there's not an equivalent typography variant
+const tagFontVariantMedium = buildVariant(
+  500,
+  16,
+  20,
+  undefined,
+  'none',
+  '"Inter", sans-serif',
+  "'cv05' 1, 'ss03' 1"
+);
+const tagFontVariantSmall = buildVariant(
+  600,
+  12,
+  20,
+  undefined,
+  'none',
+  '"Inter", sans-serif',
+  "'cv05' 1, 'ss03' 1"
+);
+
+const useStyles = makeStyles<Unstable_TagClassKey>(
+  (theme) => ({
+    root: (props: Unstable_TagProps) => {
+      // style property value determinations are pulled out into this function body because there's significant reuse and patterns for the background color in pseudo-states, and because of a special styling case
+
+      let borderColor, borderStyle, borderWidth;
+
+      let padding;
+      if (props.size === 'medium') {
+        padding = '6px 16px';
+      } else if (props.size === 'small') {
+        padding = '2px 12px';
+      }
+
+      let backgroundColor;
+      let color = theme.unstable_palette.text.heading;
+      if (props.color === 'neutral' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.neutral[70];
+      } else if (props.color === 'neutral' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.neutral[0];
+        // Special case: add border and decrease padding to account for the added height/width
+        borderColor = theme.unstable_palette.neutral[70];
+        borderStyle = 'solid';
+        borderWidth = '1px';
+        if (props.size === 'medium') {
+          padding = '5px 15px';
+        } else if (props.size === 'small') {
+          padding = '1px 11px';
+        }
+      } else if (props.color === 'red' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.red[700];
+        color = theme.unstable_palette.text.inverseHeading;
+      } else if (props.color === 'red' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.red[100];
+      } else if (props.color === 'yellow' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.yellow[500];
+      } else if (props.color === 'yellow' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.yellow[200];
+      } else if (props.color === 'teal' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.teal[600];
+        color = theme.unstable_palette.text.inverseHeading;
+      } else if (props.color === 'teal' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.teal[100];
+      } else if (props.color === 'green' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.green[600];
+        color = theme.unstable_palette.text.inverseHeading;
+      } else if (props.color === 'green' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.green[100];
+      } else if (props.color === 'blue' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.blue[600];
+        color = theme.unstable_palette.text.inverseHeading;
+      } else if (props.color === 'blue' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.blue[100];
+      } else if (props.color === 'purple' && props.variant === 'bold') {
+        backgroundColor = theme.unstable_palette.purple[600];
+        color = theme.unstable_palette.text.inverseHeading;
+      } else if (props.color === 'purple' && props.variant === 'subtle') {
+        backgroundColor = theme.unstable_palette.purple[100];
+      }
+
+      return {
+        borderRadius: 4,
+        height: 'unset', // unset MUI
+        // Determined in fn body
+        color,
+        backgroundColor,
+        borderColor,
+        borderStyle,
+        borderWidth,
+        padding,
+        '&:focus': {
+          backgroundColor, // override MUI
+        },
+        ...(props.onClick && {
+          // artificially increase specificity to override MUI
+          '&&': {
+            '&:hover': {
+              ...(props.variant === 'bold' && {
+                backgroundColor: darken(backgroundColor, 0.2),
+              }),
+              ...(props.variant === 'subtle' && {
+                backgroundColor: darken(backgroundColor, 0.1),
+              }),
+            },
+            '&:active': {
+              boxShadow: 'none', // override MUI
+              ...(props.variant === 'bold' && {
+                backgroundColor: darken(backgroundColor, 0.4),
+              }),
+              ...(props.variant === 'subtle' && {
+                backgroundColor: darken(backgroundColor, 0.2),
+              }),
+            },
+          },
+          '&.Mui-focusVisible, &:focus-visible': {
+            boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+          },
+        }),
+        ...(props.onDelete && {
+          // artificially increase specificity to override MUI
+          '&&': {
+            '&:hover': { backgroundColor },
+            '&:active': { backgroundColor },
+          },
+          '&.Mui-focusVisible, &:focus-visible': {
+            boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+          },
+        }),
+      };
+    },
+    label: (props: Unstable_TagProps) => ({
+      color: 'inherit',
+      padding: 0, // unset MUI
+      ...(props.size === 'medium' && tagFontVariantMedium),
+      ...(props.size === 'small' && tagFontVariantSmall),
+      // artificially shift label down by 1px to appear more centered; especially apparent when beside an icon
+      marginTop: 1,
+      marginBottom: -1,
+    }),
+    deleteIcon: (props: Unstable_TagProps) => ({
+      borderRadius: 2,
+      color: 'inherit',
+      height: '1em',
+      margin: '0 0 0 4px',
+      width: '1em',
+      ...(props.size === 'medium' && {
+        fontSize: theme.typography.pxToRem(16),
+      }),
+      ...(props.size === 'small' && {
+        fontSize: theme.typography.pxToRem(12),
+      }),
+      '&:hover': {
+        color: 'inherit', // override MUI
+        ...(props.variant === 'bold' && {
+          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.2),
+        }),
+        ...(props.variant === 'subtle' && {
+          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.1),
+        }),
+      },
+      '&:active': {
+        ...(props.variant === 'bold' && {
+          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.3),
+        }),
+        ...(props.variant === 'subtle' && {
+          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.2),
+        }),
+      },
+    }),
+    icon: (props: Unstable_TagProps) => ({
+      color: 'inherit',
+      height: '1em',
+      margin: '0 4px 0 0',
+      width: '1em',
+      ...(props.size === 'medium' && {
+        fontSize: theme.typography.pxToRem(16),
+      }),
+      ...(props.size === 'small' && {
+        fontSize: theme.typography.pxToRem(12),
+      }),
+    }),
+    avatar: {
+      // blocked until `Unstable_Avatar` initial implementation
+    },
+  }),
+  { name: 'MuiSparkUnstable_Tag' }
+);
+
+const Unstable_Tag: OverridableComponent<Unstable_TagTypeMap> = React.forwardRef(
+  function Unstable_Tag(props, ref) {
+    const {
+      classes: classesProp,
+      color = 'neutral',
+      onClick,
+      onDelete,
+      size = 'medium',
+      variant = 'bold',
+      ...other
+    } = props;
+
+    const classes = useStyles({ color, size, onClick, onDelete, variant });
+
+    return (
+      <MuiChip
+        classes={{
+          root: clsx(classes.root, classesProp?.root),
+          label: clsx(classes.label, classesProp?.label),
+          deleteIcon: clsx(classes.deleteIcon, classesProp?.deleteIcon),
+          icon: clsx(classes.icon, classesProp?.icon),
+          avatar: clsx(classes.avatar, classesProp?.avatar),
+        }}
+        deleteIcon={<Unstable_CrossSmall />}
+        onClick={onClick}
+        onDelete={onDelete}
+        ref={ref}
+        {...other}
+        {...(onClick && {
+          // `disableFocusRipple` leaks to DOM
+          disableRipple: true,
+          disableTouchRipple: true,
+          focusRipple: false,
+        })}
+      />
+    );
+  }
+);
+
+export default Unstable_Tag;

--- a/libs/spark/src/Unstable_Tag/Unstable_TextField.test.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_TextField.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_Tag from './Unstable_Tag';
+
+describe('Unstable_Tag', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<Unstable_Tag label="Label" />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_Tag/index.ts
+++ b/libs/spark/src/Unstable_Tag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_Tag';
+export * from './Unstable_Tag';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -245,6 +245,9 @@ export * from './Unstable_Select';
 export { default as Unstable_SvgIcon } from './Unstable_SvgIcon';
 export * from './Unstable_SvgIcon';
 
+export { default as Unstable_Tag } from './Unstable_Tag';
+export * from './Unstable_Tag';
+
 export { default as Unstable_TextField } from './Unstable_TextField';
 export * from './Unstable_TextField';
 

--- a/libs/spark/src/internal/Unstable_CrossSmall.tsx
+++ b/libs/spark/src/internal/Unstable_CrossSmall.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import unstable_createSvgIcon from '../unstable_createSvgIcon';
+
+export default unstable_createSvgIcon(
+  <path d="M3.293 3.293a1 1 0 0 1 1.414 0L8 6.586l3.293-3.293a1 1 0 1 1 1.414 1.414L9.414 8l3.293 3.293a1 1 0 0 1-1.414 1.414L8 9.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L6.586 8 3.293 4.707a1 1 0 0 1 0-1.414Z" />,
+  'Unstable_CrossSmall',
+  '0 0 16 16'
+);

--- a/libs/spark/src/internal/index.ts
+++ b/libs/spark/src/internal/index.ts
@@ -15,4 +15,5 @@ export { default as Unstable_AlertTriangle } from './Unstable_AlertTriangle';
 export { default as Unstable_CheckCircle2 } from './Unstable_CheckCircle2';
 export { default as Unstable_ChevronDown } from './Unstable_ChevronDown';
 export { default as Unstable_Cross } from './Unstable_Cross';
+export { default as Unstable_CrossSmall } from './Unstable_CrossSmall';
 export { default as Unstable_Info } from './Unstable_Info';


### PR DESCRIPTION
Part of #350 

I winged some things that the Figma did not specify like styling for the "active" pseudo state, the "clickable" styling, plain "icon" prop, etc.

I had to keep the "cross-product" layout for the stories because the complex underlying styles mean we should validate all possibilities for conflicts, and creating individual stories for each is not only way too much code, unfortunately, it's also 2 x 2 x 7 = 28 times more stories for _each_ current "cross-product" story (which there are 10 of). (The special Unicode char in the story names is the a cross product symbol.)