### PR TITLE
feat(Unstable_FormGroup): widen gap in row layout

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.9...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_CheckboxGroupField**
+  - See **Unstable_FormGroup**
+- **Unstable_FormGroup**
+  - Styles: widen gap in row layout.
+- **Unstable_RadioGroup**
+  - See **Unstable_FormGroup**
+- **Unstable_RadioGroupField**
+  - See **Unstable_FormGroup**
+
 ## [v1.0.0-alpha.9](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.8...v1.0.0-alpha.9) (2022-06-21)
 
 ### Unstable Preview

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
@@ -16,7 +16,8 @@ const useStyles = makeStyles<Unstable_FormGroupClassKey>(
   {
     /** Styles applied to the root element. */
     root: {
-      gap: 16,
+      columnGap: 32,
+      rowGap: 16,
       width: 'fit-content',
     },
   },


### PR DESCRIPTION
Small change to have wider gaps when in a row for readability. Matches Figma design.