### PR TITLE
fix(unstable_typography): wrong weight for T22 variant

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.6...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_Typography**
+  - Fix component typing so `variant` and `color` props appear as a discriminated union of string literals (i.e. `'body' | 'description' | ...`) instead of just `string`.
+  - Fix variant T22 having wrong font weight.
+
 ## [v1.0.0-alpha.6](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2022-04-29)
 
 ### Unstable Preview

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import {
-  Unstable_Typography,
-  Unstable_TypographyProps,
-  styled,
-  withStyles,
-} from '..';
-import { capitalize } from '../utils';
+import { Unstable_Typography, Unstable_TypographyProps } from '..';
+import { inverseBackground, sparkThemeProvider } from '../../stories';
 
 export const SbUnstable_Typography = (props: Unstable_TypographyProps) => (
   <Unstable_Typography {...props} />
@@ -18,144 +13,61 @@ export default {
   excludeStories: ['SbUnstable_Typography'],
   args: {
     children: 'typography',
-    color: 'default',
-    variant: 'body',
   },
 } as Meta;
 
 const Template = (args: Unstable_TypographyProps) => (
   <Unstable_Typography {...args} />
 );
-export const Playground: Story = Template.bind({});
 
-const Container = styled('div')({
-  margin: '2.5rem 0',
-  display: 'grid',
-  gridTemplateColumns: '11rem 1.5rem auto',
-  gridTemplateRows: '1.5rem auto',
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
 
-  '& .pos-1': {
-    gridColumn: 1,
-    gridRow: 1,
-  },
+export const SparkThemeProvider: Story = Template.bind({});
+SparkThemeProvider.decorators = [sparkThemeProvider];
+SparkThemeProvider.storyName = '(SparkThemeProvider)';
 
-  '& .pos-2': {
-    gridColumn: 1,
-    gridRow: 2,
-    paddingTop: '0.5rem',
-  },
+export const Display: Story = Template.bind({});
+Display.args = { variant: 'display' };
+Display.storyName = 'variant=display';
 
-  '& .pos-3': {
-    gridColumn: 3,
-    gridRow: '1 / span 2',
-  },
-});
+export const VariantT32: Story = Template.bind({});
+VariantT32.args = { variant: 'T32' };
+VariantT32.storyName = 'variant=T32';
 
-const CustomTypography = withStyles((theme) => ({
-  root: {
-    color: theme.unstable_palette.text.heading,
-    fontFamily: '"Poppins"',
-    fontSize: '1.25rem',
-    lineHeight: 32 / 16,
-    fontWeight: 900,
-  },
-}))(Unstable_Typography);
+export const VariantT28: Story = Template.bind({});
+VariantT28.args = { variant: 'T28' };
+VariantT28.storyName = 'variant=T28';
 
-const VariantSection = (props: {
-  variant: Unstable_TypographyProps['variant'];
-  details: Array<string>;
-  children: React.ReactNode;
-}) => {
-  const { variant, details, children } = props;
+export const VariantT22: Story = Template.bind({});
+VariantT22.args = { variant: 'T22' };
+VariantT22.storyName = 'variant=T22';
 
-  return (
-    <Container>
-      <CustomTypography>{capitalize(variant)}</CustomTypography>
+export const VariantT18: Story = Template.bind({});
+VariantT18.args = { variant: 'T18' };
+VariantT18.storyName = 'variant=T18';
 
-      <Unstable_Typography variant="code" className="pos-2">
-        {details[0]}
-        <br />
-        {details[1]}
-        <br />
-        {details[2]}
-        <br />
-        {details.length === 4 ? details[3] : ''}
-      </Unstable_Typography>
+export const VariantT14: Story = Template.bind({});
+VariantT14.args = { variant: 'T14' };
+VariantT14.storyName = 'variant=T14';
 
-      <span className="pos-3">
-        <Unstable_Typography variant={variant}>{children}</Unstable_Typography>
-      </span>
-    </Container>
-  );
-};
+export const VariantLabel: Story = Template.bind({});
+VariantLabel.args = { variant: 'label' };
+VariantLabel.storyName = 'variant=label';
 
-export const Overview: Story = () => (
-  <div>
-    <VariantSection
-      variant="display"
-      details={['48px/52px/-1%', 'Extrabold', 'Poppins']}
-    >
-      Empower learners everywhere
-    </VariantSection>
-    <VariantSection
-      variant="T32"
-      details={['32px/40px/-1%', 'Bold', 'Poppins']}
-    >
-      Empower learners everywhere
-    </VariantSection>
-    <VariantSection
-      variant="T28"
-      details={['28px/36px/-1%', 'Bold', 'Poppins']}
-    >
-      Empower learners everywhere
-    </VariantSection>
-    <VariantSection
-      variant="T22"
-      details={['22px/28px/-1%', 'Semibold', 'Poppins']}
-    >
-      Empower learners everywhere
-    </VariantSection>
-    <VariantSection
-      variant="T18"
-      details={['18px/28px/-1%', 'Semibold', 'Poppins']}
-    >
-      Empower learners everywhere
-    </VariantSection>
-    <VariantSection
-      variant="T14"
-      details={['14px/20px/4%/uppercase', 'Extrabold', 'Poppins']}
-    >
-      Passion to learn
-    </VariantSection>
-    <VariantSection
-      variant="body"
-      details={['16px/24px', 'Regular', 'Inter', '(cv05,ss03)']}
-    >
-      When we allow students to own their education, connect them with quality
-      learning tools, caring adults, and a community, their natural love of
-      learning takes over and they become <strong>unstoppable</strong>.
-    </VariantSection>
-    <VariantSection
-      variant="label"
-      details={['16px/20px', 'Semibold', 'Inter']}
-    >
-      Select a grade
-    </VariantSection>
-    <VariantSection
-      variant="description"
-      details={['14px/20px', 'Regular', 'Inter', '(cv05,ss03)']}
-    >
-      When we allow students to own their education, connect them with quality
-      learning tools, caring adults, and a community, their natural love of
-      learning takes over and they become <strong>unstoppable</strong>.
-    </VariantSection>
-    <VariantSection
-      variant="code"
-      details={['14px/24px', 'Regular', 'Roboto Mono']}
-    >{`<script>
-  let mystring = 'abc123';
-</script>
+export const VariantBody: Story = Template.bind({});
+VariantBody.args = { variant: 'body' };
+VariantBody.storyName = 'variant=body';
 
-<h1>This is {myString}</h1>`}</VariantSection>
-  </div>
-);
+export const VariantDescription: Story = Template.bind({});
+VariantDescription.args = { variant: 'description' };
+VariantDescription.storyName = 'variant=description';
+
+export const VariantCode: Story = Template.bind({});
+VariantCode.args = { variant: 'code' };
+VariantCode.storyName = 'variant=code';
+
+export const ColorInverse: Story = Template.bind({});
+ColorInverse.args = { color: 'inverse' };
+ColorInverse.decorators = [inverseBackground];
+ColorInverse.storyName = 'color=inverse';

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -5,7 +5,7 @@ import {
   TypographyProps as MuiTypographyProps,
 } from '@material-ui/core/Typography';
 import makeStyles from '../makeStyles';
-import { OverrideProps } from '../utils';
+import { OverridableComponent, OverrideProps } from '../utils';
 import { Unstable_TypographyVariant } from '../theme/unstable_typography';
 
 export interface Unstable_TypographyTypeMap<
@@ -15,7 +15,17 @@ export interface Unstable_TypographyTypeMap<
 > {
   props: P &
     Omit<MuiTypographyProps, 'classes' | 'variant' | 'color'> & {
-      variant?: Unstable_TypographyVariant;
+      variant?:
+        | 'display'
+        | 'T32'
+        | 'T28'
+        | 'T22'
+        | 'T18'
+        | 'T14'
+        | 'body'
+        | 'label'
+        | 'description'
+        | 'code';
       color?: 'initial' | 'inherit' | 'default' | 'inverse';
     };
   defaultComponent: D;
@@ -129,33 +139,30 @@ const defaultVariantMapping: Record<Unstable_TypographyVariant, string> = {
   code: 'pre',
 };
 
-const Unstable_Typography = React.forwardRef(function Unstable_Typography<
-  D extends React.ElementType = Unstable_TypographyTypeMap['defaultComponent']
->(
-  props: Unstable_TypographyProps<D>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ref: React.ForwardedRef<any>
-) {
-  const {
-    classes: classesProp,
-    variant = 'body',
-    color = 'default',
-    component,
-    ...other
-  } = props;
+const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = React.forwardRef(
+  function Unstable_Typography(props, ref) {
+    const {
+      classes: classesProp,
+      variant = 'body',
+      color = 'default',
+      // @ts-expect-error not picked up as a prop from `OverridableComponent`
+      component,
+      ...other
+    } = props;
 
-  const classes = useStyles({ variant, color });
+    const classes = useStyles({ variant, color });
 
-  return (
-    <MuiTypography
-      classes={{
-        root: clsx(classes.root, classesProp?.root),
-      }}
-      component={component || defaultVariantMapping[variant]}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+    return (
+      <MuiTypography
+        classes={{
+          root: clsx(classes.root, classesProp?.root),
+        }}
+        component={component || defaultVariantMapping[variant]}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
 
 export default Unstable_Typography;

--- a/libs/spark/src/theme/unstable_typography.ts
+++ b/libs/spark/src/theme/unstable_typography.ts
@@ -10,7 +10,6 @@ export type Unstable_TypographyVariant =
   | 'display'
   | 'T32'
   | 'T28'
-  | 'T28'
   | 'T22'
   | 'T18'
   | 'T14'
@@ -36,7 +35,7 @@ const customVariants: Record<Unstable_TypographyVariant, TypographyStyle> = {
   display: buildVariant(800, 48, 52, -0.01, undefined, headingFontFamily),
   T32: buildVariant(700, 32, 40, -0.01, undefined, headingFontFamily),
   T28: buildVariant(700, 28, 36, -0.01, undefined, headingFontFamily),
-  T22: buildVariant(700, 22, 28, -0.01, undefined, headingFontFamily),
+  T22: buildVariant(600, 22, 28, -0.01, undefined, headingFontFamily),
   T18: buildVariant(600, 18, 28, -0.01, undefined, headingFontFamily),
   T14: buildVariant(800, 14, 20, 0.04, 'uppercase', headingFontFamily),
   body: buildVariant(

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { DecoratorFn } from '@storybook/react';
-import { SparkThemeProvider } from '../src';
+import { SparkThemeProvider, styled } from '../src';
 
 /**
  * [Internal] A Storybook decorator that wraps a story in the `SparkThemeProvider`.
@@ -37,3 +37,16 @@ export const statefulValue: DecoratorFn = (Story, context) => {
 
   return <Story />;
 };
+
+const InverseBackgroundDiv = styled('div')(({ theme }) => ({
+  backgroundColor: theme.unstable_palette.background.inverse,
+}));
+
+/**
+ * [Internal] A Storybook decorator that applies the inverse background to a story.
+ */
+export const inverseBackground: DecoratorFn = (Story) => (
+  <InverseBackgroundDiv>
+    <Story />
+  </InverseBackgroundDiv>
+);


### PR DESCRIPTION
Primarily fixes the "T22" typography variant font weight. 

Also fixes the fact that the component wasn't being typed in the right way and the resulting props were losing information, like `variant: string` instead of the true `variant: "display" | "T32" | ...`.

Also rewrites the stories for `Unstable_Typography`. The big example section is already reflected in the story for the theme property story, i.e. `theme/unstable_typography`. The component story now adheres to single stories that just go thru the prop values.