### PR TITLE
feat: remove margin from Input and related components

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -69,6 +69,10 @@ _This section details previews of breaking changes or experimental features that
     - values: `"standard" | "inverse"`
     - default value: `"standard"`
     - (does not affect display of `"primary" | "stroked"` variants yet -- planned for future)
+- **Unstable_Input**
+  - Remove default margin that accounted for the box-shadow effects.
+- **Unstable_InputLabel**
+  - Remove default left-margin.
 - **Unstable_FormGroup**
   - Initial implementation of **FormGroup** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -76,6 +80,8 @@ _This section details previews of breaking changes or experimental features that
     - Removed all class keys _except `'root'`_.
   - Props API Changes:
     - `classes`: removed all class keys _except `'root'`_
+- **Unstable_FormHelperText**
+  - Remove default left-margin.
 - **Unstable_FormLabel**
   - Initial implementation of **FormLabel** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -105,6 +111,10 @@ _This section details previews of breaking changes or experimental features that
 - **Unstable_SectionMessage**
   - Fix `closeText` not being applied to the _close_ icon button (resulted in not having an accessible name, i.e. `aria-label`).
   - Add `CloseProps` prop to apply props to the _close_ icon button.
+- **Unstable_Select**
+  - (see Unstable_Input)
+- **Unstable_TextField**
+  - (see Unstable_Input, Unstable_InputLabel, Unstable_FormHelperText)
 
 ## [v1.0.0-alpha.8](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2022-06-03)
 

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -33,8 +33,7 @@ const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
       display: 'flex',
       gap: 4,
       letterSpacing: 0,
-      marginLeft: 4, // match margin of Input
-      marginTop: 4,
+      width: 'fit-content',
       /* Styles applied to the `input` element if `disabled={true}`. */
       ...(props.disabled && {
         color: theme.unstable_palette.text.disabled,
@@ -50,6 +49,10 @@ const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
       // duped because underlying component can set this independently based on form control context
       '&.Mui-error': {
         color: theme.unstable_palette.red[700],
+      },
+      // double-specificity to override PDS v1
+      '&&': {
+        marginTop: 8,
       },
     }),
   }),

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
     root: {
       ...theme.unstable_typography.label,
       color: theme.unstable_palette.neutral[600],
+      marginBottom: 8,
       '&.Mui-disabled': {
         color: theme.unstable_palette.text.disabled,
       },

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -50,7 +50,6 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
       borderRadius: 4,
       color: theme.unstable_palette.text.body,
       letterSpacing: 0,
-      margin: 4, // avoid potential box-shadow width getting cut-off
       width: theme.unstable_typography.pxToRem(320),
       '&:hover': {
         backgroundColor: theme.unstable_palette.neutral[60],

--- a/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
+++ b/libs/spark/src/Unstable_InputLabel/Unstable_InputLabel.tsx
@@ -27,8 +27,7 @@ const useStyles = makeStyles<Unstable_InputLabelClassKey>(
     root: {
       ...theme.unstable_typography.label,
       color: theme.unstable_palette.neutral[600],
-      marginBottom: 4,
-      marginLeft: 4, // match margin of Input
+      marginBottom: 8,
       '&.Mui-disabled': {
         color: theme.unstable_palette.neutral[100],
       },


### PR DESCRIPTION
We don't add margin to other components that have box shadow effects, but we did for Input. This is probably best to leave to the consumer or consuming component instead.

This was causing a problem in the upcoming FormControl story / integration for Checkbox / Radio groups since we don't give a radio/checkbox a default margin but we expect the helper text / form label to be aligned -- it wasn't with the left-margins.