### PR TITLE
feat(Unstable_Select)!: add renderValueAsTag prop

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -34,7 +34,15 @@ _This section details previews of breaking changes or experimental features that
   - Initial implementation.
 - **Unstable_Select**
   - Props API changes:
-    - `preventMultipleOverflow`: added; values `'large' | 'medium'` where `'large'` is default.
+    - `preventMultipleOverflow`
+      - Added
+      - Values: `'large' | 'medium'` where `'large'` is default
+      - Purpose: Prevent the component from overflowing vertically (particularly when render the value as a tag) (note, a horizontal scrollbar will appear and cause some vertical growth).
+    - `renderValueAsTag`:
+      - Added
+      - Values: `true | false` where `false` is default
+      - Purpose: Render the value(s) as an `Unstable_Tag` component(s).
+      - Breaking Change: set `renderValueAsTag={true}` where previously only `multiple={true}` and the desire is to render the values as Tag components.
   - Styles: match new menu (paper) specifications.
 - **Unstable_TextField**
   - See **Unstable_Select**

--- a/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
@@ -158,6 +158,13 @@ MultipleValues.args = {
 };
 MultipleValues.storyName = 'multiple value=[...]';
 
+export const Multiple4Values: Story = Template.bind({});
+Multiple4Values.args = {
+  value: ['value-1', 'value-2', 'value-3', 'value-4'],
+  multiple: true,
+};
+Multiple4Values.storyName = 'multiple value=[...x4]';
+
 export const MultipleValuesDisabled: Story = Template.bind({});
 MultipleValuesDisabled.args = {
   value: ['value-1', 'value-2'],
@@ -166,12 +173,32 @@ MultipleValuesDisabled.args = {
 };
 MultipleValuesDisabled.storyName = 'multiple value=[...] disabled';
 
+export const MultipleValuesRenderValueAsTag: Story = Template.bind({});
+MultipleValuesRenderValueAsTag.args = {
+  value: ['value-1', 'value-2'],
+  multiple: true,
+  renderValueAsTag: true,
+};
+MultipleValuesRenderValueAsTag.storyName =
+  'multiple value=[...] renderValueAsTag';
+
+export const MultipleValuesRenderValueAsTagDisabled: Story = Template.bind({});
+MultipleValuesRenderValueAsTagDisabled.args = {
+  value: ['value-1', 'value-2'],
+  multiple: true,
+  disabled: true,
+  renderValueAsTag: true,
+};
+MultipleValuesRenderValueAsTagDisabled.storyName =
+  'multiple value=[...] disabled renderValueAsTag';
+
 export const MultipleValuesGetTagProps: Story = Template.bind({});
 MultipleValuesGetTagProps.args = {
   value: ['value-1', 'value-2', 'value-3', 'value-4'],
   multiple: true,
   getTagProps: '(getValueLabels)',
+  renderValueAsTag: true,
   preventMultipleOverflow: true,
 };
 MultipleValuesGetTagProps.storyName =
-  'multiple value=[...] getTagProps preventMultipleOverflow';
+  'multiple value=[...] getTagProps renderValueAsTag preventMultipleOverflow';

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -54,7 +54,7 @@ export interface Unstable_SelectProps
       | 'value'
     > {
   /**
-   * A tag props getter. Use to customize the props of `Unstable_Tag`'s rendered when `multiple={true}`.
+   * A tag props getter. Use to customize the props of `Unstable_Tag`'s rendered when `renderValueAsTag={true}`.
    */
   getTagProps?: ({
     value,
@@ -67,6 +67,10 @@ export interface Unstable_SelectProps
    * Prevent the render container from overflowing with multiple values or tags.
    */
   preventMultipleOverflow?: boolean;
+  /**
+   * Render the value as Tag components.
+   */
+  renderValueAsTag?: boolean;
 }
 
 export type Unstable_SelectClassKey =
@@ -97,8 +101,8 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
           // adjust embedded Menu's anchor/transform position to edge when there's a startAdornment
           marginLeft: -40,
         },
-        /* multiple */
-        ...(props.multiple && {
+        /* renderValueAsTag */
+        ...(props.renderValueAsTag && {
           paddingBottom: 8,
           paddingTop: 8,
           '& > div': {
@@ -111,7 +115,7 @@ const useStyles = makeStyles<Unstable_SelectClassKey>(
               whiteSpace: 'nowrap',
             }),
           },
-          '& > .PrivateSelect-multipleNoValue': {
+          '& > .PrivateSelect-renderValueAsTagNoValue': {
             paddingBottom: 4,
             paddingTop: 4,
           },
@@ -174,12 +178,16 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
       open,
       preventMultipleOverflow = false,
       renderValue: renderValueProp,
+      renderValueAsTag = false,
       value,
       SelectDisplayProps,
       ...other
     } = props;
 
-    const classes = useStyles({ multiple, preventMultipleOverflow });
+    const classes = useStyles({
+      preventMultipleOverflow,
+      renderValueAsTag,
+    });
     const paperClasses = useUnstable_PaperStyles();
 
     const inputComponent = native ? MuiNativeSelectInput : MuiSelectInput;
@@ -189,7 +197,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
     let renderValue;
     if (renderValueProp) {
       renderValue = renderValueProp;
-    } else if (multiple) {
+    } else if (renderValueAsTag) {
       renderValue = (selected: string[]) => {
         if (selected.length) {
           return (
@@ -208,7 +216,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
         } else {
           return (
             <div
-              className="PrivateSelect-multipleNoValue"
+              className="PrivateSelect-renderValueAsTagNoValue"
               // [from MUI] Set `dangerouslySetInnerHTML` so the vertical align positioning algorithm kicks in; otherwise, the component shifts up in positioning because this span is rendered too high.
               dangerouslySetInnerHTML={{ __html: '&#8203;' }}
             />


### PR DESCRIPTION
I had thought the design system's intention was to render the values of _all_ multiple select inputs as Tag's, but that is not the case. So it's now controlled by a prop and off by default. Note that this is technically a breaking change.