### PR TITLE
feat(Unstable_IconButton): add color prop

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.8...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_IconButton**
+  - Add `color` prop with preliminary support for the `"ghost"` variant on inverse backgrounds.
+    - values: `"standard" | "inverse"`
+    - default value: `"standard"`
+    - (does not affect display of `"primary" | "stroked"` variants yet -- planned for future)
+
 ## [v1.0.0-alpha.8](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2022-06-03)
 
 ### Unstable Preview

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { Unstable_IconButton, Unstable_IconButtonProps } from '..';
+import { theme, Unstable_IconButton, Unstable_IconButtonProps } from '..';
 import {
   Unstable_ChevronDown,
   Unstable_Filter,
@@ -74,6 +74,29 @@ const SizeByVariantTemplate = (args) => (
             {...args}
             variant={variant}
             size={size}
+          />
+        ))}
+      </div>
+    ))}
+    {sizes.map((size) => (
+      <div
+        key={size}
+        style={{
+          display: 'flex',
+          gap: 8,
+          alignItems: 'flex-start',
+          backgroundColor: theme.unstable_palette.background.inverse,
+          margin: -4,
+          padding: 4,
+        }}
+      >
+        {['ghost'].map((variant) => (
+          <Unstable_IconButton
+            key={variant}
+            {...args}
+            variant={variant}
+            size={size}
+            color="inverse"
           />
         ))}
       </div>

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -27,13 +27,17 @@ export interface Unstable_IconButtonTypeMap<
       | 'TouchRippleProps'
     > & {
       /**
-       * The variant to use.
+       * The color of the component.
        */
-      variant?: 'primary' | 'stroked' | 'ghost';
+      color?: 'standard' | 'inverse';
       /**
        * The size of the component.
        */
       size?: 'small' | 'medium';
+      /**
+       * The variant to use.
+       */
+      variant?: 'primary' | 'stroked' | 'ghost';
     };
   defaultComponent: D;
   classKey: Unstable_IconButtonClassKey;
@@ -89,21 +93,38 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
           color: theme.unstable_palette.neutral[100],
         },
       }),
-      ...(props.variant === 'ghost' && {
-        backgroundColor: 'transparent',
-        '&:hover': {
-          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.08),
-        },
-        '&:active': {
-          backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
-        },
-        '&[aria-expanded="true"]': {
-          backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.8),
-        },
-        '&:disabled': {
-          backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
-        },
-      }),
+      ...(props.variant === 'ghost' &&
+        props.color === 'standard' && {
+          backgroundColor: 'transparent',
+          '&:hover': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.08),
+          },
+          '&:active': {
+            backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
+          },
+          '&[aria-expanded="true"]': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.8),
+          },
+          '&:disabled': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
+          },
+        }),
+      ...(props.variant === 'ghost' &&
+        props.color === 'inverse' && {
+          backgroundColor: 'transparent',
+          '&:hover': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[0], 0.08),
+          },
+          '&:active': {
+            backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
+          },
+          '&[aria-expanded="true"]': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[90], 0.4),
+          },
+          '&:disabled': {
+            backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
+          },
+        }),
 
       ...(props.size === 'small' && {
         padding: 4,
@@ -121,9 +142,14 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
       ...(props.variant === 'stroked' && {
         color: theme.unstable_palette.brand.blue,
       }),
-      ...(props.variant === 'ghost' && {
-        color: theme.unstable_palette.brand.blue,
-      }),
+      ...(props.variant === 'ghost' &&
+        props.color === 'standard' && {
+          color: theme.unstable_palette.brand.blue,
+        }),
+      ...(props.variant === 'ghost' &&
+        props.color === 'inverse' && {
+          color: theme.unstable_palette.neutral[0],
+        }),
       '[aria-expanded="true"] > &': {
         color: theme.unstable_palette.neutral[0],
       },
@@ -138,6 +164,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
 const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = React.forwardRef(
   function Unstable_IconButton(props, ref) {
     const {
+      color = 'standard',
       classes: classesProp,
       disabled,
       size = 'medium',
@@ -147,7 +174,7 @@ const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = Re
       ...other
     } = props;
 
-    const classes = useStyles({ disabled, size, variant });
+    const classes = useStyles({ color, disabled, size, variant });
 
     return (
       <MuiIconButton


### PR DESCRIPTION
Support the ghost icon button variant on inverse background with new color prop ([see figma](https://www.figma.com/file/y6Ca8BdJtQEd3Of1saRieF/components?node-id=5080%3A10852)). This is essential for the Banner implementation (up next) (also the Sidebar).