### PR TITLE
chore: standardize styles

### DIFF
--- a/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
+++ b/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
@@ -73,7 +73,7 @@ const useStyles = makeStyles<Unstable_AvatarClassKey>(
     root: (props: Unstable_AvatarProps) => ({
       backgroundColor: theme.unstable_palette.neutral[70],
       color: theme.unstable_palette.text.heading,
-      /** size */
+      /* size */
       // must set height/width instead of padding because different children (text, icon) require different padding but there's no way to tell which is passed here
       // set min height/width to match design, and lesser-responsive height/width to scale with user's browser-set font size to maintain a11y
       ...(props.size === 'large' && {
@@ -100,7 +100,7 @@ const useStyles = makeStyles<Unstable_AvatarClassKey>(
         width: theme.unstable_typography.pxToRem(16),
         ...avatarFontVariantSmall,
       }),
-      /** color */
+      /* color */
       ...(props.color === 'neutral' && {
         backgroundColor: theme.unstable_palette.neutral[70],
       }),
@@ -125,10 +125,10 @@ const useStyles = makeStyles<Unstable_AvatarClassKey>(
       ...(props.color === 'magenta' && {
         backgroundColor: theme.unstable_palette.magenta[300],
       }),
-      /** icon children */
+      /* icon children */
       '& [class*=MuiSvgIcon-root]': {
         color: theme.unstable_palette.text.icon,
-        /** size */
+        /* size */
         ...(props.size === 'large' && {
           fontSize: theme.unstable_typography.pxToRem(32),
         }),

--- a/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
+++ b/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles<Unstable_BannerClassKey>(
       display: 'flex',
       gap: 16,
       padding: 24,
+      /* severity */
       ...(props.severity === 'error' && {
         backgroundColor: theme.unstable_palette.red[700],
       }),
@@ -38,6 +39,7 @@ const useStyles = makeStyles<Unstable_BannerClassKey>(
       lineHeight: 1,
       paddingBottom: 4,
       paddingTop: 4,
+      /* severity */
       ...(props.severity === 'warning' && {
         color: theme.unstable_palette.neutral[600],
       }),
@@ -47,6 +49,7 @@ const useStyles = makeStyles<Unstable_BannerClassKey>(
       color: theme.unstable_palette.neutral[0],
       flexGrow: 2,
       paddingTop: 4,
+      /* severity */
       ...(props.severity === 'warning' && {
         color: theme.unstable_palette.neutral[600],
       }),

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -104,20 +104,17 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       '&.Mui-focusVisible, &:focus-visible': {
         boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
       },
-      /** variant */
+      /* variant */
       ...(props.variant === 'primary' && {
-        backgroundColor: theme.unstable_palette.brand.blue,
+        backgroundColor: theme.unstable_palette.background.brand,
         '&:hover': {
-          backgroundColor: lighten(theme.unstable_palette.brand.blue, 0.1),
+          backgroundColor: lighten(
+            theme.unstable_palette.background.brand,
+            0.1
+          ),
         },
         '&:active': {
-          backgroundColor: darken(theme.unstable_palette.brand.blue, 0.2),
-        },
-        '&[aria-expanded="true"]': {
-          backgroundColor: theme.unstable_palette.neutral[600],
-        },
-        '&:disabled': {
-          backgroundColor: theme.unstable_palette.neutral[80],
+          backgroundColor: darken(theme.unstable_palette.background.brand, 0.2),
         },
       }),
       ...(props.variant === 'stroked' && {
@@ -129,13 +126,6 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
         '&:active': {
           backgroundColor: theme.unstable_palette.blue[100],
         },
-        '&[aria-expanded="true"]': {
-          backgroundColor: theme.unstable_palette.neutral[600],
-        },
-        '&:disabled': {
-          backgroundColor: theme.unstable_palette.neutral[80],
-          color: theme.unstable_palette.neutral[100],
-        },
       }),
       ...(props.variant === 'ghost' && {
         backgroundColor: 'transparent',
@@ -144,12 +134,6 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
         },
         '&:active': {
           backgroundColor: theme.unstable_palette.blue[100],
-        },
-        '&[aria-expanded="true"]': {
-          backgroundColor: theme.unstable_palette.neutral[600],
-        },
-        '&:disabled': {
-          backgroundColor: theme.unstable_palette.neutral[80],
         },
       }),
       ...(props.variant === 'destructive' && {
@@ -160,15 +144,8 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
         '&:active': {
           backgroundColor: darken(theme.unstable_palette.red[700], 0.2),
         },
-        '&[aria-expanded="true"]': {
-          backgroundColor: theme.unstable_palette.neutral[600],
-        },
-        '&:disabled': {
-          backgroundColor: theme.unstable_palette.neutral[80],
-          color: theme.unstable_palette.neutral[100],
-        },
       }),
-      /** size */
+      /* size */
       ...(props.size === 'small' && {
         padding: '8px 16px',
       }),
@@ -182,17 +159,25 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       '&&': {
         borderColor: 'transparent',
         borderWidth: 1,
-        '&:disabled': {
-          opacity: 'unset',
-        },
+        /* variant */
         ...(props.variant === 'stroked' && {
           borderColor: theme.unstable_palette.neutral[90],
+        }),
+        /* aria-expanded */
+        ...(props['aria-expanded'] && {
+          backgroundColor: theme.unstable_palette.background.inverse,
+        }),
+        /* disabled */
+        ...(props.disabled && {
+          backgroundColor: theme.unstable_palette.neutral[80],
+          color: theme.unstable_palette.text.disabled,
+          opacity: 'unset',
         }),
       },
     }),
 
     label: (props: Unstable_ButtonProps) => ({
-      /** size */
+      /* size */
       ...(props.size === 'small' && {
         ...buttonFontVariantSmall,
       }),
@@ -202,43 +187,33 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       ...(props.size === 'large' && {
         ...buttonFontVariantLarge,
       }),
-      /** variant */
+      /* variant */
       ...(props.variant === 'primary' && {
-        color: theme.palette.common.white,
-        ...(props.disabled && {
-          color: theme.unstable_palette.neutral[100],
-        }),
+        color: theme.unstable_palette.neutral[0],
       }),
       ...(props.variant === 'stroked' && {
         color: theme.unstable_palette.brand.blue,
-        '[aria-expanded="true"] > & ': {
-          color: theme.palette.common.white,
-        },
-        ...(props.disabled && {
-          color: theme.unstable_palette.neutral[100],
-        }),
       }),
       ...(props.variant === 'ghost' && {
         color: theme.unstable_palette.brand.blue,
-        '[aria-expanded="true"] > & ': {
-          color: theme.palette.common.white,
-        },
-        ...(props.disabled && {
-          color: theme.unstable_palette.neutral[100],
-        }),
       }),
       ...(props.variant === 'destructive' && {
-        color: theme.palette.common.white,
-        ...(props.disabled && {
-          color: theme.unstable_palette.neutral[100],
-        }),
+        color: theme.unstable_palette.neutral[0],
+      }),
+      /* aria-expanded */
+      ...(props['aria-expanded'] && {
+        color: theme.unstable_palette.neutral[0],
+      }),
+      /* disabled */
+      ...(props.disabled && {
+        color: theme.unstable_palette.text.disabled,
       }),
     }),
     leadingAvatar: (props: Unstable_ButtonProps) => ({
       color: 'inherit',
       display: 'flex',
       marginRight: 8,
-      /** size */
+      /* size */
       ...(props.size === 'small' && {
         marginBottom: -4,
         marginLeft: -8,
@@ -254,7 +229,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
         marginLeft: -8,
         marginTop: -8,
       }),
-      /** disabled */
+      /* disabled */
       ...(props.disabled && {
         opacity: 0.62,
       }),
@@ -264,7 +239,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       display: 'flex',
       lineHeight: 1,
       margin: '0 8px 0 0',
-      /** size */
+      /* size */
       ...(props.size === 'small' && {
         fontSize: theme.typography.pxToRem(16),
       }),
@@ -280,7 +255,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
       display: 'flex',
       lineHeight: 1,
       margin: '0 0 0 8px',
-      /** size */
+      /* size */
       ...(props.size === 'small' && {
         fontSize: theme.typography.pxToRem(16),
       }),
@@ -302,6 +277,7 @@ const useStyles = makeStyles<Unstable_ButtonClassKey>(
 const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef(
   function Unstable_Button(props, ref) {
     const {
+      'aria-expanded': ariaExpanded,
       children,
       classes: classesProp,
       disabled,
@@ -314,7 +290,12 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
       ...other
     } = props;
 
-    const classes = useStyles({ disabled, variant, size });
+    const classes = useStyles({
+      'aria-expanded': ariaExpanded,
+      disabled,
+      variant,
+      size,
+    });
 
     let leadingEl: ReactNode;
     if (leadingAvatar) {
@@ -347,6 +328,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
 
     return (
       <MuiButton
+        aria-expanded={ariaExpanded}
         classes={{
           root: clsx(classes.root, classesProp?.root),
           label: clsx(classes.label, classesProp?.label),

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -28,14 +28,15 @@ const useStyles = makeStyles<Unstable_FormControlLabelClassKey>(
     /* Styles applied to the label element. */
     label: (props: Unstable_FormControlLabelProps) => ({
       ...theme.unstable_typography.body,
-      color: theme.unstable_palette.neutral[500],
+      color: theme.unstable_palette.text.body,
       'label:hover > &': {
         textDecoration: 'underline',
       },
       // triple-specificity to override Mui default and above hover selector,
       '&&&': {
+        /** disabled */
         ...(props.disabled && {
-          color: theme.unstable_palette.neutral[100],
+          color: theme.unstable_palette.text.disabled,
           textDecoration: 'none',
         }),
       },

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -26,7 +26,7 @@ export type Unstable_FormHelperTextProps<
 
 const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
   (theme) => ({
-    root: (props: Unstable_FormHelperTextProps) => ({
+    root: {
       ...theme.unstable_typography.description,
       alignItems: 'center',
       color: theme.unstable_palette.text.subdued,
@@ -34,42 +34,32 @@ const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
       gap: 4,
       letterSpacing: 0,
       width: 'fit-content',
-      /* Styles applied to the `input` element if `disabled={true}`. */
-      ...(props.disabled && {
-        color: theme.unstable_palette.text.disabled,
-      }),
-      // duped because underlying component can set this independently based on form control context
-      '&.Mui-disabled': {
-        color: theme.unstable_palette.text.disabled,
-      },
-      /* Styles applied to the `input` element if `disabled={true}`. */
-      ...(props.error && {
-        color: theme.unstable_palette.red[700],
-      }),
-      // duped because underlying component can set this independently based on form control context
+      /* error -- can get from internal context => can't condition on prop */
       '&.Mui-error': {
         color: theme.unstable_palette.red[700],
+      },
+      /* disabled -- can get from internal context => can't condition on prop */
+      '&.Mui-disabled': {
+        color: theme.unstable_palette.text.disabled,
       },
       // double-specificity to override PDS v1
       '&&': {
         marginTop: 8,
       },
-    }),
+    },
   }),
   { name: 'MuiSparkUnstable_FormHelperText' }
 );
 
 const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeMap> = forwardRef(
   function Unstable_FormHelperText(props, ref) {
-    const { classes: classesProp, disabled, error, ...other } = props;
+    const { classes: classesProp, ...other } = props;
 
-    const classes = useStyles({ disabled, error });
+    const classes = useStyles();
 
     return (
       <MuiFormHelperText
         classes={{ root: clsx(classes.root, classesProp?.root) }}
-        disabled={disabled}
-        error={error}
         ref={ref}
         {...other}
       />

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -29,24 +29,23 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
     /** Styles applied to the root element. */
     root: {
       ...theme.unstable_typography.label,
-      color: theme.unstable_palette.neutral[600],
+      color: theme.unstable_palette.text.heading,
       marginBottom: 8,
-      '&.Mui-disabled': {
-        color: theme.unstable_palette.text.disabled,
+      /* focused -- can get from internal context => can't condition on prop */
+      '&.Mui-focused': {
+        // override Mui default
+        color: theme.unstable_palette.text.heading,
       },
+      /* error -- can get from internal context => can't condition on prop */
       '&.Mui-error': {
         color: theme.unstable_palette.red[700],
       },
-      '&.Mui-focused': {
-        color: theme.unstable_palette.neutral[600],
-      },
-      // underlying class
-      '&.MuiFormLabel-formControl': {
-        transform: 'none',
-        position: 'relative',
+      /* disabled -- can get from internal context => can't condition on prop */
+      '&.Mui-disabled': {
+        color: theme.unstable_palette.text.disabled,
       },
     },
-    /** Styles applied to the root element. */
+    /** Styles applied to the asterisk element. */
     asterisk: {},
   }),
   { name: 'MuiSparkUnstable_FormLabel' }

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
       '&.Mui-focusVisible, &:focus-visible': {
         boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
       },
+      /* variant & color */
       ...(props.variant === 'primary' && {
         backgroundColor: theme.unstable_palette.brand.blue,
         '&:hover': {
@@ -90,7 +91,6 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
         },
         '&:disabled': {
           backgroundColor: theme.unstable_palette.neutral[80],
-          color: theme.unstable_palette.neutral[100],
         },
       }),
       ...(props.variant === 'ghost' &&
@@ -125,7 +125,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
             backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
           },
         }),
-
+      /* size */
       ...(props.size === 'small' && {
         padding: 4,
       }),
@@ -136,6 +136,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
 
     label: (props: Unstable_IconButtonProps) => ({
       fontSize: '1.5rem',
+      /* variant & color */
       ...(props.variant === 'primary' && {
         color: theme.unstable_palette.neutral[0],
       }),
@@ -150,11 +151,13 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
         props.color === 'inverse' && {
           color: theme.unstable_palette.neutral[0],
         }),
-      '[aria-expanded="true"] > &': {
+      /* aria-expanded */
+      ...(props['aria-expanded'] && {
         color: theme.unstable_palette.neutral[0],
-      },
+      }),
+      /* disabled */
       ...(props.disabled && {
-        color: theme.unstable_palette.neutral[100],
+        color: theme.unstable_palette.text.disabled,
       }),
     }),
   }),
@@ -164,6 +167,7 @@ const useStyles = makeStyles<Unstable_IconButtonClassKey>(
 const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = forwardRef(
   function Unstable_IconButton(props, ref) {
     const {
+      'aria-expanded': ariaExpanded,
       color = 'standard',
       classes: classesProp,
       disabled,
@@ -174,10 +178,17 @@ const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = fo
       ...other
     } = props;
 
-    const classes = useStyles({ color, disabled, size, variant });
+    const classes = useStyles({
+      'aria-expanded': ariaExpanded,
+      color,
+      disabled,
+      size,
+      variant,
+    });
 
     return (
       <MuiIconButton
+        aria-expanded={ariaExpanded}
         classes={{
           root: clsx(classes.root, classesProp?.root),
           label: clsx(classes.label, classesProp?.label),

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -54,7 +54,7 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
       '&:hover': {
         backgroundColor: theme.unstable_palette.neutral[60],
       },
-      /* Styles applied to the root element if `value` is provided and truthy. */
+      /* value */
       ...(props.value && {
         backgroundColor: theme.unstable_palette.neutral[60],
         borderColor: theme.unstable_palette.neutral[100],
@@ -62,49 +62,40 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
           backgroundColor: theme.unstable_palette.neutral[70],
         },
       }),
+      // must come after `value`
       '&.Mui-focused, &:focus-visible': {
         backgroundColor: theme.unstable_palette.neutral[0],
         borderColor: theme.unstable_palette.blue[600],
         boxShadow: `0 0 0 4px ${theme.unstable_palette.blue[100]}`,
       },
-      /* Styles applied to the root element if `success={true}`. */
+      /* multiline */
+      ...(props.multiline && {
+        padding: 0,
+      }),
+      /* leadingEl */
+      ...(props.leadingEl && {
+        paddingLeft: 14,
+      }),
+      /* trailingEl */
+      ...(props.trailingEl && {
+        paddingRight: 14,
+      }),
+      /* success */
       ...(props.success && {
         borderColor: theme.unstable_palette.green[600],
         boxShadow: `0 0 0 4px ${theme.unstable_palette.green[100]}`,
       }),
-      /* Styles applied to the root element if `error={true}`. */
+      /* error */
       ...(props.error && {
         borderColor: theme.unstable_palette.red[700],
         boxShadow: `0 0 0 4px ${theme.unstable_palette.red[100]}`,
       }),
-      // duped because underlying component can set this independently based on form control context
-      '&.Mui-error': {
-        borderColor: theme.unstable_palette.red[700],
-        boxShadow: `0 0 0 4px ${theme.unstable_palette.red[100]}`,
-      },
-      /* Styles applied to the root element if `disabled={true}`. */
-      ...(props.disabled && {
-        backgroundColor: theme.unstable_palette.neutral[80],
-      }),
-      // duped because underlying component can set this independently based on form control context
+      /* disabled -- can get from internal context => can't condition on prop */
       '&.Mui-disabled': {
         backgroundColor: theme.unstable_palette.neutral[80],
         opacity: 1,
-        // override mui disabled
-        color: theme.unstable_palette.text.disabled,
+        color: theme.unstable_palette.text.disabled, // override Mui default
       },
-      /* Styles applied to the root element if `multiline={true}`. */
-      ...(props.multiline && {
-        padding: 0,
-      }),
-      /* Styles applied to the root element if `leadingEl` is provided. */
-      ...(props.leadingEl && {
-        paddingLeft: 14,
-      }),
-      /* Styles applied to the root element if `trailingEl` is provided. */
-      ...(props.trailingEl && {
-        paddingRight: 14,
-      }),
     }),
     /* Styles applied to the `input` element. */
     input: (props: Unstable_InputProps) => ({
@@ -112,7 +103,7 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
       color: 'inherit',
       height: 'unset', // override weird default `em` height
       padding: '12px 16px',
-      /* Styles applied to the `input` element if `placeholder` is provided and truthy. */
+      /* placeholder */
       ...(props.placeholder && {
         color: theme.unstable_palette.neutral[400],
         opacity: 0.87,
@@ -122,27 +113,23 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
           opacity: 0.87,
         },
       }),
-      /* Styles applied to the root element if `disabled={true}`. */
-      ...(props.disabled && {
-        color: 'inherit',
+      /* multiline */
+      ...(props.multiline && {
+        padding: '12px 16px',
       }),
-      // duped because underlying component can set this independently based on form control context
+      /* leadingEl */
+      ...(props.leadingEl && {
+        paddingLeft: 8,
+      }),
+      /* trailingEl */
+      ...(props.trailingEl && {
+        paddingRight: 8,
+      }),
+      /* disabled -- can get from internal context => can't condition on prop */
       '&.Mui-disabled': {
         color: 'inherit',
         opacity: 1,
       },
-      /* Styles applied to the `input` element if `multiline={true}`. */
-      ...(props.multiline && {
-        padding: '12px 16px',
-      }),
-      /* Styles applied to the `input` element if `leadingEl` is provided. */
-      ...(props.leadingEl && {
-        paddingLeft: 8,
-      }),
-      /* Styles applied to the `input` element if `trailingEl` is provided. */
-      ...(props.trailingEl && {
-        paddingRight: 8,
-      }),
     }),
   }),
   { name: 'MuiSparkUnstable_Input' }

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -85,11 +85,11 @@ const useStyles = makeStyles<Unstable_InputClassKey>(
         borderColor: theme.unstable_palette.green[600],
         boxShadow: `0 0 0 4px ${theme.unstable_palette.green[100]}`,
       }),
-      /* error */
-      ...(props.error && {
+      /* error -- -- can get from internal context => can't condition on prop */
+      '&.Mui-error': {
         borderColor: theme.unstable_palette.red[700],
         boxShadow: `0 0 0 4px ${theme.unstable_palette.red[100]}`,
-      }),
+      },
       /* disabled -- can get from internal context => can't condition on prop */
       '&.Mui-disabled': {
         backgroundColor: theme.unstable_palette.neutral[80],

--- a/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
+++ b/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
@@ -27,23 +27,23 @@ const useStyles = makeStyles<Unstable_InputAdornmentClassKey>(
   (theme) => ({
     /* Styles applied to the root element. */
     root: (props: Unstable_InputAdornmentProps) => ({
-      /** Styles from Mui */
+      /* from Mui */
       display: 'flex',
       alignItems: 'flex-start',
       whiteSpace: 'nowrap',
-      /** PDS styles */
+      /* for PDS */
       fontSize: theme.unstable_typography.pxToRem(24),
       lineHeight: 1,
       alignSelf: 'flex-start', // un-center in multiline input
       marginTop: 12, // shift-down in multiline input (= half of typical icon height + input top margin)
-      /* Styles applied to the root element if `position="start"`. */
+      /* position */
       ...(props.position === 'start' && {
         marginRight: 2,
       }),
-      /* Styles applied to the root element if `position="end"`. */
       ...(props.position === 'end' && {
         marginLeft: 2,
       }),
+      /* children */
       ...(typeof props.children === 'string' && {
         ...theme.unstable_typography.body,
       }),

--- a/libs/spark/src/Unstable_Link/Unstable_Link.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.tsx
@@ -41,7 +41,14 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
     root: (props: Unstable_LinkProps) => ({
       ...theme.unstable_typography.body,
       textDecoration: 'underline',
-      ...(props.standalone && { textDecoration: 'none' }),
+      '&.Mui-focusVisible, &:focus-visible': {
+        boxShadow: `0 0 2px 4px ${theme.unstable_palette.teal[200]}`,
+      },
+      /* standalone */
+      ...(props.standalone && {
+        textDecoration: 'none',
+      }),
+      /* color */
       ...((!props.color || props.color === 'default') && {
         color: theme.unstable_palette.blue['600'],
         '&:hover': {
@@ -58,9 +65,6 @@ const useStyles = makeStyles<Unstable_LinkClassKey>(
       // reset browser default
       '&:focus': {
         outline: 'none',
-      },
-      '&.Mui-focusVisible, &:focus-visible': {
-        boxShadow: `0 0 2px 4px ${theme.unstable_palette.teal[200]}`,
       },
     }),
   }),

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -14,7 +14,7 @@ export type Unstable_RadioGroupClassKey = 'root';
 
 const useStyles = makeStyles<Unstable_RadioGroupClassKey>(
   {
-    /** Styles applied to the root element. */
+    /* Styles applied to the root element. */
     root: {
       gap: 16,
       width: 'fit-content',

--- a/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
+++ b/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles<Unstable_SectionMessageClassKey>(
       padding: 24,
       borderWidth: 1,
       borderStyle: 'solid',
+      /* severity */
       ...(props.severity === 'error' && {
         backgroundColor: theme.unstable_palette.red[100],
         borderColor: theme.unstable_palette.red[700],
@@ -50,6 +51,7 @@ const useStyles = makeStyles<Unstable_SectionMessageClassKey>(
       display: 'flex',
       fontSize: theme.unstable_typography.pxToRem(24),
       lineHeight: 1,
+      /* severity */
       ...(props.severity === 'error' && {
         color: theme.unstable_palette.red[700],
       }),
@@ -68,7 +70,10 @@ const useStyles = makeStyles<Unstable_SectionMessageClassKey>(
       color: theme.unstable_palette.text.body,
       flexGrow: 2,
     },
-    action: { alignSelf: 'flex-start', justifySelf: 'flex-end' },
+    action: {
+      alignSelf: 'flex-start',
+      justifySelf: 'flex-end',
+    },
     title: {
       ...theme.unstable_typography.label,
       color: theme.unstable_palette.text.heading,

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -91,6 +91,7 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
           // adjust embedded Menu's anchor/transform position to edge when there's a startAdornment
           marginLeft: -40,
         },
+        /* multiple */
         ...(props.multiple && {
           paddingBottom: 8,
           paddingTop: 8,
@@ -114,8 +115,9 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
         fontSize: theme.unstable_typography.pxToRem(24),
         marginRight: 14,
         transition: 'transform 250ms ease',
+        /* disabled -- can get from internal context => can't condition on prop */
         '.Mui-disabled > &': {
-          color: theme.unstable_palette.neutral[100],
+          color: theme.unstable_palette.text.disabled,
         },
       },
       iconOpen: {

--- a/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
+++ b/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
@@ -48,6 +48,7 @@ export type Unstable_SvgIconClassKey = 'root';
 const useStyles = makeStyles<Unstable_SvgIconClassKey>(
   (theme) => ({
     root: (props: Unstable_SvgIconProps) => ({
+      /* color */
       ...(props.color === 'inherit' && { color: 'inherit' }),
       ...(props.color === 'normal' && {
         color: theme.unstable_palette.text.icon,
@@ -61,6 +62,7 @@ const useStyles = makeStyles<Unstable_SvgIconClassKey>(
       ...(props.color === 'inverseSecondary' && {
         color: theme.unstable_palette.text.inverseSecondaryIcon,
       }),
+      /* fontSize */
       ...(props.fontSize === 'inherit' && { fontSize: 'inherit' }),
       ...(props.fontSize === 'small' && {
         fontSize: theme.unstable_typography.pxToRem(16),

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -150,6 +150,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
         '&:focus': {
           backgroundColor, // override MUI
         },
+        /** onClick (clickable) */
         ...(props.onClick && {
           // artificially increase specificity to override MUI
           '&&': {
@@ -175,6 +176,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
             boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
           },
         }),
+        /** onDelete (deletable) */
         ...(props.onDelete && {
           // artificially increase specificity to override MUI
           '&&': {
@@ -190,11 +192,12 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
     label: (props: Unstable_TagProps) => ({
       color: 'inherit',
       padding: 0, // unset MUI
-      ...(props.size === 'medium' && tagFontVariantMedium),
-      ...(props.size === 'small' && tagFontVariantSmall),
       // artificially shift label down by 1px to appear more centered; especially apparent when beside an icon
       marginTop: 1,
       marginBottom: -1,
+      /* size */
+      ...(props.size === 'medium' && tagFontVariantMedium),
+      ...(props.size === 'small' && tagFontVariantSmall),
     }),
     deleteIcon: (props: Unstable_TagProps) => ({
       borderRadius: 2,
@@ -202,6 +205,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
       height: '1em',
       margin: '0 0 0 4px',
       width: '1em',
+      /* size */
       ...(props.size === 'medium' && {
         fontSize: theme.typography.pxToRem(16),
       }),
@@ -210,6 +214,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
       }),
       '&:hover': {
         color: 'inherit', // override MUI
+        /* variant */
         ...(props.variant === 'bold' && {
           backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.2),
         }),
@@ -218,6 +223,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
         }),
       },
       '&:active': {
+        /* variant */
         ...(props.variant === 'bold' && {
           backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.3),
         }),
@@ -231,6 +237,7 @@ const useStyles = makeStyles<Unstable_TagClassKey>(
       height: '1em',
       margin: '0 4px 0 0',
       width: '1em',
+      /* size */
       ...(props.size === 'medium' && {
         fontSize: theme.typography.pxToRem(16),
       }),

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -158,9 +158,9 @@ export interface Unstable_TextFieldProps
 
 export type Unstable_TextFieldClassKey = 'root';
 
-const useStyles = makeStyles<Unstable_TextFieldClassKey>((theme) => ({
+const useStyles = makeStyles<Unstable_TextFieldClassKey>({
   root: {},
-}));
+});
 
 const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
   function TextField(props, ref) {

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -43,6 +43,7 @@ export type Unstable_TypographyClassKey = 'root';
 const useStyles = makeStyles<Unstable_TypographyClassKey>(
   (theme) => ({
     root: (props: Unstable_TypographyProps) => ({
+      /* variant & color */
       ...(props.variant === 'display' && {
         ...theme.unstable_typography.display,
         color: theme.unstable_palette.text.heading,


### PR DESCRIPTION
- Add block comment groupings to prop conditional spreads
- Pull focus styles before all props conditions because it's always constant
- Push disabled styles to be **last** so they override anything before it.
- Extract any common style blocks among conditional spreads
- Use `text.disabled` instead of `neutral[0]` where appropriate for text color
- Use `background.inverse` instead of `neutral[600]` where appropriate for background color
- Condition on `aria-expanded` as a prop instead of a DOM attribute