### PR TITLE
feat(Unstable_Button): improve text baseline shift

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.7...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_Button**
+  - Improve the visual alignment of text and icons.
+
 ## [v1.0.0-alpha.7](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.6...v1.0.0-alpha.7) (2022-05-27)
 
 ### Unstable Preview

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -46,7 +46,8 @@ export type Unstable_ButtonClassKey =
   | 'root'
   | 'startIcon'
   | 'endIcon'
-  | 'label';
+  | 'label'
+  | 'private-textBaselineShift';
 
 // extracted since there's not an equivalent typography variant
 const buttonFontVariantSmall = buildVariant(
@@ -176,18 +177,12 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
     label: (props: Unstable_ButtonProps) => ({
       ...(props.size === 'small' && {
         ...buttonFontVariantSmall,
-        // top/bottom margin is part of re-aligning text and icon baselines: shift label baseline down
-        margin: '1px 0 -1px 0',
       }),
       ...(props.size === 'medium' && {
         ...buttonFontVariantMedium,
-        // top/bottom margin is part of re-aligning text and icon baselines: shift label baseline down
-        margin: '2px 0 -2px 0',
       }),
       ...(props.size === 'large' && {
         ...buttonFontVariantLarge,
-        // top/bottom margin is part of re-aligning text and icon baselines: shift label baseline down
-        margin: '2px 0 -2px 0',
       }),
 
       ...(props.variant === 'primary' && {
@@ -224,8 +219,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
     startIcon: (props: Unstable_ButtonProps) => ({
       color: 'inherit',
       lineHeight: 1,
-      // top margin is part of re-aligning text and icon baselines: shift icon baseline up
-      margin: '-2px 8px 0 0',
+      margin: '0 8px 0 0',
       ...(props.size === 'small' && {
         fontSize: theme.typography.pxToRem(16),
       }),
@@ -240,8 +234,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
     endIcon: (props: Unstable_ButtonProps) => ({
       color: 'inherit',
       lineHeight: 1,
-      // top margin is part of re-aligning text and icon baselines: shift icon baseline up
-      margin: '-2px 0 0 8px',
+      margin: '0 0 0 8px',
       ...(props.size === 'small' && {
         fontSize: theme.typography.pxToRem(16),
       }),
@@ -253,6 +246,10 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       }),
       '& > :first-child': { fontSize: 'inherit' },
     }),
+    'private-textBaselineShift': {
+      marginTop: theme.unstable_typography.pxToRem(1),
+      marginBottom: theme.unstable_typography.pxToRem(-1),
+    },
   }),
   { name: 'MuiSparkUnstable_Button' }
 );
@@ -260,6 +257,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
 const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forwardRef(
   function Unstable_Button(props, ref) {
     const {
+      children,
       classes: classesProp,
       disabled,
       variant = 'primary',
@@ -284,7 +282,9 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
         focusRipple={false}
         ref={ref}
         {...other}
-      />
+      >
+        <span className={classes['private-textBaselineShift']}>{children}</span>
+      </MuiButton>
     );
   }
 );


### PR DESCRIPTION
The alignments were still off from the attempt to shift the text baseline. Instead of messing with the entire label to adjust the text (requires re-adjusting the icon), we just add a wrap the text in an extra tag and shift that instead. This is better because the icon is always aligned correctly in the button, it's just the text that has a higher baseline than normal (and doesn't appear vertically centered without the shift).

**Before**
![image](https://user-images.githubusercontent.com/25781782/171305018-92d9b41b-66a7-4482-bc26-6dcb5a4cc8ac.png)

**After**
![image](https://user-images.githubusercontent.com/25781782/171305402-524ddac6-e7e1-4a6a-bd3a-78d8208fb381.png)
