### PR TITLE
feat(Unstable_Button): support leadingAvatar

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -27,10 +27,12 @@ _This section details previews of breaking changes or experimental features that
   - Props API Changes:
     - `classes`: Removed all class keys _except `'root' | 'icon' | 'message' | 'action'`_.
 - **Unstable_Button**
+  - Added support for a leading Avatar (`leadingAvatar`).
   - Replaced `startIcon` and `endIcon` with `leadingIcon` and `trailingIcon`, respectively.
   - Props API changes:
-    - `classes`: removed `'startIcon' | 'endIcon'` class keys; added `'leadingIcon' | 'trailingIcon'` class keys
+    - `classes`: removed `'startIcon' | 'endIcon'` class keys; added `'leadingAvatar' | 'leadingIcon' | 'trailingIcon'` class keys
     - `endIcon`: removed
+    - `leadingAvatar`: added
     - `leadingIcon`: added
     - `startIcon`: removed
     - `trailingIcon`: added

--- a/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { Unstable_Button, Unstable_ButtonProps } from '..';
+import { Unstable_Avatar, Unstable_Button, Unstable_ButtonProps } from '..';
 import {
   ChevronDown,
   containFocusIndicator,
@@ -17,6 +17,17 @@ export default {
   parameters: { actions: { argTypesRegex: '^on.*' } },
   decorators: [containFocusIndicator],
   argTypes: {
+    leadingAvatar: {
+      control: 'select',
+      options: ['undefined', '(Guide)', '(Initials)'],
+      mapping: {
+        undefined: undefined,
+        '(Guide)': (
+          <Unstable_Avatar src="/img/guide-2.png" alt="Adult woman smiling" />
+        ),
+        '(Initials)': <Unstable_Avatar color="blue">M</Unstable_Avatar>,
+      },
+    },
     leadingIcon: {
       control: 'select',
       options: ['undefined', 'Plus'],
@@ -136,6 +147,20 @@ export const SizeByVariantDisabledSTP: Story = SizeByVariantTemplate.bind({});
 SizeByVariantDisabledSTP.args = { disabled: true };
 SizeByVariantDisabledSTP.decorators = [sparkThemeProvider];
 SizeByVariantDisabledSTP.storyName = 'size ⨯ variant disabled (STP)';
+
+export const SizeByVariantLeadingAvatar: Story = SizeByVariantTemplate.bind({});
+SizeByVariantLeadingAvatar.args = { leadingAvatar: '(Guide)' };
+SizeByVariantLeadingAvatar.storyName = 'size ⨯ variant leadingAvatar';
+
+export const SizeByVariantLeadingAvatarDisabled: Story = SizeByVariantTemplate.bind(
+  {}
+);
+SizeByVariantLeadingAvatarDisabled.args = {
+  leadingAvatar: '(Guide)',
+  disabled: true,
+};
+SizeByVariantLeadingAvatarDisabled.storyName =
+  'size ⨯ variant leadingAvatar disabled';
 
 export const SizeByVariantLeadingIcon: Story = SizeByVariantTemplate.bind({});
 SizeByVariantLeadingIcon.args = { leadingIcon: 'Plus' };

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -8,6 +8,7 @@ import makeStyles from '../makeStyles';
 import { OverridableComponent, OverrideProps } from '../utils';
 import { buildVariant } from '../theme/typography';
 import { lighten, darken } from '@material-ui/core/styles';
+import { Unstable_AvatarProps } from '../Unstable_Avatar';
 
 export interface Unstable_ButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -35,6 +36,10 @@ export interface Unstable_ButtonTypeMap<
        */
       variant?: 'primary' | 'stroked' | 'ghost' | 'destructive';
       /**
+       * Avatar placed before the children.
+       */
+      leadingAvatar?: React.ReactNode;
+      /**
        * Icon placed before the children.
        */
       leadingIcon?: React.ReactNode;
@@ -55,6 +60,7 @@ export type Unstable_ButtonProps<
 
 export type Unstable_ButtonClassKey =
   | 'root'
+  | 'leadingAvatar'
   | 'leadingIcon'
   | 'trailingIcon'
   | 'label'
@@ -228,6 +234,31 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
         }),
       }),
     }),
+    leadingAvatar: (props: Unstable_ButtonProps) => ({
+      color: 'inherit',
+      display: 'flex',
+      marginRight: 8,
+      /** size */
+      ...(props.size === 'small' && {
+        marginBottom: -4,
+        marginLeft: -8,
+        marginTop: -4,
+      }),
+      ...(props.size === 'medium' && {
+        marginBottom: -8,
+        marginLeft: -8,
+        marginTop: -8,
+      }),
+      ...(props.size === 'large' && {
+        marginBottom: -8,
+        marginLeft: -8,
+        marginTop: -8,
+      }),
+      /** disabled */
+      ...(props.disabled && {
+        opacity: 0.62,
+      }),
+    }),
     leadingIcon: (props: Unstable_ButtonProps) => ({
       color: 'inherit',
       display: 'flex',
@@ -274,6 +305,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
       children,
       classes: classesProp,
       disabled,
+      leadingAvatar,
       leadingIcon,
       size = 'medium',
       trailingIcon,
@@ -285,7 +317,18 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
     const classes = useStyles({ disabled, variant, size });
 
     let leadingEl: React.ReactNode;
-    if (leadingIcon) {
+    if (leadingAvatar) {
+      const avatarSize: Unstable_AvatarProps['size'] =
+        size === 'small' ? 'small' : 'medium';
+      leadingEl = (
+        <span
+          className={clsx(classes.leadingAvatar, classesProp?.leadingAvatar)}
+        >
+          {/* @ts-expect-error can't know if actually given an Unstable_Avatar instance, so prop may be invalid */}
+          {React.cloneElement(leadingAvatar, { size: avatarSize })}
+        </span>
+      );
+    } else if (leadingIcon) {
       leadingEl = (
         <span className={clsx(classes.leadingIcon, classesProp?.leadingIcon)}>
           {leadingIcon}


### PR DESCRIPTION
(based on #421 )

Add support for `leadingAvatar`.