### PR TITLE
feat: support required radio groups

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -96,7 +96,7 @@ _This section details previews of breaking changes or experimental features that
   - Props API Changes:
     - `classes`: removed all class keys _except `'root'`_
 - **Unstable_FormHelperText**
-  - Remove default left-margin.
+  - Remove default margin.
 - **Unstable_FormLabel**
   - Initial implementation of **FormLabel** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -131,10 +131,12 @@ _This section details previews of breaking changes or experimental features that
   - (see Unstable_Input)
 - **Unstable_TextField**
   - (see Unstable_Input, Unstable_InputLabel, Unstable_FormHelperText)
-  - Replace internal use of Unstable_InputLabel with Unstable_FormLabel.
   - Props API Changes:
     - `InputLabelProps`: removed
     - `FormLabelProps`: added; applied to the `FormLabel` element
+  - Internal:
+    - use Unstable_FormLabel instead of Unstable_InputLabel
+    - use Unstable_FormControl instead of FormControl
 
 ## [v1.0.0-alpha.8](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2022-06-03)
 

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -58,24 +58,6 @@ _This section details previews of breaking changes or experimental features that
     - `edge`: removed
     - `error`: added; display the component in an error state
     - `size`: removed
-- **Unstable_FormControlLabel**
-  - Initial implementation of **FormControlLabel** replacement according to PDS v2.
-  - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
-  - CSS API Changes:
-    - Removed all class keys _except `'root' | 'label'`_.
-  - Props API Changes:
-    - `classes`: removed all class keys _except `'root' | 'label'`_
-    - `error`: added; display the label and control in an error state
-- **Unstable_IconButton**
-  - Add `color` prop with preliminary support for the `"ghost"` variant on inverse backgrounds.
-    - values: `"standard" | "inverse"`
-    - default value: `"standard"`
-    - (does not affect display of `"primary" | "stroked"` variants yet -- planned for future)
-- **Unstable_Input**
-  - Remove default margin that accounted for the box-shadow effects.
-- **Unstable_InputLabel**
-  - **Removed**.
-  - Migration: use Unstable_FormLabel instead as a one-to-one replacement.
 - **Unstable_FormControl**
   - Initial implementation of **FormControl** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -88,6 +70,15 @@ _This section details previews of breaking changes or experimental features that
     - `margin`: removed
     - `size`: removed
     - `variant`: removed
+- **Unstable_FormControlLabel**
+  - Initial implementation of **FormControlLabel** replacement according to PDS v2.
+  - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
+  - CSS API Changes:
+    - Removed all class keys _except `'root' | 'label'`_.
+  - Props API Changes:
+    - `classes`: removed all class keys _except `'root' | 'label'`_
+    - `error`: added; display the label and control in an error state
+    - `required`: added; the control element will be required
 - **Unstable_FormGroup**
   - Initial implementation of **FormGroup** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -106,6 +97,16 @@ _This section details previews of breaking changes or experimental features that
     - `classes`: removed all class keys _except `'root' | 'asterisk'`_
     - `color`: removed
     - `filled`: removed
+- **Unstable_IconButton**
+  - Add `color` prop with preliminary support for the `"ghost"` variant on inverse backgrounds.
+    - values: `"standard" | "inverse"`
+    - default value: `"standard"`
+    - (does not affect display of `"primary" | "stroked"` variants yet -- planned for future)
+- **Unstable_Input**
+  - Remove default margin that accounted for the box-shadow effects.
+- **Unstable_InputLabel**
+  - **Removed**.
+  - Migration: use Unstable_FormLabel instead as a one-to-one replacement.
 - **Unstable_Radio**
   - Initial implementation of **Radio** replacement according to PDS v2.
   - Supports rendering _without_ `theme` being in an ancestor `ThemeProvider`.
@@ -124,6 +125,7 @@ _This section details previews of breaking changes or experimental features that
     - Removed all class keys _except `'root'`_.
   - Props API Changes:
     - `classes`: removed all class keys _except `'root'`_
