### PR TITLE
feat(Unstable_IconButton): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -8,6 +8,36 @@ _This section details previews of breaking changes or experimental features that
 
 - **Unstable_Button**
   - Fix conflicting styles from previous `theme` (e.g. when rendered under `SparkThemeProvider`) when disabled or given start or end icons.
+- **Unstable_IconButton**
+  - Initial implementation of **IconButton** replacement according to PDS v2.
+  - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
+  - CSS API Changes:
+    - Removed all class keys _except `"root"`, `"label"`_.
+  - Props API Changes:
+    - `classes`: Removed all class keys _except `"root"`, `"label"`_.
+    - `color`: Removed.
+    - `disableElevation`: Removed.
+    - `disableFocusRipple`: Removed.
+    - `disableRipple`: Removed.
+    - `disableTouchRipple`: Removed.
+    - `centerRipple`: Removed.
+    - `focusRipple`: Removed.
+    - `TouchRippleProps`: Removed.
+    - `variant`:
+      - Removed values: `contained`, `outlined`, `text`.
+      - Added values: `primary`, `stroked`, `ghost`.
+  - Planned Migration from current `IconButton`:
+    - `color={*}` -> _removed_
+    - `disableElevation` -> _removed_
+    - `disableFocusRipple` -> _removed_
+    - `disableRipple` -> _removed_
+    - `disableTouchRipple` -> _removed_
+    - `centerRipple` -> _removed_
+    - `focusRipple` -> _removed_
+    - `TouchRippleProps={*}` -> _removed_
+    - `variant="contained"` -> `variant="primary"`
+    - `variant="outlined"` -> `variant="stroked"`
+    - `variant="text"` -> `variant="ghost"`
 - **Unstable_Typography**
   - Fix component typing so `variant` and `color` props appear as a discriminated union of string literals (i.e. `'body' | 'description' | ...`) instead of just `string`.
   - Fix variant T22 having wrong font weight.

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { Unstable_IconButton, Unstable_IconButtonProps } from '..';
+import {
+  Unstable_ChevronDown,
+  Unstable_Filter,
+  Unstable_Info,
+} from '../internal';
+import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Sb_Unstable_IconButtonProps
+  extends Omit<Unstable_IconButtonProps, 'tabIndex'> {}
+
+export const Sb_Unstable_IconButton = (props: Sb_Unstable_IconButtonProps) => (
+  <Unstable_IconButton {...props} />
+);
+
+export default {
+  title: '@ps/Unstable_IconButton',
+  component: Sb_Unstable_IconButton,
+  excludeStories: ['Sb_Unstable_IconButton'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+  decorators: [containFocusIndicator],
+  argTypes: {
+    children: {
+      control: 'select',
+      options: ['Unstable_ChevronDown', 'Unstable_Filter', 'Unstable_Info'],
+      mapping: {
+        Unstable_ChevronDown: <Unstable_ChevronDown />,
+        Unstable_Filter: <Unstable_Filter />,
+        Unstable_Info: <Unstable_Info />,
+      },
+    },
+  },
+  args: {
+    children: 'Unstable_ChevronDown',
+  },
+} as Meta;
+
+const Template = (args) => <Unstable_IconButton {...args} />;
+
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
+
+export const SparkThemeProvider: Story = Template.bind({});
+SparkThemeProvider.decorators = [sparkThemeProvider];
+SparkThemeProvider.storyName = '(SparkThemeProvider)';
+
+const variants: Array<Unstable_IconButtonProps['variant']> = [
+  'primary',
+  'stroked',
+  'ghost',
+];
+const sizes: Array<Unstable_IconButtonProps['size']> = ['medium', 'small'];
+
+const SizeByVariantTemplate = (args) => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      // space for focus indicator
+      gap: 8,
+    }}
+  >
+    {sizes.map((size) => (
+      <div
+        key={size}
+        style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}
+      >
+        {variants.map((variant) => (
+          <Unstable_IconButton
+            key={variant}
+            {...args}
+            variant={variant}
+            size={size}
+          />
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+export const SizeByVariant: Story = SizeByVariantTemplate.bind({});
+SizeByVariant.storyName = 'size ⨯ variant';
+
+export const SizeByVariantSTP: Story = SizeByVariantTemplate.bind({});
+SizeByVariantSTP.decorators = [sparkThemeProvider];
+SizeByVariantSTP.storyName = 'size ⨯ variant (STP)';
+
+export const SizeByVariantHover: Story = SizeByVariantTemplate.bind({});
+SizeByVariantHover.parameters = { pseudo: { hover: true } };
+SizeByVariantHover.storyName = 'size ⨯ variant :hover';
+
+export const SizeByVariantHoverSTP: Story = SizeByVariantTemplate.bind({});
+SizeByVariantHoverSTP.decorators = [sparkThemeProvider];
+SizeByVariantHoverSTP.parameters = { pseudo: { hover: true } };
+SizeByVariantHoverSTP.storyName = 'size ⨯ variant :hover (STP)';
+
+export const SizeByVariantActive: Story = SizeByVariantTemplate.bind({});
+SizeByVariantActive.parameters = { pseudo: { active: true } };
+SizeByVariantActive.storyName = 'size ⨯ variant :active';
+
+export const SizeByVariantActiveSTP: Story = SizeByVariantTemplate.bind({});
+SizeByVariantActiveSTP.decorators = [sparkThemeProvider];
+SizeByVariantActiveSTP.parameters = { pseudo: { active: true } };
+SizeByVariantActiveSTP.storyName = 'size ⨯ variant :active (STP)';
+
+export const SizeByVariantExpanded: Story = SizeByVariantTemplate.bind({});
+SizeByVariantExpanded.args = { 'aria-expanded': true };
+SizeByVariantExpanded.storyName = 'size ⨯ variant aria-expanded';
+
+export const SizeByVariantExpandedSTP: Story = SizeByVariantTemplate.bind({});
+SizeByVariantExpandedSTP.args = { 'aria-expanded': true };
+SizeByVariantExpandedSTP.decorators = [sparkThemeProvider];
+SizeByVariantExpandedSTP.storyName = 'size ⨯ variant aria-expanded (STP)';
+
+export const SizeByVariantFocusVisible: Story = SizeByVariantTemplate.bind({});
+SizeByVariantFocusVisible.parameters = { pseudo: { focusVisible: true } };
+SizeByVariantFocusVisible.storyName = 'size ⨯ variant :focus-visible';
+
+export const SizeByVariantFocusVisibleSTP: Story = SizeByVariantTemplate.bind(
+  {}
+);
+SizeByVariantFocusVisibleSTP.decorators = [sparkThemeProvider];
+SizeByVariantFocusVisibleSTP.parameters = { pseudo: { focusVisible: true } };
+SizeByVariantFocusVisibleSTP.storyName = 'size ⨯ variant :focus-visible (STP)';
+
+export const SizeByVariantDisabled: Story = SizeByVariantTemplate.bind({});
+SizeByVariantDisabled.args = { disabled: true };
+SizeByVariantDisabled.storyName = 'size ⨯ variant disabled';
+
+export const SizeByVariantDisabledSTP: Story = SizeByVariantTemplate.bind({});
+SizeByVariantDisabledSTP.args = { disabled: true };
+SizeByVariantDisabledSTP.decorators = [sparkThemeProvider];
+SizeByVariantDisabledSTP.storyName = 'size ⨯ variant disabled (STP)';

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.test.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_IconButton from './Unstable_IconButton';
+
+describe('Unstable_IconButton', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<Unstable_IconButton />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import {
+  default as MuiIconButton,
+  IconButtonProps as MuiIconButtonProps,
+} from '@material-ui/core/IconButton';
+import makeStyles from '../makeStyles';
+import { OverridableComponent, OverrideProps } from '../utils';
+import { lighten, darken, alpha } from '@material-ui/core/styles';
+
+export interface Unstable_IconButtonTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends React.ElementType = 'button'
+> {
+  props: P &
+    Omit<
+      MuiIconButtonProps,
+      | 'classes'
+      | 'color'
+      | 'disableFocusRipple'
+      | 'centerRipple'
+      | 'disableRipple'
+      | 'disableTouchRipple'
+      | 'focusRipple'
+      | 'size'
+      | 'TouchRippleProps'
+    > & {
+      /**
+       * The variant to use.
+       */
+      variant?: 'primary' | 'stroked' | 'ghost';
+      /**
+       * The size of the component.
+       */
+      size?: 'small' | 'medium';
+    };
+  defaultComponent: D;
+  classKey: Unstable_IconButtonClassKey;
+}
+
+export type Unstable_IconButtonProps<
+  D extends React.ElementType = Unstable_IconButtonTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_IconButtonTypeMap<P, D>, D>;
+
+export type Unstable_IconButtonClassKey = 'root' | 'label';
+
+const useStyles = makeStyles<Unstable_IconButtonClassKey>(
+  (theme) => ({
+    root: (props: Unstable_IconButtonProps) => ({
+      borderColor: 'transparent',
+      borderRadius: 4,
+      borderStyle: 'solid',
+      borderWidth: 1,
+      '&.Mui-focusVisible, &:focus-visible': {
+        boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+      },
+      ...(props.variant === 'primary' && {
+        backgroundColor: theme.unstable_palette.brand.blue,
+        '&:hover': {
+          backgroundColor: lighten(theme.unstable_palette.brand.blue, 0.1),
+        },
+        '&:active': {
+          backgroundColor: darken(theme.unstable_palette.brand.blue, 0.2),
+        },
+        '&[aria-expanded="true"]': {
+          backgroundColor: theme.unstable_palette.neutral[600],
+        },
+        '&:disabled': {
+          backgroundColor: theme.unstable_palette.neutral[80],
+        },
+      }),
+      ...(props.variant === 'stroked' && {
+        backgroundColor: theme.unstable_palette.neutral[0],
+        borderColor: theme.unstable_palette.neutral[90],
+        '&:hover': {
+          backgroundColor: theme.unstable_palette.neutral[70],
+        },
+        '&:active': {
+          backgroundColor: theme.unstable_palette.blue[100],
+        },
+        '&[aria-expanded="true"]': {
+          backgroundColor: theme.unstable_palette.neutral[600],
+        },
+        '&:disabled': {
+          backgroundColor: theme.unstable_palette.neutral[80],
+          color: theme.unstable_palette.neutral[100],
+        },
+      }),
+      ...(props.variant === 'ghost' && {
+        backgroundColor: 'transparent',
+        '&:hover': {
+          backgroundColor: theme.unstable_palette.neutral[70],
+        },
+        '&:active': {
+          backgroundColor: theme.unstable_palette.blue[100],
+        },
+        '&[aria-expanded="true"]': {
+          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.8),
+        },
+        '&:disabled': {
+          backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
+        },
+      }),
+
+      ...(props.size === 'small' && {
+        padding: 4,
+      }),
+      ...(props.size === 'medium' && {
+        padding: 12,
+      }),
+    }),
+
+    label: (props: Unstable_IconButtonProps) => ({
+      fontSize: '1.5rem',
+      ...(props.variant === 'primary' && {
+        color: theme.unstable_palette.neutral[0],
+      }),
+      ...(props.variant === 'stroked' && {
+        color: theme.unstable_palette.brand.blue,
+      }),
+      ...(props.variant === 'ghost' && {
+        color: theme.unstable_palette.brand.blue,
+      }),
+      '[aria-expanded="true"] > &': {
+        color: theme.unstable_palette.neutral[0],
+      },
+      ...(props.disabled && {
+        color: theme.unstable_palette.neutral[100],
+      }),
+    }),
+  }),
+  { name: 'MuiSparkUnstable_IconButton' }
+);
+
+const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = React.forwardRef(
+  function Unstable_IconButton(props, ref) {
+    const {
+      classes: classesProp,
+      disabled,
+      size = 'medium',
+      variant = 'primary',
+      // `color` happens to be an html attribute as well; conflicts with Mui prop type
+      color: _color,
+      ...other
+    } = props;
+
+    const classes = useStyles({ disabled, size, variant });
+
+    return (
+      <MuiIconButton
+        classes={{
+          root: clsx(classes.root, classesProp?.root),
+          label: clsx(classes.label, classesProp?.label),
+        }}
+        disabled={disabled}
+        disableFocusRipple
+        disableRipple
+        disableTouchRipple
+        focusRipple={false}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
+
+export default Unstable_IconButton;

--- a/libs/spark/src/Unstable_IconButton/index.ts
+++ b/libs/spark/src/Unstable_IconButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_IconButton';
+export * from './Unstable_IconButton';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -224,6 +224,9 @@ export { default as Unstable_FontFacesBaseline } from './Unstable_FontFacesBasel
 export { default as Unstable_FormHelperText } from './Unstable_FormHelperText';
 export * from './Unstable_FormHelperText';
 
+export { default as Unstable_IconButton } from './Unstable_IconButton';
+export * from './Unstable_IconButton';
+
 export { default as Unstable_Input } from './Unstable_Input';
 export * from './Unstable_Input';
 

--- a/libs/spark/src/internal/Unstable_Filter.tsx
+++ b/libs/spark/src/internal/Unstable_Filter.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import unstable_createSvgIcon from '../unstable_createSvgIcon';
+
+export default unstable_createSvgIcon(
+  <path
+    fill-rule="evenodd"
+    d="M2.25 6A.75.75 0 0 1 3 5.25h18a.75.75 0 0 1 0 1.5H3A.75.75 0 0 1 2.25 6Zm3 6a.75.75 0 0 1 .75-.75h12a.75.75 0 0 1 0 1.5H6a.75.75 0 0 1-.75-.75ZM10 17.25a.75.75 0 0 0 0 1.5h4a.75.75 0 0 0 0-1.5h-4Z"
+  />,
+  'Unstable_Filter'
+);

--- a/libs/spark/src/internal/index.ts
+++ b/libs/spark/src/internal/index.ts
@@ -16,4 +16,5 @@ export { default as Unstable_CheckCircle2 } from './Unstable_CheckCircle2';
 export { default as Unstable_ChevronDown } from './Unstable_ChevronDown';
 export { default as Unstable_Cross } from './Unstable_Cross';
 export { default as Unstable_CrossSmall } from './Unstable_CrossSmall';
+export { default as Unstable_Filter } from './Unstable_Filter';
 export { default as Unstable_Info } from './Unstable_Info';

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -53,6 +53,8 @@ export const inverseBackground: DecoratorFn = (Story) => (
 
 const ContainFocusIndicatorDiv = styled('div')({
   padding: 4,
+  // without setting it to minimum, the story snapshot will expand to 100%
+  width: 'min-content',
 });
 
 /**

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -50,3 +50,16 @@ export const inverseBackground: DecoratorFn = (Story) => (
     <Story />
   </InverseBackgroundDiv>
 );
+
+const ContainFocusIndicatorDiv = styled('div')({
+  padding: 4,
+});
+
+/**
+ * [Internal] A Storybook decorator that applies padding so that the standard focus indicator is captured in Chromatic snapshots.
+ */
+export const containFocusIndicator: DecoratorFn = (Story) => (
+  <ContainFocusIndicatorDiv>
+    <Story />
+  </ContainFocusIndicatorDiv>
+);


### PR DESCRIPTION
Part of #350 

Added a new decorator in an effort to have Chromatic fully capture the focus indicator -- [margin didn't work in the previous attempt for "Unstable_Button"](https://www.chromatic.com/component?appId=60b7f55f55fbd4004993da4c&csfId=ps-unstable-button--size-by-variant-focus-visible&buildNumber=722&k=6287d0d775c890004a1ce17e-1200-snapshot-true&h=15&b=-5); I'm assuming because either their tool disregards it or there's some margin collapsing going on or something.

_Edit: [the new decorator works](https://www.chromatic.com/test?appId=60b7f55f55fbd4004993da4c&id=628d4ef1de6ce4003a0a8b64)!_