### PR TITLE
chore: fix chromatic snapshots changing because of animations

### DIFF
--- a/libs/spark/.storybook/preview.js
+++ b/libs/spark/.storybook/preview.js
@@ -19,4 +19,6 @@ addDecorator((Story) => (
 export const parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
   actions: { argTypesRegex: '^on.*' },
+  // https://www.chromatic.com/docs/animations
+  pauseAnimationAtEnd: true,
 };


### PR DESCRIPTION
Hopefully this will fix the flip-flopping change of the Tabs indicator animation in Chromatic snapshots.