### PR TITLE
feat: improve component typings

### DIFF
--- a/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiCheckbox,
@@ -46,7 +46,7 @@ const useStyles = makeStyles<Unstable_CheckboxClassKey>(
   { name: 'MuiSparkUnstable_Checkbox' }
 );
 
-const Unstable_Checkbox = forwardRef<HTMLButtonElement, Unstable_CheckboxProps>(
+const Unstable_Checkbox = forwardRef<unknown, Unstable_CheckboxProps>(
   function Unstable_Checkbox(props, ref) {
     const { classes: classesProp, ...other } = props;
 
@@ -65,7 +65,7 @@ const Unstable_Checkbox = forwardRef<HTMLButtonElement, Unstable_CheckboxProps>(
         focusRipple={false}
         icon={<Unstable_CheckboxIcon />}
         indeterminateIcon={<Unstable_CheckboxIcon indeterminate />}
-        ref={ref}
+        ref={ref as Ref<HTMLButtonElement>}
         {...other}
       />
     );

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles<Unstable_FormControlLabelClassKey>(
 );
 
 const Unstable_FormControlLabel = forwardRef<
-  HTMLLabelElement,
+  unknown,
   Unstable_FormControlLabelProps
 >(function Unstable_FormControlLabel(props, ref) {
   const { classes: classesProp, disabled, ...other } = props;

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles<Unstable_FormGroupClassKey>(
   { name: 'MuiSparkUnstable_FormGroup' }
 );
 
-const Unstable_FormGroup = forwardRef<HTMLDivElement, Unstable_FormGroupProps>(
+const Unstable_FormGroup = forwardRef<unknown, Unstable_FormGroupProps>(
   function Unstable_FormGroup(props, ref) {
     const { classes: classesProp, ...other } = props;
 

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -148,63 +148,62 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
   { name: 'MuiSparkUnstable_Input' }
 );
 
-const Unstable_Input = forwardRef(function Unstable_Input(
-  props: Unstable_InputProps,
-  ref
-) {
-  const {
-    classes: classesProp,
-    disabled,
-    error,
-    leadingEl,
-    multiline,
-    placeholder,
-    success,
-    trailingEl,
-    value,
-    ...other
-  } = props;
+const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
+  function Unstable_Input(props, ref) {
+    const {
+      classes: classesProp,
+      disabled,
+      error,
+      leadingEl,
+      multiline,
+      placeholder,
+      success,
+      trailingEl,
+      value,
+      ...other
+    } = props;
 
-  const classes = useStyles({
-    disabled,
-    error,
-    leadingEl,
-    multiline,
-    placeholder,
-    success,
-    trailingEl,
-    value,
-  });
+    const classes = useStyles({
+      disabled,
+      error,
+      leadingEl,
+      multiline,
+      placeholder,
+      success,
+      trailingEl,
+      value,
+    });
 
-  return (
-    <MuiInputBase
-      classes={{
-        root: clsx(classes.root, classesProp?.root),
-        input: clsx(classes.input, classesProp?.input),
-      }}
-      disabled={disabled}
-      endAdornment={
-        trailingEl ? (
-          <Unstable_InputAdornment position="end">
-            {trailingEl}
-          </Unstable_InputAdornment>
-        ) : undefined
-      }
-      error={error}
-      multiline={multiline}
-      placeholder={placeholder}
-      startAdornment={
-        leadingEl ? (
-          <Unstable_InputAdornment position="start">
-            {leadingEl}
-          </Unstable_InputAdornment>
-        ) : undefined
-      }
-      value={value}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+    return (
+      <MuiInputBase
+        classes={{
+          root: clsx(classes.root, classesProp?.root),
+          input: clsx(classes.input, classesProp?.input),
+        }}
+        disabled={disabled}
+        endAdornment={
+          trailingEl ? (
+            <Unstable_InputAdornment position="end">
+              {trailingEl}
+            </Unstable_InputAdornment>
+          ) : undefined
+        }
+        error={error}
+        multiline={multiline}
+        placeholder={placeholder}
+        startAdornment={
+          leadingEl ? (
+            <Unstable_InputAdornment position="start">
+              {leadingEl}
+            </Unstable_InputAdornment>
+          ) : undefined
+        }
+        value={value}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
 
 export default Unstable_Input;

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import clsx from 'clsx';
 import {
   default as MuiRadio,
@@ -47,7 +47,7 @@ const useStyles = makeStyles<Unstable_RadioClassKey>(
   { name: 'MuiSparkUnstable_Radio' }
 );
 
-const Unstable_Radio = forwardRef<HTMLButtonElement, Unstable_RadioProps>(
+const Unstable_Radio = forwardRef<unknown, Unstable_RadioProps>(
   function Unstable_Radio(props, ref) {
     const { classes: classesProp, ...other } = props;
 
@@ -65,7 +65,7 @@ const Unstable_Radio = forwardRef<HTMLButtonElement, Unstable_RadioProps>(
         disableTouchRipple
         focusRipple={false}
         icon={<Unstable_RadioIcon />}
-        ref={ref}
+        ref={ref as Ref<HTMLButtonElement>}
         {...other}
       />
     );

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -23,21 +23,20 @@ const useStyles = makeStyles<Unstable_RadioGroupClassKey>(
   { name: 'MuiSparkUnstable_RadioGroup' }
 );
 
-const Unstable_RadioGroup = forwardRef<
-  HTMLDivElement,
-  Unstable_RadioGroupProps
->(function Unstable_RadioGroup(props, ref) {
-  const { classes: classesProp, ...other } = props;
+const Unstable_RadioGroup = forwardRef<unknown, Unstable_RadioGroupProps>(
+  function Unstable_RadioGroup(props, ref) {
+    const { classes: classesProp, ...other } = props;
 
-  const classes = useStyles();
+    const classes = useStyles();
 
-  return (
-    <MuiRadioGroup
-      classes={{ root: clsx(classes.root, classesProp?.root) }}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+    return (
+      <MuiRadioGroup
+        classes={{ root: clsx(classes.root, classesProp?.root) }}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
 
 export default Unstable_RadioGroup;

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -126,124 +126,131 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
   { name: 'MuiSparkUnstable_Select' }
 );
 
-const Unstable_Select = forwardRef(function Unstable_Select(
-  props: Unstable_SelectProps,
-  ref
-) {
-  const {
-    autoWidth = false,
-    children,
-    classes: classesProp,
-    disabled,
-    displayEmpty = true,
-    getTagProps,
-    IconComponent = Unstable_ChevronDown,
-    id,
-    input,
-    inputProps,
-    labelId,
-    MenuProps = {
-      getContentAnchorEl: null,
-      anchorOrigin: {
-        vertical: 'bottom',
-        horizontal: 'right',
-      },
-      transformOrigin: {
-        vertical: 'top',
-        horizontal: 'right',
-      },
-      classes: { paper: 'MuiSparkMenu-offsetTop' },
-    },
-    multiple = false,
-    native = false,
-    onClose,
-    onOpen,
-    open,
-    renderValue: renderValueProp,
-    value,
-    SelectDisplayProps,
-    ...other
-  } = props;
-
-  const classes = useStyles({ multiple });
-
-  const inputComponent = native ? MuiNativeSelectInput : MuiSelectInput;
-
-  const InputComponent = input || <Unstable_Input />;
-
-  let renderValue;
-  if (renderValueProp) {
-    renderValue = renderValueProp;
-  } else if (multiple) {
-    renderValue = (selected: string[]) => {
-      if (selected.length) {
-        return (
-          <div>
-            {selected.map((value, index) => (
-              // can't make deletable because Select's `onChange` isn't extensible enough; but consumer can implement custom logic through `getTagProps`
-              <Unstable_Tag
-                key={value}
-                label={value}
-                disabled={disabled}
-                {...(getTagProps && getTagProps({ value, index }))}
-              />
-            ))}
-          </div>
-        );
-      } else {
-        return (
-          <div
-            className="PrivateSelect-multipleNoValue"
-            // [from MUI] Set `dangerouslySetInnerHTML` so the vertical align positioning algorithm kicks in; otherwise, the component shifts up in positioning because this span is rendered too high.
-            dangerouslySetInnerHTML={{ __html: '&#8203;' }}
-          />
-        );
-      }
-    };
-  }
-
-  return cloneElement(InputComponent, {
-    disabled,
-    inputComponent,
-    inputProps: {
+const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
+  function Unstable_Select(props, ref) {
+    const {
+      autoWidth = false,
       children,
-      IconComponent,
-      type: undefined, // We render a select. We can ignore the type provided by the `Input`.
-      multiple,
-      ...(native
-        ? { id }
-        : {
-            autoWidth,
-            displayEmpty,
-            labelId,
-            MenuProps,
-            onClose,
-            onOpen,
-            open,
-            renderValue,
-            SelectDisplayProps: { id, ...SelectDisplayProps },
-          }),
-      ...inputProps,
-      classes: {
-        root: clsx(classes.root, classesProp?.root, inputProps?.classes?.root),
-        nativeInput: clsx(
-          classes.nativeInput,
-          classesProp?.nativeInput,
-          inputProps?.classes?.nativeInput
-        ),
-        icon: clsx(classes.icon, classesProp?.icon, inputProps?.classes?.icon),
-        iconOpen: clsx(
-          classes.iconOpen,
-          classesProp?.iconOpen,
-          inputProps?.classes?.iconOpen
-        ),
+      classes: classesProp,
+      disabled,
+      displayEmpty = true,
+      getTagProps,
+      IconComponent = Unstable_ChevronDown,
+      id,
+      input,
+      inputProps,
+      labelId,
+      MenuProps = {
+        getContentAnchorEl: null,
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'right',
+        },
+        transformOrigin: {
+          vertical: 'top',
+          horizontal: 'right',
+        },
+        classes: { paper: 'MuiSparkMenu-offsetTop' },
       },
-      ...(input ? input.props.inputProps : {}),
-    },
-    value,
-    ref,
-    ...other,
-  });
-});
+      multiple = false,
+      native = false,
+      onClose,
+      onOpen,
+      open,
+      renderValue: renderValueProp,
+      value,
+      SelectDisplayProps,
+      ...other
+    } = props;
+
+    const classes = useStyles({ multiple });
+
+    const inputComponent = native ? MuiNativeSelectInput : MuiSelectInput;
+
+    const InputComponent = input || <Unstable_Input />;
+
+    let renderValue;
+    if (renderValueProp) {
+      renderValue = renderValueProp;
+    } else if (multiple) {
+      renderValue = (selected: string[]) => {
+        if (selected.length) {
+          return (
+            <div>
+              {selected.map((value, index) => (
+                // can't make deletable because Select's `onChange` isn't extensible enough; but consumer can implement custom logic through `getTagProps`
+                <Unstable_Tag
+                  key={value}
+                  label={value}
+                  disabled={disabled}
+                  {...(getTagProps && getTagProps({ value, index }))}
+                />
+              ))}
+            </div>
+          );
+        } else {
+          return (
+            <div
+              className="PrivateSelect-multipleNoValue"
+              // [from MUI] Set `dangerouslySetInnerHTML` so the vertical align positioning algorithm kicks in; otherwise, the component shifts up in positioning because this span is rendered too high.
+              dangerouslySetInnerHTML={{ __html: '&#8203;' }}
+            />
+          );
+        }
+      };
+    }
+
+    return cloneElement(InputComponent, {
+      disabled,
+      inputComponent,
+      inputProps: {
+        children,
+        IconComponent,
+        type: undefined, // We render a select. We can ignore the type provided by the `Input`.
+        multiple,
+        ...(native
+          ? { id }
+          : {
+              autoWidth,
+              displayEmpty,
+              labelId,
+              MenuProps,
+              onClose,
+              onOpen,
+              open,
+              renderValue,
+              SelectDisplayProps: { id, ...SelectDisplayProps },
+            }),
+        ...inputProps,
+        classes: {
+          root: clsx(
+            classes.root,
+            classesProp?.root,
+            inputProps?.classes?.root
+          ),
+          nativeInput: clsx(
+            classes.nativeInput,
+            classesProp?.nativeInput,
+            inputProps?.classes?.nativeInput
+          ),
+          icon: clsx(
+            classes.icon,
+            classesProp?.icon,
+            inputProps?.classes?.icon
+          ),
+          iconOpen: clsx(
+            classes.iconOpen,
+            classesProp?.iconOpen,
+            inputProps?.classes?.iconOpen
+          ),
+        },
+        ...(input ? input.props.inputProps : {}),
+      },
+      value,
+      ref,
+      ...other,
+    });
+  }
+);
 
 export default Unstable_Select;

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -11,7 +11,8 @@ import { buildVariant } from '../theme/typography';
 import { alpha, darken } from '@material-ui/core/styles';
 
 export interface Unstable_TagTypeMap<
-  P = Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
   D extends ElementType = 'div'
 > {
   props: P &
@@ -45,7 +46,8 @@ export interface Unstable_TagTypeMap<
 
 export type Unstable_TagProps<
   D extends ElementType = Unstable_TagTypeMap['defaultComponent'],
-  P = Record<string, unknown>
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
 > = OverrideProps<Unstable_TagTypeMap<P, D>, D>;
 
 export type Unstable_TagClassKey =

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -162,138 +162,137 @@ const useStyles = makeStyles<Unstable_TextFieldClassKey>((theme) => ({
   root: {},
 }));
 
-const Unstable_TextField = forwardRef(function TextField(
-  props: Unstable_TextFieldProps,
-  ref
-) {
-  const {
-    autoComplete,
-    autoFocus = false,
-    children,
-    classes: classesProp,
-    className,
-    defaultValue,
-    disabled = false,
-    error = false,
-    FormHelperTextProps,
-    fullWidth = false,
-    helperText,
-    id: idProp,
-    FormLabelProps,
-    inputProps,
-    InputProps,
-    inputRef,
-    leadingEl,
-    label,
-    multiline = false,
-    name,
-    onBlur,
-    onChange,
-    onFocus,
-    placeholder,
-    required = false,
-    maxRows,
-    minRows,
-    select = false,
-    SelectProps,
-    success,
-    trailingEl,
-    type,
-    value,
-    ...other
-  } = props;
+const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
+  function TextField(props, ref) {
+    const {
+      autoComplete,
+      autoFocus = false,
+      children,
+      classes: classesProp,
+      className,
+      defaultValue,
+      disabled = false,
+      error = false,
+      FormHelperTextProps,
+      fullWidth = false,
+      helperText,
+      id: idProp,
+      FormLabelProps,
+      inputProps,
+      InputProps,
+      inputRef,
+      leadingEl,
+      label,
+      multiline = false,
+      name,
+      onBlur,
+      onChange,
+      onFocus,
+      placeholder,
+      required = false,
+      maxRows,
+      minRows,
+      select = false,
+      SelectProps,
+      success,
+      trailingEl,
+      type,
+      value,
+      ...other
+    } = props;
 
-  const classes = useStyles();
+    const classes = useStyles();
 
-  const id = useId(idProp);
+    const id = useId(idProp);
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (select && !children) {
-      console.error(
-        'Prenda Spark: Material-UI: `children` must be passed when using the `TextField` component with `select`.'
-      );
+    if (process.env.NODE_ENV !== 'production') {
+      if (select && !children) {
+        console.error(
+          'Prenda Spark: Material-UI: `children` must be passed when using the `TextField` component with `select`.'
+        );
+      }
     }
-  }
 
-  const InputMore: Partial<Unstable_InputProps> = {};
+    const InputMore: Partial<Unstable_InputProps> = {};
 
-  if (select) {
-    // unset defaults from textbox inputs
-    if (!SelectProps || !SelectProps.native) {
-      InputMore.id = undefined;
+    if (select) {
+      // unset defaults from textbox inputs
+      if (!SelectProps || !SelectProps.native) {
+        InputMore.id = undefined;
+      }
+      InputMore['aria-describedby'] = undefined;
     }
-    InputMore['aria-describedby'] = undefined;
+
+    const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
+    const formLabelId = label && id ? `${id}-label` : undefined;
+    const InputElement = (
+      <Unstable_Input
+        aria-describedby={helperTextId}
+        autoComplete={autoComplete}
+        autoFocus={autoFocus}
+        disabled={disabled}
+        defaultValue={defaultValue}
+        fullWidth={fullWidth}
+        leadingEl={leadingEl}
+        multiline={multiline}
+        name={name}
+        maxRows={maxRows}
+        minRows={minRows}
+        success={success}
+        trailingEl={trailingEl}
+        type={type}
+        value={value}
+        id={id}
+        inputRef={inputRef}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        placeholder={placeholder}
+        inputProps={inputProps}
+        {...InputMore}
+        {...InputProps}
+      />
+    );
+
+    return (
+      <FormControl
+        className={clsx(classes.root, classesProp?.root, className)}
+        disabled={disabled}
+        error={error}
+        fullWidth={fullWidth}
+        ref={(ref as unknown) as RefObject<HTMLDivElement>}
+        required={required}
+        {...other}
+      >
+        {label && (
+          <Unstable_FormLabel htmlFor={id} id={formLabelId} {...FormLabelProps}>
+            {label}
+          </Unstable_FormLabel>
+        )}
+
+        {select ? (
+          <Unstable_Select
+            aria-describedby={helperTextId}
+            id={id}
+            labelId={formLabelId}
+            value={value}
+            input={InputElement}
+            {...SelectProps}
+          >
+            {children}
+          </Unstable_Select>
+        ) : (
+          InputElement
+        )}
+
+        {helperText && (
+          <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
+            {helperText}
+          </Unstable_FormHelperText>
+        )}
+      </FormControl>
+    );
   }
-
-  const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
-  const formLabelId = label && id ? `${id}-label` : undefined;
-  const InputElement = (
-    <Unstable_Input
-      aria-describedby={helperTextId}
-      autoComplete={autoComplete}
-      autoFocus={autoFocus}
-      disabled={disabled}
-      defaultValue={defaultValue}
-      fullWidth={fullWidth}
-      leadingEl={leadingEl}
-      multiline={multiline}
-      name={name}
-      maxRows={maxRows}
-      minRows={minRows}
-      success={success}
-      trailingEl={trailingEl}
-      type={type}
-      value={value}
-      id={id}
-      inputRef={inputRef}
-      onBlur={onBlur}
-      onChange={onChange}
-      onFocus={onFocus}
-      placeholder={placeholder}
-      inputProps={inputProps}
-      {...InputMore}
-      {...InputProps}
-    />
-  );
-
-  return (
-    <FormControl
-      className={clsx(classes.root, classesProp?.root, className)}
-      disabled={disabled}
-      error={error}
-      fullWidth={fullWidth}
-      ref={(ref as unknown) as RefObject<HTMLDivElement>}
-      required={required}
-      {...other}
-    >
-      {label && (
-        <Unstable_FormLabel htmlFor={id} id={formLabelId} {...FormLabelProps}>
-          {label}
-        </Unstable_FormLabel>
-      )}
-
-      {select ? (
-        <Unstable_Select
-          aria-describedby={helperTextId}
-          id={id}
-          labelId={formLabelId}
-          value={value}
-          input={InputElement}
-          {...SelectProps}
-        >
-          {children}
-        </Unstable_Select>
-      ) : (
-        InputElement
-      )}
-
-      {helperText && (
-        <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
-          {helperText}
-        </Unstable_FormHelperText>
-      )}
-    </FormControl>
-  );
-});
+);
 
 export default Unstable_TextField;


### PR DESCRIPTION
Two things:

- props that are assigned types _inside_ of the `forwardRef` function will not have the best typing -- things like discriminated unions of constant strings will show up as just `string`
- strictly typing a ref is problematic when the component is overridable -- the ref should come from the component, but the types can't be that smart. not all these components are overridable, but the principal is sound.

So, all refs are typed as unknown, and ref and props typings are given via generics to `forwardRef`.