+    - `required`: added; descendant controls (i.e. `input` elements) will be required
 - **Unstable_SectionMessage**
   - Fix `closeText` not being applied to the _close_ icon button (resulted in not having an accessible name, i.e. `aria-label`).
   - Add `CloseProps` prop to apply props to the _close_ icon button.

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.stories.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.stories.tsx
@@ -26,7 +26,9 @@ export default {
       mapping: {
         '(Checkbox Field)': (
           <>
-            <Unstable_FormLabel component="legend">Label</Unstable_FormLabel>
+            <span>
+              <Unstable_FormLabel component="legend">Label</Unstable_FormLabel>
+            </span>
             <Unstable_FormGroup>
               <Unstable_FormControlLabel
                 control={<Unstable_Checkbox />}
@@ -55,7 +57,9 @@ export default {
         ),
         '(Radio Field)': (
           <>
-            <Unstable_FormLabel component="legend">Label</Unstable_FormLabel>
+            <span>
+              <Unstable_FormLabel component="legend">Label</Unstable_FormLabel>
+            </span>
             <Unstable_RadioGroup>
               <Unstable_FormControlLabel
                 control={<Unstable_Radio />}

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -2,6 +2,8 @@ import React, { ElementType, forwardRef } from 'react';
 import MuiFormControl, {
   FormControlProps as MuiFormControlProps,
 } from '@material-ui/core/FormControl';
+import clsx from 'clsx';
+import makeStyles from '../makeStyles';
 import { OverridableComponent, OverrideProps } from '../utils';
 
 export interface Unstable_FormControlTypeMap<
@@ -26,11 +28,29 @@ export type Unstable_FormControlProps<
 
 export type Unstable_FormControlClassKey = 'root';
 
+const useStyles = makeStyles<Unstable_FormControlClassKey>(
+  {
+    /** Styles applied to the root element. */
+    root: {
+      gap: 8,
+    },
+  },
+  { name: 'MuiSparkUnstable_FormControl' }
+);
+
 const Unstable_FormControl: OverridableComponent<Unstable_FormControlTypeMap> = forwardRef(
   function Unstable_FormControl(props, ref) {
-    const { color: _color, ...other } = props;
+    const { classes: classesProp, color: _color, ...other } = props;
 
-    return <MuiFormControl ref={ref} {...other} />;
+    const classes = useStyles();
+
+    return (
+      <MuiFormControl
+        classes={{ root: clsx(classes.root, classesProp?.root) }}
+        ref={ref}
+        {...other}
+      />
+    );
   }
 );
 

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -15,6 +15,10 @@ export interface Unstable_FormControlLabelProps
    * If `true`, the label and control should be displayed in an error state.
    */
   error?: boolean;
+  /**
+   * If `true`, the control element will be required.
+   */
+  required?: boolean;
 }
 
 export type Unstable_FormControlLabelClassKey = 'root' | 'label' | 'error';
@@ -57,30 +61,38 @@ const Unstable_FormControlLabel = forwardRef<
   unknown,
   Unstable_FormControlLabelProps
 >(function Unstable_FormControlLabel(props, ref) {
-  const { classes: classesProp, className, control, error, ...other } = props;
+  const {
+    classes: classesProp,
+    className,
+    control,
+    // underscored props will be processed directly from `props` by `formControlState` below
+    error: _error,
+    required: _required,
+    ...other
+  } = props;
 
   const classes = useStyles();
 
-  const muiFormControl = useFormControl();
+  const fc = useFormControl();
   const fcs = formControlState({
     props,
-    muiFormControl,
-    states: ['error'],
+    muiFormControl: fc,
+    states: ['error', 'required'],
   });
 
   const controlProps = {};
-  ['error'].forEach((key) => {
+  ['error', 'required'].forEach((key) => {
     if (
       typeof control.props[key] === 'undefined' &&
-      typeof props[key] !== 'undefined'
+      typeof fcs[key] !== 'undefined'
     ) {
-      controlProps[key] = props[key];
+      controlProps[key] = fcs[key];
     }
   });
 
   return (
     <MuiFormControlLabel
-      className={clsx(className, { [classes.error]: error || fcs.error })}
+      className={clsx(className, { [classes.error]: fcs.error })}
       classes={{
         root: clsx(classes.root, classesProp?.root),
         label: clsx(classes.label, classesProp?.label),

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles<Unstable_FormHelperTextClassKey>(
       },
       // double-specificity to override PDS v1
       '&&': {
-        marginTop: 8,
+        marginTop: 0,
       },
     },
   }),

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -30,7 +30,6 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
     root: {
       ...theme.unstable_typography.label,
       color: theme.unstable_palette.text.heading,
-      marginBottom: 8,
       /* focused -- can get from internal context => can't condition on prop */
       '&.Mui-focused': {
         // override Mui default
@@ -38,7 +37,7 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
       },
       /* error -- can get from internal context => can't condition on prop */
       '&.Mui-error': {
-        color: theme.unstable_palette.red[700],
+        color: theme.unstable_palette.text.heading,
       },
       /* disabled -- can get from internal context => can't condition on prop */
       '&.Mui-disabled': {

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
@@ -7,6 +7,7 @@ import {
 import makeStyles from '../makeStyles';
 import { StyledComponentProps } from '../utils';
 import Unstable_RadioIcon from './Unstable_RadioIcon';
+import { useRadioGroupMore } from '../Unstable_RadioGroup';
 
 export interface Unstable_RadioProps
   extends Omit<
@@ -55,24 +56,39 @@ const useStyles = makeStyles<Unstable_RadioClassKey>(
 
 const Unstable_Radio = forwardRef<unknown, Unstable_RadioProps>(
   function Unstable_Radio(props, ref) {
-    const { classes: classesProp, className, error, ...other } = props;
+    const {
+      classes: classesProp,
+      className,
+      error,
+      required: requiredProp,
+      ...other
+    } = props;
 
     const classes = useStyles();
+
+    const radioGroup = useRadioGroupMore();
+
+    let required = requiredProp;
+
+    if (radioGroup) {
+      if (typeof required === 'undefined') {
+        required = radioGroup.required;
+      }
+    }
 
     return (
       <MuiRadio
         checkedIcon={<Unstable_RadioIcon checked />}
-        color="default"
+        classes={{ root: clsx(classes.root, classesProp?.root) }}
         className={clsx(className, { [classes.error]: error })}
-        classes={{
-          root: clsx(classes.root, classesProp?.root),
-        }}
+        color="default"
         disableFocusRipple
         disableRipple
         disableTouchRipple
         focusRipple={false}
         icon={<Unstable_RadioIcon />}
         ref={ref as Ref<HTMLButtonElement>}
+        required={required}
         {...other}
       />
     );

--- a/libs/spark/src/Unstable_RadioGroup/RadioGroupMoreContext.ts
+++ b/libs/spark/src/Unstable_RadioGroup/RadioGroupMoreContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import { Unstable_RadioGroupProps } from './Unstable_RadioGroup';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RadioGroupMoreState
+  extends Pick<Unstable_RadioGroupProps, 'required'> {}
+
+const RadioGroupMoreContext = createContext<RadioGroupMoreState>({
+  required: false,
+});
+
+if (process.env.NODE_ENV !== 'production') {
+  RadioGroupMoreContext.displayName = 'RadioGroupMoreContext';
+}
+
+export default RadioGroupMoreContext;

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
@@ -68,6 +68,13 @@ ChildrenLabeledRadiosDefaultValue.args = {
 ChildrenLabeledRadiosDefaultValue.storyName =
   'children=(Labeled Radios) defaultValue';
 
+export const ChildrenLabeledRadiosRequired: Story = Template.bind({});
+ChildrenLabeledRadiosRequired.args = {
+  children: '(Labeled Radios)',
+  required: true,
+};
+ChildrenLabeledRadiosRequired.storyName = 'children=(Labeled Radios) required';
+
 export const ChildrenLabeledRadiosRow: Story = Template.bind({});
 ChildrenLabeledRadiosRow.args = {
   children: '(Labeled Radios)',

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -5,10 +5,17 @@ import MuiRadioGroup, {
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
 import { StyledComponentProps } from '../utils';
+import { formControlState, useFormControl } from '../Unstable_FormControl';
+import RadioGroupMoreContext from './RadioGroupMoreContext';
 
 export interface Unstable_RadioGroupProps
   extends Omit<MuiRadioGroupProps, 'classes'>,
-    StyledComponentProps<Unstable_RadioGroupClassKey> {}
+    StyledComponentProps<Unstable_RadioGroupClassKey> {
+  /**
+   * If `true`, then descendant controls (i.e. `input` elements) will be required.
+   */
+  required?: boolean;
+}
 
 export type Unstable_RadioGroupClassKey = 'root';
 
@@ -25,16 +32,31 @@ const useStyles = makeStyles<Unstable_RadioGroupClassKey>(
 
 const Unstable_RadioGroup = forwardRef<unknown, Unstable_RadioGroupProps>(
   function Unstable_RadioGroup(props, ref) {
-    const { classes: classesProp, ...other } = props;
+    const {
+      classes: classesProp,
+      id: idProp,
+      // underscored props will be processed directly from `props` by `formControlState` below
+      required: _required,
+      ...other
+    } = props;
 
     const classes = useStyles();
 
+    const fc = useFormControl();
+    const fcs = formControlState({
+      props,
+      muiFormControl: fc,
+      states: ['error', 'required'],
+    });
+
     return (
-      <MuiRadioGroup
-        classes={{ root: clsx(classes.root, classesProp?.root) }}
-        ref={ref}
-        {...other}
-      />
+      <RadioGroupMoreContext.Provider value={{ required: fcs.required }}>
+        <MuiRadioGroup
+          classes={{ root: clsx(classes.root, classesProp?.root) }}
+          ref={ref}
+          {...other}
+        />
+      </RadioGroupMoreContext.Provider>
     );
   }
 );

--- a/libs/spark/src/Unstable_RadioGroup/index.ts
+++ b/libs/spark/src/Unstable_RadioGroup/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Unstable_RadioGroup';
 export * from './Unstable_RadioGroup';
+export { default as useRadioGroupMore } from './useRadioGroupMore';

--- a/libs/spark/src/Unstable_RadioGroup/useRadioGroupMore.ts
+++ b/libs/spark/src/Unstable_RadioGroup/useRadioGroupMore.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import RadioGroupMoreContext, {
+  RadioGroupMoreState,
+} from './RadioGroupMoreContext';
+
+export default function useRadioGroupMore(): RadioGroupMoreState | undefined {
+  return useContext(RadioGroupMoreContext);
+}

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -5,26 +5,22 @@ import React, {
   Ref,
   RefObject,
 } from 'react';
-import clsx from 'clsx';
 import Unstable_Input, { Unstable_InputProps } from '../Unstable_Input';
 import Unstable_FormLabel, {
   Unstable_FormLabelProps,
 } from '../Unstable_FormLabel';
-import FormControl, { FormControlProps } from '../FormControl';
+import Unstable_FormControl, {
+  Unstable_FormControlProps,
+} from '../Unstable_FormControl';
 import Unstable_FormHelperText, {
   Unstable_FormHelperTextProps,
 } from '../Unstable_FormHelperText';
 import Unstable_Select, { Unstable_SelectProps } from '../Unstable_Select';
-import makeStyles from '../makeStyles';
-import { StandardProps, useId } from '../utils';
+import { useId } from '../utils';
 
 export interface Unstable_TextFieldProps
-  extends StandardProps<
-    Omit<
-      FormControlProps,
-      'color' | 'hiddenLabel' | 'margin' | 'size' | 'variant'
-    >,
-    Unstable_TextFieldClassKey,
+  extends Omit<
+    Unstable_FormControlProps,
     // event handlers are declared on derived interfaces
     'onChange' | 'onBlur' | 'onFocus' | 'defaultValue'
   > {
@@ -55,7 +51,7 @@ export interface Unstable_TextFieldProps
    */
   error?: boolean;
   /**
-   * Props applied to the [`FormHelperText`](/api/form-helper-text/) element.
+   * Props applied to the `FormHelperText` element.
    */
   FormHelperTextProps?: Partial<Unstable_FormHelperTextProps>;
   /**
@@ -130,12 +126,12 @@ export interface Unstable_TextFieldProps
    */
   minRows?: string | number;
   /**
-   * Render a [`Select`](/api/select/) element while passing the Input element to `Select` as `input` parameter.
+   * Render a `Select` element while passing the `Input` element to `Select` as `input` parameter.
    * If this option is set you must pass the options of the select as children.
    */
   select?: boolean;
   /**
-   * Props applied to the [`Select`](/api/select/) element.
+   * Props applied to the `Select` element.
    */
   SelectProps?: Partial<Unstable_SelectProps>;
   /**
@@ -143,7 +139,7 @@ export interface Unstable_TextFieldProps
    */
   success?: boolean;
   /**
-   * The content of the `endAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
+   * The content of the `endAdornment` (an `InputAdornment`), usually an `Icon`, `IconButton`, or `string`.
    */
   trailingEl?: ReactNode;
   /**
@@ -156,20 +152,12 @@ export interface Unstable_TextFieldProps
   value?: unknown;
 }
 
-export type Unstable_TextFieldClassKey = 'root';
-
-const useStyles = makeStyles<Unstable_TextFieldClassKey>({
-  root: {},
-});
-
 const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
-  function TextField(props, ref) {
+  function Unstable_TextField(props, ref) {
     const {
       autoComplete,
       autoFocus = false,
       children,
-      classes: classesProp,
-      className,
       defaultValue,
       disabled = false,
       error = false,
@@ -201,8 +189,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       ...other
     } = props;
 
-    const classes = useStyles();
-
     const id = useId(idProp);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -224,7 +210,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
     }
 
     const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
-    const formLabelId = label && id ? `${id}-label` : undefined;
+    const labelId = label && id ? `${id}-label` : undefined;
     const InputElement = (
       <Unstable_Input
         aria-describedby={helperTextId}
@@ -255,8 +241,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
     );
 
     return (
-      <FormControl
-        className={clsx(classes.root, classesProp?.root, className)}
+      <Unstable_FormControl
         disabled={disabled}
         error={error}
         fullWidth={fullWidth}
@@ -264,17 +249,17 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         required={required}
         {...other}
       >
-        {label && (
-          <Unstable_FormLabel htmlFor={id} id={formLabelId} {...FormLabelProps}>
+        {label ? (
+          <Unstable_FormLabel htmlFor={id} id={labelId} {...FormLabelProps}>
             {label}
           </Unstable_FormLabel>
-        )}
+        ) : null}
 
         {select ? (
           <Unstable_Select
             aria-describedby={helperTextId}
             id={id}
-            labelId={formLabelId}
+            labelId={labelId}
             value={value}
             input={InputElement}
             {...SelectProps}
@@ -285,12 +270,12 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
           InputElement
         )}
 
-        {helperText && (
+        {helperText ? (
           <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
             {helperText}
           </Unstable_FormHelperText>
-        )}
-      </FormControl>
+        ) : null}
+      </Unstable_FormControl>
     );
   }
 );


### PR DESCRIPTION
"Required" radio groups are supported and spec'd [in the HTML spec](https://html.spec.whatwg.org/multipage/input.html#the-required-attribute), but not by Mui's RadioGroup component. We add support here but mirroring Mui's internal "RadioGroupContext" pattern, naming it "RadioGroupMore..." instead. Descendant components like FormControlLabel and Radio are given explicit naming and handling of this prop and context.

Aside: the changelog and some out-of-order entries so I rearranged those as well.