### PR TITLE
chore: replace wildcard with named React imports

### DIFF
--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { addons, Config } from '@storybook/addons';
 import { create } from '@storybook/theming';
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ import { Button, ButtonProps } from './Button';
 export interface DropdownButtonProps = ButtonProps;
 
 function SparkDropdownButton(props: DropdownButtonProps) {
-  const { id, handleClick } = React.useContext(Context);
+  const { id, handleClick } = useContext(Context);
   return (
     <Button
       aria-controls={id}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install @prenda/spark
 Here is an example to get you started.
 
 ```tsx
-import * as React from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { SparkThemeProvider } from '@prenda/spark';
 import { Button } from '@material-ui/core';

--- a/apps/example-nextjs/pages/_document.tsx
+++ b/apps/example-nextjs/pages/_document.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/core/styles';
 import { withEmotionCache } from 'tss-react/nextJs';
@@ -31,7 +31,7 @@ MyDocument.getInitialProps = async (ctx) => {
   return {
     ...initialProps,
     styles: [
-      ...React.Children.toArray(initialProps.styles),
+      ...Children.toArray(initialProps.styles),
       sheets.getStyleElement(),
     ],
   };

--- a/libs/spark/README.md
+++ b/libs/spark/README.md
@@ -57,7 +57,7 @@ npm install --save @prenda/spark
 ## Usage
 
 ```tsx
-import * as React from 'react';
+import React from 'react';
 
 import { Button } from '@prenda/spark';
 

--- a/libs/spark/src/Alert/defaults.tsx
+++ b/libs/spark/src/Alert/defaults.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { AlertProps } from './Alert';
 import {
   AlertOctagonFilled,

--- a/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
+++ b/libs/spark/src/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Autocomplete,

--- a/libs/spark/src/Autocomplete/defaults.tsx
+++ b/libs/spark/src/Autocomplete/defaults.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { AutocompleteClassKey } from './Autocomplete';
 import { ChevronDown } from '../internal';
 import type { Theme } from '../theme';

--- a/libs/spark/src/Avatar/Avatar.stories.tsx
+++ b/libs/spark/src/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { UserDuotone } from '@prenda/spark-icons';
 import { Avatar, Box } from '..';

--- a/libs/spark/src/Avatar/Avatar.tsx
+++ b/libs/spark/src/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiAvatar,
@@ -27,7 +27,7 @@ type CustomClassKey =
 
 export interface AvatarTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P &
     Omit<MuiAvatarProps, 'variant' | 'classes'> & {
@@ -41,7 +41,7 @@ export interface AvatarTypeMap<
 }
 
 export type AvatarProps<
-  D extends React.ElementType = AvatarTypeMap['defaultComponent'],
+  D extends ElementType = AvatarTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<AvatarTypeMap<P, D>, D>;
 
@@ -96,33 +96,34 @@ const useCustomStyles = makeStyles<CustomClassKey>(
   { name: 'MuiSparkAvatar' }
 );
 
-const Avatar: OverridableComponent<AvatarTypeMap> = React.forwardRef(
-  function Avatar({ classes, size = 'medium', ...other }, ref) {
-    const baseCustomClasses = useCustomStyles();
+const Avatar: OverridableComponent<AvatarTypeMap> = forwardRef(function Avatar(
+  { classes, size = 'medium', ...other },
+  ref
+) {
+  const baseCustomClasses = useCustomStyles();
 
-    const { otherClasses, customClasses } = useClassesCapture<
-      AvatarClassKey,
-      CustomClassKey
-    >({
-      classes,
-      baseCustomClasses,
-    });
+  const { otherClasses, customClasses } = useClassesCapture<
+    AvatarClassKey,
+    CustomClassKey
+  >({
+    classes,
+    baseCustomClasses,
+  });
 
-    return (
-      <MuiAvatar
-        classes={{
-          ...otherClasses,
-          root: clsx(
-            customClasses.root,
-            customClasses[`size${capitalize(size)}`]
-          ),
-          colorDefault: customClasses.colorDefault,
-        }}
-        {...other}
-        ref={ref}
-      />
-    );
-  }
-);
+  return (
+    <MuiAvatar
+      classes={{
+        ...otherClasses,
+        root: clsx(
+          customClasses.root,
+          customClasses[`size${capitalize(size)}`]
+        ),
+        colorDefault: customClasses.colorDefault,
+      }}
+      {...other}
+      ref={ref}
+    />
+  );
+});
 
 export default Avatar;

--- a/libs/spark/src/Banner/Banner.stories.tsx
+++ b/libs/spark/src/Banner/Banner.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Banner, BannerProps, styled } from '..';
 import {

--- a/libs/spark/src/Banner/Banner.tsx
+++ b/libs/spark/src/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { CSSProperties, SyntheticEvent } from 'react';
 import { default as Alert, AlertProps, AlertClassKey } from '../Alert';
 import Button from '../Button';
 import IconButton from '../IconButton';
@@ -16,7 +16,7 @@ export interface BannerProps extends Omit<AlertProps, 'variant'> {
    *
    * @param {object} event The event source of the callback.
    */
-  onDetails?: (event: React.SyntheticEvent) => void;
+  onDetails?: (event: SyntheticEvent) => void;
 }
 
 export type BannerClassKey = AlertClassKey;
@@ -90,7 +90,7 @@ export default withStyles(
       marginRight: 8,
     },
     message: {
-      ...(theme.typography['label-lg-strong'] as React.CSSProperties),
+      ...(theme.typography['label-lg-strong'] as CSSProperties),
       padding: '9px 0',
     },
   }),

--- a/libs/spark/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/libs/spark/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Breadcrumbs, BreadcrumbsProps, Link } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import {
   default as MuiBreadcrumbs,
   BreadcrumbsClassKey,
@@ -37,7 +37,7 @@ const useStyles = makeStyles<BreadcrumbsClassKey>(
   { name: 'MuiSparkBreadcrumbs' }
 );
 
-const Breadcrumbs: OverridableComponent<BreadcrumbsTypeMap> = React.forwardRef(
+const Breadcrumbs: OverridableComponent<BreadcrumbsTypeMap> = forwardRef(
   function Breadcrumbs(
     { classes: classesProp, separator = <ChevronRight />, ...other },
     ref

--- a/libs/spark/src/Button/Button.stories.tsx
+++ b/libs/spark/src/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
 import { Box, Button, ButtonProps } from '..';

--- a/libs/spark/src/Card/Card.stories.tsx
+++ b/libs/spark/src/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { HeartDuotone } from '@prenda/spark-icons';
 import {

--- a/libs/spark/src/Checkbox/Checkbox.spec.tsx
+++ b/libs/spark/src/Checkbox/Checkbox.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import Checkbox from './Checkbox';
 import SparkThemeProvider from '../SparkThemeProvider';

--- a/libs/spark/src/Checkbox/Checkbox.stories.tsx
+++ b/libs/spark/src/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Checkbox, CheckboxProps, FormControlLabel } from '..';
 import { DocumentationTemplate } from '../../stories/templates';

--- a/libs/spark/src/Checkbox/CheckboxIcon.tsx
+++ b/libs/spark/src/Checkbox/CheckboxIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import styled from '../styled';
 import { createSvgIcon } from '../utils';

--- a/libs/spark/src/Checkbox/defaults.tsx
+++ b/libs/spark/src/Checkbox/defaults.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { CheckboxProps, CheckboxClassKey } from './Checkbox';
 import CheckboxIcon from './CheckboxIcon';
 import type { Theme } from '../theme';

--- a/libs/spark/src/Collapse/Collapse.stories.tsx
+++ b/libs/spark/src/Collapse/Collapse.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Box,
@@ -132,7 +132,7 @@ const useDemoStyles = makeStyles({
 
 const DemoTemplate: Story = () => {
   const classes = useDemoStyles();
-  const [checked, setChecked] = React.useState(false);
+  const [checked, setChecked] = useState(false);
 
   const handleChange = () => {
     setChecked((prev) => !prev);

--- a/libs/spark/src/Collapse/Collapse.tsx
+++ b/libs/spark/src/Collapse/Collapse.tsx
@@ -1,5 +1,5 @@
 // Adapted from MUI, from the last source before the emotion migration. Permalink https://github.com/mui-org/material-ui/blob/fe6a7db45959dcd5650f917db0d5a452548e191b/packages/material-ui/src/Collapse/Collapse.js
-import * as React from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
@@ -76,7 +76,7 @@ export const useStyles = makeStyles<CollapseClassKey>(
   { name: 'MuiSparkCollapse' }
 );
 
-const Collapse = React.forwardRef<
+const Collapse = forwardRef<
   CollapseProps,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any
@@ -107,9 +107,9 @@ const Collapse = React.forwardRef<
   const baseClasses = useStyles();
   const classes = useMergeClasses({ baseClasses, classesProp });
 
-  const timer = React.useRef<NodeJS.Timeout>();
-  const wrapperRef = React.useRef(null);
-  const autoTransitionDuration = React.useRef<number>();
+  const timer = useRef<NodeJS.Timeout>();
+  const wrapperRef = useRef(null);
+  const autoTransitionDuration = useRef<number>();
   const collapsedSize =
     typeof collapsedSizeProp === 'number'
       ? `${collapsedSizeProp}px`
@@ -117,13 +117,13 @@ const Collapse = React.forwardRef<
   const isHorizontal = orientation === 'horizontal';
   const size = isHorizontal ? 'width' : 'height';
 
-  React.useEffect(() => {
+  useEffect(() => {
     return () => {
       clearTimeout(timer.current);
     };
   }, []);
 
-  const nodeRef = React.useRef(null);
+  const nodeRef = useRef(null);
   const handleRef = useForkRef(ref, nodeRef);
 
   const normalizedTransitionCallback = (callback) => (maybeIsAppearing) => {

--- a/libs/spark/src/CssBaseline/CssBaseline.ts
+++ b/libs/spark/src/CssBaseline/CssBaseline.ts
@@ -5,10 +5,10 @@ import withStyles from '../withStyles';
  *
  * @example
  *  const MyApp = () => (
- *    <React.Fragment>
+ *    <>
  *      <CssBaseline />
  *      // rest of my app
- *    </React.Fragment>
+ *    </>
  *  )
  */
 const CssBaseline = withStyles(

--- a/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
+++ b/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
@@ -1,30 +1,30 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import { default as Button, ButtonTypeMap } from '../Button';
 import { useDropdownContext } from '../DropdownContext';
 import { OverridableComponent, OverrideProps } from '../utils';
 
 export type DropdownAnchorProps<
-  D extends React.ElementType = DropdownAnchorTypeMap['defaultComponent'],
+  D extends ElementType = DropdownAnchorTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<DropdownAnchorTypeMap<P, D>, D>;
 
 export interface DropdownAnchorTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = ButtonTypeMap['defaultComponent']
+  D extends ElementType = ButtonTypeMap['defaultComponent']
 > {
   props: P;
   defaultComponent: D;
   classKey: string;
 }
 
-const DropdownAnchor: OverridableComponent<DropdownAnchorTypeMap> = React.forwardRef(
+const DropdownAnchor: OverridableComponent<DropdownAnchorTypeMap> = forwardRef(
   function DropdownAnchor(
     { component = Button, onClick, ...other }: DropdownAnchorProps,
     ref
   ) {
     const { id, openDropdown } = useDropdownContext();
 
-    const Component = component as React.ElementType;
+    const Component = component as ElementType;
 
     return (
       <Component

--- a/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { UserDuotone, ChevronDown } from '@prenda/spark-icons';
 import {

--- a/libs/spark/src/DropdownContext/DropdownContext.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.tsx
@@ -1,4 +1,11 @@
-import * as React from 'react';
+import React, {
+  createContext,
+  MouseEvent,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import { useUniqueId } from '../utils';
 
 // This file is an adaption of Mui's TabContext.
@@ -7,11 +14,11 @@ import { useUniqueId } from '../utils';
 export interface DropdownContextValue {
   id: string;
   anchorEl: null | HTMLElement;
-  openDropdown: (event: React.MouseEvent<HTMLElement>) => void;
+  openDropdown: (event: MouseEvent<HTMLElement>) => void;
   closeDropdown: () => void;
 }
 
-const Context = React.createContext<DropdownContextValue | null>(null);
+const Context = createContext<DropdownContextValue | null>(null);
 
 if (process.env.NODE_ENV !== 'production') {
   Context.displayName = 'DropdownContext';
@@ -21,7 +28,7 @@ export interface DropdownContextProps {
   /**
    * The content of the component.
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export default function DropdownContext(
@@ -29,9 +36,9 @@ export default function DropdownContext(
 ): JSX.Element {
   const id = useUniqueId();
 
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const openDropdown = (event: React.MouseEvent<HTMLElement>) => {
+  const openDropdown = (event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
@@ -39,14 +46,14 @@ export default function DropdownContext(
     setAnchorEl(null);
   };
 
-  const value = React.useMemo(
-    () => ({ id, anchorEl, openDropdown, closeDropdown }),
-    [id, anchorEl]
-  );
+  const value = useMemo(() => ({ id, anchorEl, openDropdown, closeDropdown }), [
+    id,
+    anchorEl,
+  ]);
 
   return <Context.Provider value={value} {...props} />;
 }
 
 export function useDropdownContext(): DropdownContextValue | null {
-  return React.useContext(Context);
+  return useContext(Context);
 }

--- a/libs/spark/src/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import { useDropdownContext } from '../DropdownContext';
 import type { MenuProps } from '../Menu';
@@ -18,7 +18,7 @@ export interface DropdownMenuProps extends Omit<MenuProps, 'open'> {
   placement?: Placement;
 }
 
-const DropdownMenu = React.forwardRef<HTMLUListElement, DropdownMenuProps>(
+const DropdownMenu = forwardRef<HTMLUListElement, DropdownMenuProps>(
   (
     {
       placement = 'bottom-left',

--- a/libs/spark/src/FontFacesBaseline/FontFacesBaseline.ts
+++ b/libs/spark/src/FontFacesBaseline/FontFacesBaseline.ts
@@ -7,10 +7,10 @@ import withStyles from '../withStyles';
  *
  * @example
  *  const MyApp = () => (
- *    <React.Fragment>
+ *    <>
  *      <FontFacesBaseline />
  *      // rest of my app
- *    </React.Fragment>
+ *    </>
  *  )
  */
 const FontFacesBaseline = withStyles(

--- a/libs/spark/src/FormControl/FormControl.stories.tsx
+++ b/libs/spark/src/FormControl/FormControl.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Box,
@@ -165,7 +165,7 @@ const CheckboxGroupIndeterminateTemplate = ({
   value,
   ...args
 }) => {
-  const [rows, setRows] = React.useState([false, true, false]);
+  const [rows, setRows] = useState([false, true, false]);
 
   const handleChange = (event) => {
     const { name, checked } = event.target;

--- a/libs/spark/src/IconButton/IconButton.stories.tsx
+++ b/libs/spark/src/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ChevronDown } from '@prenda/spark-icons';
 import { Box, IconButton, IconButtonProps } from '..';

--- a/libs/spark/src/IconButton/IconButton.tsx
+++ b/libs/spark/src/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiIconButton,
@@ -11,7 +11,7 @@ import { OverridableComponent, capitalize, useClassesCapture } from '../utils';
 export interface IconButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > {
   props: P & IconButtonProps;
   defaultComponent: D;
@@ -133,7 +133,7 @@ const useCustomStyles = makeStyles<CustomClassKey>(
   { name: 'MuiSparkIconButton' }
 );
 
-const IconButton: OverridableComponent<IconButtonTypeMap> = React.forwardRef(
+const IconButton: OverridableComponent<IconButtonTypeMap> = forwardRef(
   function IconButton(
     { classes, variant = 'contained', size = 'large', children, ...other },
     ref

--- a/libs/spark/src/Input/Input.stories.tsx
+++ b/libs/spark/src/Input/Input.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone, QuestionDuotone } from '@prenda/spark-icons';
 import { Input, InputAdornment, InputProps, styled } from '..';

--- a/libs/spark/src/Link/Link.stories.tsx
+++ b/libs/spark/src/Link/Link.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Link, LinkProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Link/Link.tsx
+++ b/libs/spark/src/Link/Link.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiLink,
@@ -10,7 +10,7 @@ import { OverridableComponent, OverrideProps, useMergeClasses } from '../utils';
 export interface LinkTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'a'
+  D extends ElementType = 'a'
 > {
   props: P &
     Omit<MuiLinkProps, 'classes' | 'underline'> & {
@@ -24,7 +24,7 @@ export interface LinkTypeMap<
 }
 
 export type LinkProps<
-  D extends React.ElementType = LinkTypeMap['defaultComponent'],
+  D extends ElementType = LinkTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<LinkTypeMap<P, D>, D>;
@@ -65,7 +65,7 @@ const useStyles = makeStyles<LinkClassKey>(
   { name: 'MuiSparkLink' }
 );
 
-const Link: OverridableComponent<LinkTypeMap> = React.forwardRef(function Link(
+const Link: OverridableComponent<LinkTypeMap> = forwardRef(function Link(
   {
     classes: classesProp,
     // reset MuiLink default prop to match our Typography default

--- a/libs/spark/src/MenuItem/MenuItem.stories.tsx
+++ b/libs/spark/src/MenuItem/MenuItem.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone } from '@prenda/spark-icons';
 import {

--- a/libs/spark/src/MenuList/MenuList.stories.tsx
+++ b/libs/spark/src/MenuList/MenuList.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Avatar,

--- a/libs/spark/src/NavBar/NavBar.stories.tsx
+++ b/libs/spark/src/NavBar/NavBar.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   BeakerDuotone,

--- a/libs/spark/src/NavBar/NavBar.tsx
+++ b/libs/spark/src/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { default as AppBar, AppBarProps } from '@material-ui/core/AppBar';
 import withStyles from '../withStyles';
 

--- a/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
+++ b/libs/spark/src/NavBarButton/NavBarButton.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { CheckCircleDuotone } from '@prenda/spark-icons';
 import { Box, NavBarButton, NavBarButtonProps } from '..';

--- a/libs/spark/src/NavBarButton/NavBarButton.tsx
+++ b/libs/spark/src/NavBarButton/NavBarButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { default as Button, ButtonProps } from '@material-ui/core/Button';
 import withStyles from '../withStyles';
 

--- a/libs/spark/src/Pagination/Pagination.stories.tsx
+++ b/libs/spark/src/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Pagination, PaginationProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
+++ b/libs/spark/src/PaginationItem/PaginationItem.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { PaginationItem, PaginationItemProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Radio/Radio.spec.tsx
+++ b/libs/spark/src/Radio/Radio.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import Radio from './Radio';
 import SparkThemeProvider from '../SparkThemeProvider';

--- a/libs/spark/src/Radio/Radio.stories.tsx
+++ b/libs/spark/src/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { FormControlLabel, Radio, RadioProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Radio/RadioIcon.tsx
+++ b/libs/spark/src/Radio/RadioIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import styled from '../styled';
 import { createSvgIcon } from '../utils';

--- a/libs/spark/src/Radio/defaults.tsx
+++ b/libs/spark/src/Radio/defaults.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { RadioProps, RadioClassKey } from './Radio';
 import RadioIcon from './RadioIcon';
 import type { Theme } from '../theme';

--- a/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
+++ b/libs/spark/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   FormControl,

--- a/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
+++ b/libs/spark/src/SectionMessage/SectionMessage.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   SectionMessage,

--- a/libs/spark/src/SectionMessage/SectionMessage.tsx
+++ b/libs/spark/src/SectionMessage/SectionMessage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { CSSProperties } from 'react';
 import { default as Alert, AlertProps, AlertClassKey } from '../Alert';
 import IconButton from '../IconButton';
 import { Cross } from '../internal';
@@ -75,7 +75,7 @@ export default withStyles(
       padding: 0,
     },
     message: {
-      ...(theme.typography['paragraph-lg'] as React.CSSProperties),
+      ...(theme.typography['paragraph-lg'] as CSSProperties),
       padding: '2px 0',
     },
   }),

--- a/libs/spark/src/Select/Select.stories.tsx
+++ b/libs/spark/src/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone } from '@prenda/spark-icons';
 import { InputAdornment, MenuItem, Select, SelectProps, styled } from '..';
@@ -49,7 +49,7 @@ export default {
 } as Meta;
 
 const Template = ({ value: propValue, ...args }) => {
-  const [value, setValue] = React.useState(propValue);
+  const [value, setValue] = useState(propValue);
 
   const handleChange = (event) => setValue(event.target.value);
 

--- a/libs/spark/src/SparkThemeProvider/SparkThemeProvider.tsx
+++ b/libs/spark/src/SparkThemeProvider/SparkThemeProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import ThemeProvider from '../ThemeProvider';
 import {
   StylesProvider,

--- a/libs/spark/src/Step/Step.stories.tsx
+++ b/libs/spark/src/Step/Step.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Step, StepButton, StepContent, StepLabel, StepProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Step/Step.tsx
+++ b/libs/spark/src/Step/Step.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ReactElement, forwardRef } from 'react';
 import {
   default as MuiStep,
   StepClasskey as MuiStepClassKey,
@@ -44,7 +44,7 @@ export interface StepProps extends MuiStepProps {
    * An element before the step, if _not_ `index={0}`.
    */
   connector?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  React.ReactElement<any, any>;
+  ReactElement<any, any>;
   /**
    * Whether the step is disabled.
    */
@@ -69,7 +69,7 @@ export interface StepProps extends MuiStepProps {
 
 const defaultConnector = <StepConnector />;
 
-const Step = React.forwardRef<unknown, StepProps>(function Step(
+const Step = forwardRef<unknown, StepProps>(function Step(
   { classes, connector = defaultConnector, ...other },
   ref
 ) {

--- a/libs/spark/src/StepButton/StepButton.stories.tsx
+++ b/libs/spark/src/StepButton/StepButton.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ReactNode } from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepButton, StepButtonProps } from '..';
@@ -8,7 +8,7 @@ interface SbStepButtonProps extends StepButtonProps {
   /**
    * **[Storybook-only:** hard-coded options.**]**
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const SbStepButton = (props: SbStepButtonProps) => (

--- a/libs/spark/src/StepButton/StepButton.tsx
+++ b/libs/spark/src/StepButton/StepButton.tsx
@@ -1,5 +1,11 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepButton/StepButton.js
-import * as React from 'react';
+import React, {
+  cloneElement,
+  ElementType,
+  forwardRef,
+  isValidElement,
+  ReactNode,
+} from 'react';
 import clsx from 'clsx';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
@@ -33,7 +39,7 @@ const useStyles = makeStyles<StepButtonClassKey>(
 export interface StepButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > {
   props: P & StepButtonProps;
   defaultComponent: D;
@@ -60,14 +66,14 @@ export type StepButtonProps = {
   /**
    * Passed to children (`StepLabel` by default).
    */
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   /**
    * Passed to children (`StepLabel` by default).
    */
   orientation?: Orientation;
 };
 
-const StepButton: OverridableComponent<StepButtonTypeMap> = React.forwardRef(
+const StepButton: OverridableComponent<StepButtonTypeMap> = forwardRef(
   function StepButton(
     {
       active,
@@ -104,10 +110,10 @@ const StepButton: OverridableComponent<StepButtonTypeMap> = React.forwardRef(
       orientation,
     };
     const child =
-      React.isValidElement(children) &&
+      isValidElement(children) &&
       // @ts-expect-error Property 'muiName' does not exist on type ...
       children.type.muiName === 'StepLabel' ? (
-        React.cloneElement(children, childProps)
+        cloneElement(children, childProps)
       ) : (
         <StepLabel {...childProps}>{children}</StepLabel>
       );

--- a/libs/spark/src/StepConnector/StepConnector.stories.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepConnector, StepConnectorProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/StepConnector/StepConnector.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.tsx
@@ -1,5 +1,5 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepConnector/StepConnector.js
-import * as React from 'react';
+import React, { forwardRef, HTMLAttributes, Ref } from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import { StandardProps, useMergeClasses } from '../utils';
@@ -73,11 +73,11 @@ const useCustomStyles = makeStyles<StepConnectorClassKey>(
 
 export interface StepConnectorProps
   extends StandardProps<
-    React.HTMLAttributes<HTMLDivElement>,
+    HTMLAttributes<HTMLDivElement>,
     StepConnectorClassKey,
     'children'
   > {
-  ref?: React.Ref<HTMLDivElement>;
+  ref?: Ref<HTMLDivElement>;
   /**
    * Whether connected step is active.
    */
@@ -100,7 +100,7 @@ export interface StepConnectorProps
   orientation?: Orientation;
 }
 
-const StepConnector = React.forwardRef<HTMLDivElement, StepConnectorProps>(
+const StepConnector = forwardRef<HTMLDivElement, StepConnectorProps>(
   function StepConnector(
     {
       active,

--- a/libs/spark/src/StepContent/StepContent.stories.tsx
+++ b/libs/spark/src/StepContent/StepContent.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { StepContent, StepContentProps, Typography } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/StepContent/StepContent.tsx
+++ b/libs/spark/src/StepContent/StepContent.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import {
   default as MuiStepContent,
   StepContentClasskey as StepContentClassKey,
@@ -24,14 +24,15 @@ const useStyles = makeStyles<StepContentClassKey>(({ palette }) => ({
   transition: {},
 }));
 
-const StepContent = React.forwardRef<unknown, StepContentProps>(
-  function StepContent({ classes: classesProp, ...other }, ref) {
-    const baseClasses = useStyles();
+const StepContent = forwardRef<unknown, StepContentProps>(function StepContent(
+  { classes: classesProp, ...other },
+  ref
+) {
+  const baseClasses = useStyles();
 
-    const classes = useMergeClasses({ baseClasses, classesProp });
+  const classes = useMergeClasses({ baseClasses, classesProp });
 
-    return <MuiStepContent classes={classes} ref={ref} {...other} />;
-  }
-);
+  return <MuiStepContent classes={classes} ref={ref} {...other} />;
+});
 
 export default StepContent;

--- a/libs/spark/src/StepIcon/StepIcon.stories.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepIcon, StepIconProps } from '..';

--- a/libs/spark/src/StepIcon/StepIcon.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.tsx
@@ -1,5 +1,5 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepIcon/StepIcon.js
-import * as React from 'react';
+import React, { ReactNode, forwardRef } from 'react';
 import clsx from 'clsx';
 import { default as SvgIcon, SvgIconProps } from '../SvgIcon';
 import { AlertThick, CheckThick } from '../internal';
@@ -30,7 +30,7 @@ export interface StepIconProps
   /**
    * The label displayed in the step icon.
    */
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 const useCustomStyles = makeStyles<StepIconClassKey>(
@@ -99,7 +99,7 @@ const useCustomStyles = makeStyles<StepIconClassKey>(
   { name: 'MuiSparkStepIcon' }
 );
 
-const StepIcon = React.forwardRef<
+const StepIcon = forwardRef<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any,
   StepIconProps

--- a/libs/spark/src/StepLabel/StepLabel.stories.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearFilled } from '@prenda/spark-icons';
 import { StepLabel, StepLabelProps } from '..';

--- a/libs/spark/src/StepLabel/StepLabel.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import {
   default as MuiStepLabel,
   StepLabelClasskey as StepLabelClassKey,
@@ -72,7 +72,7 @@ export interface StepLabelProps
 
 const defaultStepIcon = StepIcon;
 
-const StepLabel = React.forwardRef<unknown, StepLabelProps>(function StepLabel(
+const StepLabel = forwardRef<unknown, StepLabelProps>(function StepLabel(
   { StepIconComponent = defaultStepIcon, classes: classesProp, ...other },
   ref
 ) {

--- a/libs/spark/src/Stepper/Stepper.stories.tsx
+++ b/libs/spark/src/Stepper/Stepper.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Step,

--- a/libs/spark/src/Stepper/Stepper.tsx
+++ b/libs/spark/src/Stepper/Stepper.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import {
   default as MuiStepper,
   Orientation,
@@ -23,7 +23,7 @@ const useStyles = makeStyles<StepperClassKey>({
 
 const defaultConnector = <StepConnector />;
 
-const Stepper = React.forwardRef<unknown, StepperProps>(function Stepper(
+const Stepper = forwardRef<unknown, StepperProps>(function Stepper(
   { classes: classesProp, connector = defaultConnector, ...other },
   ref
 ) {

--- a/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {

--- a/libs/spark/src/SvgIcon/SvgIcon.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiSvgIcon,
@@ -98,7 +98,7 @@ const useStyles = makeStyles<SvgIconClassKey>(
 export interface SvgIconTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'svg'
+  D extends ElementType = 'svg'
 > {
   props: P &
     Omit<MuiSvgIconProps, 'color' | 'classes'> & {
@@ -125,12 +125,12 @@ export interface SvgIconTypeMap<
 }
 
 export type SvgIconProps<
-  D extends React.ElementType = SvgIconTypeMap['defaultComponent'],
+  D extends ElementType = SvgIconTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<SvgIconTypeMap<P, D>, D>;
 
-const SvgIcon: OverridableComponent<SvgIconTypeMap> = React.forwardRef(
+const SvgIcon: OverridableComponent<SvgIconTypeMap> = forwardRef(
   function SvgIcon(
     {
       lowContrast,

--- a/libs/spark/src/Switch/Switch.stories.tsx
+++ b/libs/spark/src/Switch/Switch.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Card,

--- a/libs/spark/src/Switch/Switch.tsx
+++ b/libs/spark/src/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import {
   default as MuiSwitch,
   SwitchClassKey as MuiSwitchClassKey,
@@ -11,7 +11,7 @@ export type SwitchClassKey = MuiSwitchClassKey | 'edgeEnd' | 'edgeStart';
 
 export interface SwitchTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P &
     Omit<MuiSwitchProps, 'size' | 'color'> & {
@@ -25,17 +25,18 @@ export interface SwitchTypeMap<
 }
 
 export type SwitchProps<
-  D extends React.ElementType = SwitchTypeMap['defaultComponent'],
+  D extends ElementType = SwitchTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<SwitchTypeMap<P, D>, D>;
 
-const Switch: OverridableComponent<SwitchTypeMap> = React.forwardRef(
-  function Switch({ size: passedSize = 'small', ...other }, ref) {
-    // Spark spec's large & small, Mui spec's medium and small => map large to medium.
-    const size = passedSize === 'large' ? 'medium' : passedSize;
+const Switch: OverridableComponent<SwitchTypeMap> = forwardRef(function Switch(
+  { size: passedSize = 'small', ...other },
+  ref
+) {
+  // Spark spec's large & small, Mui spec's medium and small => map large to medium.
+  const size = passedSize === 'large' ? 'medium' : passedSize;
 
-    return <MuiSwitch size={size} color="default" ref={ref} {...other} />;
-  }
-);
+  return <MuiSwitch size={size} color="default" ref={ref} {...other} />;
+});
 
 export default Switch;

--- a/libs/spark/src/Tab/Tab.stories.tsx
+++ b/libs/spark/src/Tab/Tab.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Tab, TabProps, styled } from '..';
 import {

--- a/libs/spark/src/TabContext/TabContext.stories.tsx
+++ b/libs/spark/src/TabContext/TabContext.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Box,
@@ -62,7 +62,7 @@ const Template = ({
   sb_TabList_onChange,
   ...args
 }) => {
-  const [value, setValue] = React.useState(args.value);
+  const [value, setValue] = useState(args.value);
 
   return (
     <>

--- a/libs/spark/src/Tag/Tag.stories.tsx
+++ b/libs/spark/src/Tag/Tag.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Box, Tag } from '..';
 import {

--- a/libs/spark/src/Tag/Tag.tsx
+++ b/libs/spark/src/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiChip,
@@ -32,7 +32,7 @@ type CustomClassKey =
 
 export interface TagTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P &
     Omit<MuiChipProps, 'classes' | 'size' | 'color' | 'variant'> & {
@@ -57,7 +57,7 @@ export interface TagTypeMap<
 }
 
 export type TagProps<
-  D extends React.ElementType = TagTypeMap['defaultComponent'],
+  D extends ElementType = TagTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<TagTypeMap<P, D>, D>;
 
@@ -301,7 +301,7 @@ const useCustomStyles = makeStyles<CustomClassKey>(
   { name: 'MuiSparkTag' }
 );
 
-const Tag: OverridableComponent<TagTypeMap> = React.forwardRef(function Tag(
+const Tag: OverridableComponent<TagTypeMap> = forwardRef(function Tag(
   { classes, color = 'default', variant = 'subtle', ...other },
   ref
 ) {

--- a/libs/spark/src/TextField/TextField.stories.tsx
+++ b/libs/spark/src/TextField/TextField.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { GearDuotone, QuestionDuotone } from '@prenda/spark-icons';
 import {

--- a/libs/spark/src/Typography/Typography.stories.tsx
+++ b/libs/spark/src/Typography/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Typography, TypographyProps, styled, withStyles } from '..';
 import { ChangelogTemplate } from '../../stories/templates';

--- a/libs/spark/src/Typography/Typography.tsx
+++ b/libs/spark/src/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, ForwardedRef, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiTypography,
@@ -12,7 +12,7 @@ import { OverrideProps, capitalize, useClassesCapture } from '../utils';
 export interface TypographyTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'span'
+  D extends ElementType = 'span'
 > {
   props: P &
     Omit<MuiTypographyProps, 'classes' | 'variant' | 'color'> & {
@@ -25,7 +25,7 @@ export interface TypographyTypeMap<
 }
 
 export type TypographyProps<
-  D extends React.ElementType = TypographyTypeMap['defaultComponent'],
+  D extends ElementType = TypographyTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<TypographyTypeMap<P, D>, D>;
@@ -125,8 +125,8 @@ const defaultVariantMapping: Record<SparkVariant, string> = {
   'code-sm': 'pre',
 };
 
-const Typography = React.forwardRef(function Typography<
-  D extends React.ElementType = TypographyTypeMap['defaultComponent']
+const Typography = forwardRef(function Typography<
+  D extends ElementType = TypographyTypeMap['defaultComponent']
 >(
   {
     classes,
@@ -137,7 +137,7 @@ const Typography = React.forwardRef(function Typography<
     ...other
   }: TypographyProps<D>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ref: React.ForwardedRef<any>
+  ref: ForwardedRef<any>
 ) {
   const baseCustomClasses = useCustomStyles();
 

--- a/libs/spark/src/Unstable_Avatar/Unstable_Avatar.stories.tsx
+++ b/libs/spark/src/Unstable_Avatar/Unstable_Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Avatar, Unstable_AvatarProps } from '..';
 import { sparkThemeProvider, User } from '../../stories';

--- a/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
+++ b/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiAvatar,
@@ -10,7 +10,7 @@ import { buildVariant } from '../theme/typography';
 
 export interface Unstable_AvatarTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P &
     Omit<MuiAvatarProps, 'classes' | 'variant'> & {
@@ -36,7 +36,7 @@ export interface Unstable_AvatarTypeMap<
 }
 
 export type Unstable_AvatarProps<
-  D extends React.ElementType = Unstable_AvatarTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_AvatarTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<Unstable_AvatarTypeMap<P, D>, D>;
 
@@ -146,7 +146,7 @@ const useStyles = makeStyles<Unstable_AvatarClassKey>(
   { name: 'MuiSparkUnstable_Avatar' }
 );
 
-const Unstable_Avatar: OverridableComponent<Unstable_AvatarTypeMap> = React.forwardRef(
+const Unstable_Avatar: OverridableComponent<Unstable_AvatarTypeMap> = forwardRef(
   function Unstable_Avatar(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.stories.tsx
+++ b/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_AvatarButton } from '..';
 import {

--- a/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
+++ b/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as ButtonBase,
@@ -11,7 +11,7 @@ import Unstable_Avatar, { Unstable_AvatarProps } from '../Unstable_Avatar';
 type _Unstable_AvatarButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > = ExtendButtonBaseTypeMap<{
   props: P &
     Pick<
@@ -25,7 +25,7 @@ type _Unstable_AvatarButtonTypeMap<
 export type Unstable_AvatarButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > = {
   props: Omit<
     _Unstable_AvatarButtonTypeMap<P, D>['props'],
@@ -41,7 +41,7 @@ export type Unstable_AvatarButtonTypeMap<
 };
 
 export type Unstable_AvatarButtonProps<
-  D extends React.ElementType = Unstable_AvatarButtonTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_AvatarButtonTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_AvatarButtonTypeMap<P, D>, D>;
@@ -84,7 +84,7 @@ const useStyles = makeStyles<Unstable_AvatarButtonClassKey>(
   { name: 'MuiSparkUnstable_AvatarButton' }
 );
 
-const Unstable_AvatarButton: OverridableComponent<Unstable_AvatarButtonTypeMap> = React.forwardRef(
+const Unstable_AvatarButton: OverridableComponent<Unstable_AvatarButtonTypeMap> = forwardRef(
   function Unstable_AvatarButton(props, ref) {
     const {
       alt,

--- a/libs/spark/src/Unstable_Banner/Unstable_Banner.stories.tsx
+++ b/libs/spark/src/Unstable_Banner/Unstable_Banner.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Banner } from '..';
 

--- a/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
+++ b/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import Unstable_Alert, {
@@ -59,7 +59,7 @@ const useStyles = makeStyles<Unstable_BannerClassKey>(
   { name: 'MuiSparkUnstable_Banner' }
 );
 
-const Unstable_Banner = React.forwardRef<unknown, Unstable_BannerProps>(
+const Unstable_Banner = forwardRef<unknown, Unstable_BannerProps>(
   function Unstable_Banner(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Avatar, Unstable_Button, Unstable_ButtonProps } from '..';
 import {

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { cloneElement, ElementType, forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiButton,
@@ -13,7 +13,7 @@ import { Unstable_AvatarProps } from '../Unstable_Avatar';
 export interface Unstable_ButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > {
   props: P &
     Omit<
@@ -38,22 +38,22 @@ export interface Unstable_ButtonTypeMap<
       /**
        * Avatar placed before the children.
        */
-      leadingAvatar?: React.ReactNode;
+      leadingAvatar?: ReactNode;
       /**
        * Icon placed before the children.
        */
-      leadingIcon?: React.ReactNode;
+      leadingIcon?: ReactNode;
       /**
        * Icon placed after the children.
        */
-      trailingIcon?: React.ReactNode;
+      trailingIcon?: ReactNode;
     };
   defaultComponent: D;
   classKey: Unstable_ButtonClassKey;
 }
 
 export type Unstable_ButtonProps<
-  D extends React.ElementType = Unstable_ButtonTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_ButtonTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_ButtonTypeMap<P, D>, D>;
@@ -299,7 +299,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
   { name: 'MuiSparkUnstable_Button' }
 );
 
-const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forwardRef(
+const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef(
   function Unstable_Button(props, ref) {
     const {
       children,
@@ -316,7 +316,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
 
     const classes = useStyles({ disabled, variant, size });
 
-    let leadingEl: React.ReactNode;
+    let leadingEl: ReactNode;
     if (leadingAvatar) {
       const avatarSize: Unstable_AvatarProps['size'] =
         size === 'small' ? 'small' : 'medium';
@@ -325,7 +325,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
           className={clsx(classes.leadingAvatar, classesProp?.leadingAvatar)}
         >
           {/* @ts-expect-error can't know if actually given an Unstable_Avatar instance, so prop may be invalid */}
-          {React.cloneElement(leadingAvatar, { size: avatarSize })}
+          {cloneElement(leadingAvatar, { size: avatarSize })}
         </span>
       );
     } else if (leadingIcon) {
@@ -336,7 +336,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = React.forw
       );
     }
 
-    let trailingEl: React.ReactNode;
+    let trailingEl: ReactNode;
     if (trailingIcon) {
       trailingEl = (
         <span className={clsx(classes.trailingIcon, classesProp?.trailingIcon)}>

--- a/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.stories.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Checkbox } from '..';
 import { enableHooks, sparkThemeProvider, statefulValue } from '../../stories';

--- a/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiCheckbox,
@@ -46,31 +46,30 @@ const useStyles = makeStyles<Unstable_CheckboxClassKey>(
   { name: 'MuiSparkUnstable_Checkbox' }
 );
 
-const Unstable_Checkbox = React.forwardRef<
-  HTMLButtonElement,
-  Unstable_CheckboxProps
->(function Unstable_Checkbox(props, ref) {
-  const { classes: classesProp, ...other } = props;
+const Unstable_Checkbox = forwardRef<HTMLButtonElement, Unstable_CheckboxProps>(
+  function Unstable_Checkbox(props, ref) {
+    const { classes: classesProp, ...other } = props;
 
-  const classes = useStyles();
+    const classes = useStyles();
 
-  return (
-    <MuiCheckbox
-      checkedIcon={<Unstable_CheckboxIcon checked />}
-      color="default"
-      classes={{
-        root: clsx(classes.root, classesProp?.root),
-      }}
-      disableFocusRipple
-      disableRipple
-      disableTouchRipple
-      focusRipple={false}
-      icon={<Unstable_CheckboxIcon />}
-      indeterminateIcon={<Unstable_CheckboxIcon indeterminate />}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+    return (
+      <MuiCheckbox
+        checkedIcon={<Unstable_CheckboxIcon checked />}
+        color="default"
+        classes={{
+          root: clsx(classes.root, classesProp?.root),
+        }}
+        disableFocusRipple
+        disableRipple
+        disableTouchRipple
+        focusRipple={false}
+        icon={<Unstable_CheckboxIcon />}
+        indeterminateIcon={<Unstable_CheckboxIcon indeterminate />}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
 
 export default Unstable_Checkbox;

--- a/libs/spark/src/Unstable_Checkbox/Unstable_CheckboxIcon.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_CheckboxIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';

--- a/libs/spark/src/Unstable_CssBaseline/Unstable_CssBaseline.ts
+++ b/libs/spark/src/Unstable_CssBaseline/Unstable_CssBaseline.ts
@@ -5,10 +5,10 @@ import withStyles from '../withStyles';
  *
  * @example
  *  const MyApp = () => (
- *    <React.Fragment>
+ *    <>
  *      <Unstable_CssBaseline />
  *      // rest of my app
- *    </React.Fragment>
+ *    </>
  *  )
  */
 const Unstable_CssBaseline = withStyles(

--- a/libs/spark/src/Unstable_FontFacesBaseline/Unstable_FontFacesBaseline.ts
+++ b/libs/spark/src/Unstable_FontFacesBaseline/Unstable_FontFacesBaseline.ts
@@ -7,10 +7,10 @@ import withStyles from '../withStyles';
  *
  * @example
  *  const MyApp = () => (
- *    <React.Fragment>
+ *    <>
  *      <Unstable_FontFacesBaseline />
  *      // rest of my app
- *    </React.Fragment>
+ *    </>
  */
 const Unstable_FontFacesBaseline = withStyles(
   {

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.stories.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_Checkbox,

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiFormControlLabel,
@@ -44,7 +44,7 @@ const useStyles = makeStyles<Unstable_FormControlLabelClassKey>(
   { name: 'MuiSparkUnstable_FormControlLabel' }
 );
 
-const Unstable_FormControlLabel = React.forwardRef<
+const Unstable_FormControlLabel = forwardRef<
   HTMLLabelElement,
   Unstable_FormControlLabelProps
 >(function Unstable_FormControlLabel(props, ref) {

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.stories.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_Checkbox,

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import MuiFormGroup, {
   FormGroupProps as MuiFormGroupProps,
 } from '@material-ui/core/FormGroup';
@@ -23,21 +23,20 @@ const useStyles = makeStyles<Unstable_FormGroupClassKey>(
   { name: 'MuiSparkUnstable_FormGroup' }
 );
 
-const Unstable_FormGroup = React.forwardRef<
-  HTMLDivElement,
-  Unstable_FormGroupProps
->(function Unstable_FormGroup(props, ref) {
-  const { classes: classesProp, ...other } = props;
+const Unstable_FormGroup = forwardRef<HTMLDivElement, Unstable_FormGroupProps>(
+  function Unstable_FormGroup(props, ref) {
+    const { classes: classesProp, ...other } = props;
 
-  const classes = useStyles();
+    const classes = useStyles();
 
-  return (
-    <MuiFormGroup
-      classes={{ root: clsx(classes.root, classesProp?.root) }}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+    return (
+      <MuiFormGroup
+        classes={{ root: clsx(classes.root, classesProp?.root) }}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
 
 export default Unstable_FormGroup;

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import MuiFormGroup, {
   FormGroupProps as MuiFormGroupProps,
 } from '@material-ui/core/FormGroup';

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.stories.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_FormHelperText,
@@ -62,10 +62,10 @@ Required.storyName = 'required';
 export const LeadingIcon: Story = Template.bind({});
 LeadingIcon.args = {
   children: (
-    <React.Fragment>
+    <>
       <Info fontSize="small" />
       Helper text
-    </React.Fragment>
+    </>
   ),
 };
 LeadingIcon.storyName = '(leading icon)';
@@ -73,10 +73,10 @@ LeadingIcon.storyName = '(leading icon)';
 export const LeadingIconError: Story = Template.bind({});
 LeadingIconError.args = {
   children: (
-    <React.Fragment>
+    <>
       <Info fontSize="small" />
       Helper text
-    </React.Fragment>
+    </>
   ),
   error: true,
 };

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import MuiFormHelperText, {
   FormHelperTextProps as MuiFormHelperTextProps,
 } from '@material-ui/core/FormHelperText';
@@ -9,7 +9,7 @@ import { OverridableComponent, OverrideProps } from '../utils';
 export interface Unstable_FormHelperTextTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'p'
+  D extends ElementType = 'p'
 > {
   props: P & Omit<MuiFormHelperTextProps, 'filled' | 'margin' | 'variant'>;
   defaultComponent: D;
@@ -19,7 +19,7 @@ export interface Unstable_FormHelperTextTypeMap<
 export type Unstable_FormHelperTextClassKey = 'root';
 
 export type Unstable_FormHelperTextProps<
-  D extends React.ElementType = Unstable_FormHelperTextTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_FormHelperTextTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_FormHelperTextTypeMap<P, D>, D>;
@@ -56,7 +56,7 @@ const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
   { name: 'MuiSparkUnstable_FormHelperText' }
 );
 
-const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeMap> = React.forwardRef(
+const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeMap> = forwardRef(
   function Unstable_FormHelperText(props, ref) {
     const { classes: classesProp, disabled, error, ...other } = props;
 

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.stories.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_FormLabel } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import MuiFormLabel, {
   FormLabelProps as MuiFormLabelProps,
 } from '@material-ui/core/FormLabel';
@@ -9,7 +9,7 @@ import { OverridableComponent, OverrideProps } from '../utils';
 export interface Unstable_FormLabelTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'label'
+  D extends ElementType = 'label'
 > {
   props: P & Omit<MuiFormLabelProps, 'classes' | 'color' | 'filled'>;
   defaultComponent: D;
@@ -17,7 +17,7 @@ export interface Unstable_FormLabelTypeMap<
 }
 
 export type Unstable_FormLabelProps<
-  D extends React.ElementType = Unstable_FormLabelTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_FormLabelTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_FormLabelTypeMap<P, D>, D>;
@@ -51,7 +51,7 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
   { name: 'MuiSparkUnstable_FormLabel' }
 );
 
-const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> = React.forwardRef(
+const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> = forwardRef(
   function Unstable_FormLabel(props, ref) {
     const { classes: classesProp, color: _color, ...other } = props;
 

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { theme, Unstable_IconButton, Unstable_IconButtonProps } from '..';
 import {

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiIconButton,
@@ -11,7 +11,7 @@ import { lighten, darken, alpha } from '@material-ui/core/styles';
 export interface Unstable_IconButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'button'
+  D extends ElementType = 'button'
 > {
   props: P &
     Omit<
@@ -44,7 +44,7 @@ export interface Unstable_IconButtonTypeMap<
 }
 
 export type Unstable_IconButtonProps<
-  D extends React.ElementType = Unstable_IconButtonTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_IconButtonTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_IconButtonTypeMap<P, D>, D>;
@@ -161,7 +161,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
   { name: 'MuiSparkUnstable_IconButton' }
 );
 
-const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = React.forwardRef(
+const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = forwardRef(
   function Unstable_IconButton(props, ref) {
     const {
       color = 'standard',

--- a/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_Input,

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiInputBase,
@@ -24,11 +24,11 @@ export interface Unstable_InputProps
   /**
    * The content of the `startAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
    */
-  leadingEl?: React.ReactNode;
+  leadingEl?: ReactNode;
   /**
    * The content of the `endAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
    */
-  trailingEl?: React.ReactNode;
+  trailingEl?: ReactNode;
   /**
    * If `true`, the input will indicate a success.
    */
@@ -149,7 +149,7 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
   { name: 'MuiSparkUnstable_Input' }
 );
 
-const Unstable_Input = React.forwardRef(function Unstable_Input(
+const Unstable_Input = forwardRef(function Unstable_Input(
   props: Unstable_InputProps,
   ref
 ) {

--- a/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.stories.tsx
+++ b/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_InputAdornment,

--- a/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
+++ b/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import makeStyles from '../makeStyles';
 import { OverridableComponent, OverrideProps } from '../utils';
 
 export interface Unstable_InputAdornmentTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P & {
     position: 'start' | 'end';
@@ -18,7 +18,7 @@ export interface Unstable_InputAdornmentTypeMap<
 export type Unstable_InputAdornmentClassKey = 'root';
 
 export type Unstable_InputAdornmentProps<
-  D extends React.ElementType = Unstable_InputAdornmentTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_InputAdornmentTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_InputAdornmentTypeMap<P, D>, D>;
@@ -52,7 +52,7 @@ const useStyles = makeStyles<Unstable_InputAdornmentClassKey>(
   { name: 'MuiSparkUnstable_InputAdornment' }
 );
 
-const Unstable_InputAdornment: OverridableComponent<Unstable_InputAdornmentTypeMap> = React.forwardRef(
+const Unstable_InputAdornment: OverridableComponent<Unstable_InputAdornmentTypeMap> = forwardRef(
   function Unstable_InputAdornment(props, ref) {
     const {
       children,

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.stories.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_InputLabel, Unstable_InputLabelProps } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef, RefObject } from 'react';
 import MuiInputLabel, {
   InputLabelProps as MuiInputLabelProps,
 } from '@material-ui/core/InputLabel';
@@ -48,9 +48,9 @@ const useStyles = makeStyles<Unstable_InputLabelClassKey>(
   { name: 'MuiSparkUnstable_InputLabel' }
 );
 
-const Unstable_InputLabel = React.forwardRef(function Unstable_InputLabel(
+const Unstable_InputLabel = forwardRef(function Unstable_InputLabel(
   props: Unstable_InputLabelProps,
-  ref: React.RefObject<HTMLLabelElement>
+  ref: RefObject<HTMLLabelElement>
 ) {
   const { classes: classesProp, ...other } = props;
 

--- a/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Link, Unstable_LinkProps } from '..';
 

--- a/libs/spark/src/Unstable_Link/Unstable_Link.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiLink,
@@ -10,7 +10,7 @@ import { OverridableComponent, OverrideProps } from '../utils';
 export interface Unstable_LinkTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'a'
+  D extends ElementType = 'a'
 > {
   props: P &
     Omit<MuiLinkProps, 'color' | 'classes' | 'underline'> & {
@@ -28,7 +28,7 @@ export interface Unstable_LinkTypeMap<
 }
 
 export type Unstable_LinkProps<
-  D extends React.ElementType = Unstable_LinkTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_LinkTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_LinkTypeMap<P, D>, D>;
@@ -67,7 +67,7 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
   { name: 'MuiSparkUnstable_Link' }
 );
 
-const Unstable_Link: OverridableComponent<Unstable_LinkTypeMap> = React.forwardRef(
+const Unstable_Link: OverridableComponent<Unstable_LinkTypeMap> = forwardRef(
   function Unstable_Link(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.stories.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Radio } from '..';
 import { enableHooks, sparkThemeProvider, statefulValue } from '../../stories';

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiRadio,
@@ -47,7 +47,7 @@ const useStyles = makeStyles<Unstable_RadioClassKey>(
   { name: 'MuiSparkUnstable_Radio' }
 );
 
-const Unstable_Radio = React.forwardRef<HTMLButtonElement, Unstable_RadioProps>(
+const Unstable_Radio = forwardRef<HTMLButtonElement, Unstable_RadioProps>(
   function Unstable_Radio(props, ref) {
     const { classes: classesProp, ...other } = props;
 

--- a/libs/spark/src/Unstable_Radio/Unstable_RadioIcon.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_RadioIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   Unstable_Radio,

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef } from 'react';
 import MuiRadioGroup, {
   RadioGroupProps as MuiRadioGroupProps,
 } from '@material-ui/core/RadioGroup';
@@ -23,7 +23,7 @@ const useStyles = makeStyles<Unstable_RadioGroupClassKey>(
   { name: 'MuiSparkUnstable_RadioGroup' }
 );
 
-const Unstable_RadioGroup = React.forwardRef<
+const Unstable_RadioGroup = forwardRef<
   HTMLDivElement,
   Unstable_RadioGroupProps
 >(function Unstable_RadioGroup(props, ref) {

--- a/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.stories.tsx
+++ b/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_SectionMessage } from '..';
 

--- a/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
+++ b/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import Unstable_Alert, {
@@ -13,7 +13,7 @@ export interface Unstable_SectionMessageProps
   /**
    * Display a formatted title above the section message.
    */
-  title?: React.ReactNode;
+  title?: ReactNode;
 }
 
 export type Unstable_SectionMessageClassKey = Unstable_AlertClassKey | 'title';
@@ -78,7 +78,7 @@ const useStyles = makeStyles<Unstable_SectionMessageClassKey>(
   { name: 'MuiSparkUnstable_SectionMessage' }
 );
 
-const Unstable_SectionMessage = React.forwardRef<
+const Unstable_SectionMessage = forwardRef<
   unknown,
   Unstable_SectionMessageProps
 >(function Unstable_SectionMessage(props, ref) {

--- a/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   MenuItem,

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { cloneElement, CSSProperties, forwardRef } from 'react';
 import { SelectProps as MuiSelectProps } from '@material-ui/core/Select';
 import MuiSelectInput, {
   SelectInputProps as MuiSelectInputProps,
@@ -19,7 +19,7 @@ declare module '@material-ui/core/NativeSelect/NativeSelect' {
     theme: Theme
   ) => Record<
     'root' | 'select' | 'selectMenu' | 'icon' | 'iconOpen' | 'nativeInput',
-    React.CSSProperties
+    CSSProperties
   >;
 }
 
@@ -126,7 +126,7 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
   { name: 'MuiSparkUnstable_Select' }
 );
 
-const Unstable_Select = React.forwardRef(function Unstable_Select(
+const Unstable_Select = forwardRef(function Unstable_Select(
   props: Unstable_SelectProps,
   ref
 ) {
@@ -202,7 +202,7 @@ const Unstable_Select = React.forwardRef(function Unstable_Select(
     };
   }
 
-  return React.cloneElement(InputComponent, {
+  return cloneElement(InputComponent, {
     disabled,
     inputComponent,
     inputProps: {

--- a/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.stories.tsx
+++ b/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_SvgIcon } from '..';
 

--- a/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
+++ b/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiSvgIcon,
@@ -10,7 +10,7 @@ import { OverridableComponent, OverrideProps } from '../utils';
 export interface Unstable_SvgIconTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'svg'
+  D extends ElementType = 'svg'
 > {
   props: P &
     Omit<MuiSvgIconProps, 'classes' | 'color' | 'fontSize'> & {
@@ -35,7 +35,7 @@ export interface Unstable_SvgIconTypeMap<
 }
 
 export type Unstable_SvgIconProps<
-  D extends React.ElementType = Unstable_SvgIconTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_SvgIconTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_SvgIconTypeMap<P, D>, D>;
@@ -79,7 +79,7 @@ const useStyles = makeStyles<Unstable_SvgIconClassKey>(
   { name: 'MuiSparkUnstable_SvgIcon' }
 );
 
-const Unstable_SvgIcon: OverridableComponent<Unstable_SvgIconTypeMap> = React.forwardRef(
+const Unstable_SvgIcon: OverridableComponent<Unstable_SvgIconTypeMap> = forwardRef(
   function Unstable_SvgIcon(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Tag, unstable_createSvgIcon } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiChip,
@@ -12,7 +12,7 @@ import { alpha, darken } from '@material-ui/core/styles';
 
 export interface Unstable_TagTypeMap<
   P = Record<string, unknown>,
-  D extends React.ElementType = 'div'
+  D extends ElementType = 'div'
 > {
   props: P &
     Omit<
@@ -44,7 +44,7 @@ export interface Unstable_TagTypeMap<
 }
 
 export type Unstable_TagProps<
-  D extends React.ElementType = Unstable_TagTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_TagTypeMap['defaultComponent'],
   P = Record<string, unknown>
 > = OverrideProps<Unstable_TagTypeMap<P, D>, D>;
 
@@ -243,7 +243,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
   { name: 'MuiSparkUnstable_Tag' }
 );
 
-const Unstable_Tag: OverridableComponent<Unstable_TagTypeMap> = React.forwardRef(
+const Unstable_Tag: OverridableComponent<Unstable_TagTypeMap> = forwardRef(
   function Unstable_Tag(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.stories.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   MenuItem,

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -1,4 +1,10 @@
-import * as React from 'react';
+import React, {
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+  Ref,
+  RefObject,
+} from 'react';
 import clsx from 'clsx';
 import Unstable_Input, { Unstable_InputProps } from '../Unstable_Input';
 import Unstable_InputLabel, {
@@ -35,7 +41,7 @@ export interface Unstable_TextFieldProps
   /**
    * @ignore
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /**
    * The default value of the `input` element.
    */
@@ -59,7 +65,7 @@ export interface Unstable_TextFieldProps
   /**
    * The helper text content.
    */
-  helperText?: React.ReactNode;
+  helperText?: ReactNode;
   /**
    * The id of the `input` element.
    * Use this prop to make `label` and `helperText` accessible for screen readers.
@@ -81,15 +87,15 @@ export interface Unstable_TextFieldProps
    * Pass a ref to the `input` element.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inputRef?: React.Ref<any>;
+  inputRef?: Ref<any>;
   /**
    * The label content.
    */
-  label?: React.ReactNode;
+  label?: ReactNode;
   /**
    * The content of the `startAdornment` (InputAdornment), usually an Icon, IconButton, or string.
    */
-  leadingEl?: React.ReactNode;
+  leadingEl?: ReactNode;
   /**
    * If `true`, a textarea element will be rendered instead of an input.
    */
@@ -139,11 +145,11 @@ export interface Unstable_TextFieldProps
   /**
    * The content of the `endAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
    */
-  trailingEl?: React.ReactNode;
+  trailingEl?: ReactNode;
   /**
    * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
    */
-  type?: React.InputHTMLAttributes<unknown>['type'];
+  type?: InputHTMLAttributes<unknown>['type'];
   /**
    * The value of the `input` element, required for a controlled component.
    */
@@ -156,7 +162,7 @@ const useStyles = makeStyles<Unstable_TextFieldClassKey>((theme) => ({
   root: {},
 }));
 
-const Unstable_TextField = React.forwardRef(function TextField(
+const Unstable_TextField = forwardRef(function TextField(
   props: Unstable_TextFieldProps,
   ref
 ) {
@@ -256,7 +262,7 @@ const Unstable_TextField = React.forwardRef(function TextField(
       disabled={disabled}
       error={error}
       fullWidth={fullWidth}
-      ref={(ref as unknown) as React.RefObject<HTMLDivElement>}
+      ref={(ref as unknown) as RefObject<HTMLDivElement>}
       required={required}
       {...other}
     >

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_Typography, Unstable_TypographyProps } from '..';
 import { inverseBackground, sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ElementType, forwardRef } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiTypography,
@@ -11,7 +11,7 @@ import { Unstable_TypographyVariant } from '../theme/unstable_typography';
 export interface Unstable_TypographyTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
-  D extends React.ElementType = 'span'
+  D extends ElementType = 'span'
 > {
   props: P &
     Omit<MuiTypographyProps, 'classes' | 'variant' | 'color'> & {
@@ -33,7 +33,7 @@ export interface Unstable_TypographyTypeMap<
 }
 
 export type Unstable_TypographyProps<
-  D extends React.ElementType = Unstable_TypographyTypeMap['defaultComponent'],
+  D extends ElementType = Unstable_TypographyTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
 > = OverrideProps<Unstable_TypographyTypeMap<P, D>, D>;
@@ -139,7 +139,7 @@ const defaultVariantMapping: Record<Unstable_TypographyVariant, string> = {
   code: 'pre',
 };
 
-const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = React.forwardRef(
+const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = forwardRef(
   function Unstable_Typography(props, ref) {
     const {
       classes: classesProp,

--- a/libs/spark/src/internal/AlertOctagonFilled.tsx
+++ b/libs/spark/src/internal/AlertOctagonFilled.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/AlertThick.tsx
+++ b/libs/spark/src/internal/AlertThick.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/AlertTriangleFilled.tsx
+++ b/libs/spark/src/internal/AlertTriangleFilled.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/ArrowRight.tsx
+++ b/libs/spark/src/internal/ArrowRight.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/CheckCircleFilled.tsx
+++ b/libs/spark/src/internal/CheckCircleFilled.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/CheckThick.tsx
+++ b/libs/spark/src/internal/CheckThick.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/ChevronDown.tsx
+++ b/libs/spark/src/internal/ChevronDown.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/ChevronRight.tsx
+++ b/libs/spark/src/internal/ChevronRight.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/Cross.tsx
+++ b/libs/spark/src/internal/Cross.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/CrossSmall.tsx
+++ b/libs/spark/src/internal/CrossSmall.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/InfoFilled.tsx
+++ b/libs/spark/src/internal/InfoFilled.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createSvgIcon from '../utils/createSvgIcon';
 
 export default createSvgIcon(

--- a/libs/spark/src/internal/Unstable_Alert.tsx
+++ b/libs/spark/src/internal/Unstable_Alert.tsx
@@ -1,6 +1,6 @@
 import Paper, { PaperProps } from '@material-ui/core/Paper';
 import clsx from 'clsx';
-import * as React from 'react';
+import React, { forwardRef, ReactNode, SyntheticEvent } from 'react';
 import Unstable_AlertTriangle from './Unstable_AlertTriangle';
 import Unstable_AlertOctagon from './Unstable_AlertOctagon';
 import Unstable_CheckCircle2 from './Unstable_CheckCircle2';
@@ -20,7 +20,7 @@ export interface Unstable_AlertProps
   /**
    * The action to display. It renders after the message, at the end of the component.
    */
-  action?: React.ReactNode;
+  action?: ReactNode;
   /**
    * Override the default label for the *close popup* icon button.
    */
@@ -32,7 +32,7 @@ export interface Unstable_AlertProps
   /**
    * Override the icon displayed before the children. (By default, the icon displayed is mapped to the value of the `severity` prop.)
    */
-  icon?: React.ReactNode | false;
+  icon?: ReactNode | false;
   /**
    * The ARIA role attribute of the element.
    */
@@ -43,7 +43,7 @@ export interface Unstable_AlertProps
    *
    * @param {object} event The event source of the callback.
    */
-  onClose?: (event: React.SyntheticEvent) => void;
+  onClose?: (event: SyntheticEvent) => void;
   /**
    * Props applied to the *close alert* icon button.
    */
@@ -59,7 +59,7 @@ const defaultIconMapping = {
   info: <Unstable_Info />,
 };
 
-const Unstable_Alert = React.forwardRef(function Unstable_Alert(
+const Unstable_Alert = forwardRef(function Unstable_Alert(
   props: Unstable_AlertProps,
   ref
 ) {

--- a/libs/spark/src/internal/Unstable_AlertOctagon.tsx
+++ b/libs/spark/src/internal/Unstable_AlertOctagon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_AlertTriangle.tsx
+++ b/libs/spark/src/internal/Unstable_AlertTriangle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_CheckCircle2.tsx
+++ b/libs/spark/src/internal/Unstable_CheckCircle2.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_ChevronDown.tsx
+++ b/libs/spark/src/internal/Unstable_ChevronDown.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_Cross.tsx
+++ b/libs/spark/src/internal/Unstable_Cross.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_CrossSmall.tsx
+++ b/libs/spark/src/internal/Unstable_CrossSmall.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_Filter.tsx
+++ b/libs/spark/src/internal/Unstable_Filter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/internal/Unstable_Info.tsx
+++ b/libs/spark/src/internal/Unstable_Info.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import unstable_createSvgIcon from '../unstable_createSvgIcon';
 
 export default unstable_createSvgIcon(

--- a/libs/spark/src/makeStyles/makeStyles.spec.tsx
+++ b/libs/spark/src/makeStyles/makeStyles.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { stub } from 'sinon';
 import makeStyles from './makeStyles';

--- a/libs/spark/src/styled/styled.spec.tsx
+++ b/libs/spark/src/styled/styled.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { stub } from 'sinon';
 import styled from './styled';

--- a/libs/spark/src/styled/styled.ts
+++ b/libs/spark/src/styled/styled.ts
@@ -1,3 +1,4 @@
+import { ComponentProps, ComponentType, ElementType } from 'react';
 import {
   default as muiStyled,
   StyledProps,
@@ -12,7 +13,7 @@ import initialTheme from '../theme/initialTheme';
 
 export type { StyledProps };
 
-export type ComponentCreator<Component extends React.ElementType> = <
+export type ComponentCreator<Component extends ElementType> = <
   Theme = DefaultTheme,
   // eslint-disable-next-line @typescript-eslint/ban-types
   Props extends {} = {}
@@ -21,9 +22,9 @@ export type ComponentCreator<Component extends React.ElementType> = <
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>
-) => React.ComponentType<
+) => ComponentType<
   Omit<
-    JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
+    JSX.LibraryManagedAttributes<Component, ComponentProps<Component>>,
     'classes' | 'className'
   > &
     StyledComponentProps<'root'> & { className?: string } & (Props extends {
@@ -33,7 +34,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
       : Props)
 >;
 
-const styled = <Component extends React.ElementType>(
+const styled = <Component extends ElementType>(
   Component: Component
 ): ComponentCreator<Component> => {
   const componentCreator = muiStyled(Component);

--- a/libs/spark/src/theme/palette.stories.tsx
+++ b/libs/spark/src/theme/palette.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { styled, useTheme } from '..';
 import { sparkThemeProvider } from '../../stories';

--- a/libs/spark/src/theme/unstable_fontFaces.stories.tsx
+++ b/libs/spark/src/theme/unstable_fontFaces.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ScopedCssBaseline, styled, withStyles } from '..';
 import { VariantUseFor } from './unstable_typography.stories';

--- a/libs/spark/src/theme/unstable_palette.stories.tsx
+++ b/libs/spark/src/theme/unstable_palette.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { styled, theme, Theme } from '..';
 

--- a/libs/spark/src/theme/unstable_typography.stories.tsx
+++ b/libs/spark/src/theme/unstable_typography.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { ScopedCssBaseline, styled, withStyles } from '..';
 

--- a/libs/spark/src/unstable_createSvgIcon.tsx
+++ b/libs/spark/src/unstable_createSvgIcon.tsx
@@ -1,11 +1,11 @@
 // Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui/src/utils/createSvgIcon.js
 //  Changes made since
 
-import * as React from 'react';
+import React, { forwardRef, memo, ReactNode } from 'react';
 import Unstable_SvgIcon, { Unstable_SvgIconProps } from './Unstable_SvgIcon';
 
 const unstable_createSvgIcon = (
-  path: React.ReactNode,
+  path: ReactNode,
   displayName: string,
   viewBox?: string,
   width?: string,
@@ -29,14 +29,14 @@ const unstable_createSvgIcon = (
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    // Need to set `displayName` on the inner component for React.memo.
+    // Need to set `displayName` on the inner component for `memo`.
     // React prior to 16.14 ignores `displayName` on the wrapper.
     Component.displayName = `${displayName}Icon`;
   }
 
   Component.muiName = 'Unstable_SvgIcon';
 
-  return React.memo(React.forwardRef(Component)) as typeof Unstable_SvgIcon;
+  return memo(forwardRef(Component)) as typeof Unstable_SvgIcon;
 };
 
 export default unstable_createSvgIcon;

--- a/libs/spark/src/utils/StandardProps.ts
+++ b/libs/spark/src/utils/StandardProps.ts
@@ -1,3 +1,4 @@
+import { CSSProperties, Ref } from 'react';
 import { StyledComponentProps } from '../withStyles';
 
 export { StyledComponentProps };
@@ -15,6 +16,6 @@ export type StandardProps<
 > = Omit<C, 'classes' | Removals> &
   StyledComponentProps<ClassKey> & {
     className?: string;
-    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
-    style?: React.CSSProperties;
+    ref?: C extends { ref?: infer RefType } ? RefType : Ref<unknown>;
+    style?: CSSProperties;
   };

--- a/libs/spark/src/utils/createSvgIcon.tsx
+++ b/libs/spark/src/utils/createSvgIcon.tsx
@@ -1,12 +1,12 @@
 // Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui/src/utils/createSvgIcon.js
 //  Changes made since
 
-import * as React from 'react';
+import React, { forwardRef, memo, ReactNode } from 'react';
 import SvgIcon from '../SvgIcon';
 import type { SvgIconProps } from '../SvgIcon';
 
 export default function createSvgIcon(
-  path: React.ReactNode,
+  path: ReactNode,
   displayName: string,
   viewBox?: string,
   width?: string,
@@ -30,12 +30,12 @@ export default function createSvgIcon(
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    // Need to set `displayName` on the inner component for React.memo.
+    // Need to set `displayName` on the inner component for `memo`.
     // React prior to 16.14 ignores `displayName` on the wrapper.
     Component.displayName = `${displayName}Icon`;
   }
 
   Component.muiName = 'SvgIcon';
 
-  return React.memo(React.forwardRef(Component)) as typeof SvgIcon;
+  return memo(forwardRef(Component)) as typeof SvgIcon;
 }

--- a/libs/spark/src/utils/useId.ts
+++ b/libs/spark/src/utils/useId.ts
@@ -34,6 +34,6 @@ export default function useId(idOverride?: string): string | undefined {
     const reactId = maybeReactUseId();
     return idOverride ?? reactId;
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- `React.useId` is invariant at runtime.
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- `useId` is invariant at runtime.
   return useGlobalId(idOverride);
 }

--- a/libs/spark/stories/Illustrations.stories.tsx
+++ b/libs/spark/stories/Illustrations.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   BookIllustration,

--- a/libs/spark/stories/Logos.stories.tsx
+++ b/libs/spark/stories/Logos.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   PrendaWordmark,

--- a/libs/spark/stories/anron-icons/AlertCircle.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircle.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircle } from '@prenda/spark-icons';
 

--- a/libs/spark/stories/anron-icons/AlertCircleDuotone.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircleDuotone.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircleDuotone } from '@prenda/spark-icons';
 

--- a/libs/spark/stories/anron-icons/AlertCircleFilled.stories.tsx
+++ b/libs/spark/stories/anron-icons/AlertCircleFilled.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { AlertCircleFilled } from '@prenda/spark-icons';
 

--- a/libs/spark/stories/templates/changelog-template.tsx
+++ b/libs/spark/stories/templates/changelog-template.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Li, Root, SmCode } from './documentation-template';
 
 const ChangelogTemplate = ({

--- a/libs/spark/stories/templates/documentation-template.tsx
+++ b/libs/spark/stories/templates/documentation-template.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Box, Typography, styled, withStyles } from '../../src';
 
 export const Root = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Makes the (currently arbitrary) switch from using the wildcard import to only named imports.

I introduced only doing wildcard imports a while back under the pretense that React attaching everything to the default export was in limbo. That may or may not be true, but with the advent of the new jsx transforms and not needing even the default React imports in future versions, I think only doing named imports is the better choice.