### PR TITLE
fix: swallowing of class name and wrong ordering

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.11...vNext) (yyyy-mm-dd)
 
-No changes.
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_CheckboxField**
+  - Fixed wrong ordering of class names.
+- **Unstable_CheckboxListItem**
+  - Fixed swallowing `className` prop.
+- **Unstable_CheckboxMenuItem**
+  - Fixed swallowing `className` prop.
+- **Unstable_FormControlLabel**
+  - Fixed wrong ordering of class names.
+- **Unstable_Menu**
+  - Fixed swallowing `classes` and `className` props.
+- **Unstable_MenuItem**
+  - Fixed swallowing `className` prop.
+- **Unstable_MenuList**
+  - Fixed swallowing `classes` and `className` props.
+- **Unstable_Paper**
+  - Fixed swallowing `className` prop.
+- **Unstable_RadioField**
+  - Fixed wrong ordering of class names.
 
 ## [v1.0.0-alpha.11](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2022-07-11)
 

--- a/libs/spark/src/Unstable_CheckboxField/Unstable_CheckboxField.tsx
+++ b/libs/spark/src/Unstable_CheckboxField/Unstable_CheckboxField.tsx
@@ -70,7 +70,7 @@ const Unstable_CheckboxField = forwardRef<unknown, Unstable_CheckboxFieldProps>(
     const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
 
     return (
-      <div className={clsx(className, classes.root)}>
+      <div className={clsx(classes.root, className)}>
         <Unstable_FormControlLabel
           control={
             <Unstable_Checkbox

--- a/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.tsx
@@ -162,7 +162,7 @@ const Unstable_CheckboxListItem: OverridableComponent<
           ListItemClasses?.primary
         ),
       }}
-      className={clsx(classes.root, classesProp?.root)}
+      className={clsx(classes.root, classesProp?.root, className)}
       disabled={disabled}
       onClick={handleClick}
       primary={primary}

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
@@ -7,6 +7,7 @@ import Unstable_CheckboxListItem, {
 } from '../Unstable_CheckboxListItem';
 import { OverridableComponent, OverrideProps } from '../utils';
 import { ExtendButtonBase } from '../ButtonBase';
+import { alpha } from '@material-ui/core/styles';
 
 export type Unstable_CheckboxMenuItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -31,14 +32,25 @@ export type Unstable_CheckboxMenuItemProps<
 export type Unstable_CheckboxMenuItemClassKey = 'root' | 'selected';
 
 const useStyles = makeStyles(
-  {
+  (theme) => ({
     root: {
       width: 'auto',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
+      // reset selected styles since only checkbox should appear selected
+      '&$selected': {
+        backgroundColor: 'transparent',
+        color: theme.unstable_palette.text.body,
+      },
+      '&$selected:hover': {
+        backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.08),
+      },
+      '&$selected:active': {
+        backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
+      },
     },
     selected: {},
-  },
+  }),
   { name: 'MuiSparkUnstable_CheckboxMenuItem' }
 );
 
@@ -78,14 +90,9 @@ const Unstable_CheckboxMenuItem: OverridableComponent<
   return (
     <Unstable_CheckboxListItem
       classes={ListItemClasses}
-      className={clsx(
-        classes.root,
-        classesProp?.root,
-        {
-          [clsx(classes.selected, classesProp?.selected)]: selected,
-        },
-        className
-      )}
+      className={clsx(classes.root, classesProp?.root, {
+        [clsx(classes.selected, classesProp?.selected)]: selected,
+      })}
       component={component}
       ref={ref as Ref<HTMLLIElement>}
       role={role}

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
@@ -78,9 +78,14 @@ const Unstable_CheckboxMenuItem: OverridableComponent<
   return (
     <Unstable_CheckboxListItem
       classes={ListItemClasses}
-      className={clsx(classes.root, classesProp?.root, {
-        [clsx(classes.selected, classesProp?.selected)]: selected,
-      })}
+      className={clsx(
+        classes.root,
+        classesProp?.root,
+        {
+          [clsx(classes.selected, classesProp?.selected)]: selected,
+        },
+        className
+      )}
       component={component}
       ref={ref as Ref<HTMLLIElement>}
       role={role}

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -92,7 +92,7 @@ const Unstable_FormControlLabel = forwardRef<
 
   return (
     <MuiFormControlLabel
-      className={clsx(className, { [classes.error]: fcs.error })}
+      className={clsx({ [classes.error]: fcs.error }, className)}
       classes={{
         root: clsx(classes.root, classesProp?.root),
         label: clsx(classes.label, classesProp?.label),

--- a/libs/spark/src/Unstable_Menu/Unstable_Menu.tsx
+++ b/libs/spark/src/Unstable_Menu/Unstable_Menu.tsx
@@ -1,7 +1,10 @@
 import React, { forwardRef } from 'react';
-import MuiMenu, { MenuProps as MuiMenuProps } from '@material-ui/core/Menu';
+import MuiMenu, {
+  MenuProps as MuiMenuProps,
+  MenuClassKey as MuiMenuClassKey,
+} from '@material-ui/core/Menu';
 import Unstable_ListSubheader from '../Unstable_ListSubheader';
-import { Unstable_ListClassKey, Unstable_ListProps } from '../Unstable_List';
+import { Unstable_ListProps } from '../Unstable_List';
 import { StandardProps, useId } from '../utils';
 import { useUnstable_PaperStyles } from '../Unstable_Paper';
 
@@ -15,17 +18,11 @@ export interface Unstable_MenuProps
     Pick<Unstable_ListProps, 'ListSubheaderProps' | 'subheader'>;
 }
 
-export type Unstable_MenuClassKey = Unstable_ListClassKey;
+export type Unstable_MenuClassKey = MuiMenuClassKey;
 
 const Unstable_Menu = forwardRef<unknown, Unstable_MenuProps>(
   function Unstable_Menu(props, ref) {
-    const {
-      classes: classesProp,
-      className,
-      MenuListProps,
-      PaperProps,
-      ...other
-    } = props;
+    const { MenuListProps, PaperProps, ...other } = props;
 
     const paperClasses = useUnstable_PaperStyles();
 

--- a/libs/spark/src/Unstable_MenuItem/Unstable_MenuItem.tsx
+++ b/libs/spark/src/Unstable_MenuItem/Unstable_MenuItem.tsx
@@ -79,9 +79,14 @@ const Unstable_MenuItem: OverridableComponent<
     <Unstable_ListItem
       button
       classes={ListItemClasses}
-      className={clsx(classes.root, classesProp?.root, {
-        [clsx(classes.selected, classesProp?.selected)]: selected,
-      })}
+      className={clsx(
+        classes.root,
+        classesProp?.root,
+        {
+          [clsx(classes.selected, classesProp?.selected)]: selected,
+        },
+        className
+      )}
       component={component}
       ref={ref as Ref<HTMLLIElement>}
       role={role}

--- a/libs/spark/src/Unstable_MenuList/Unstable_MenuList.tsx
+++ b/libs/spark/src/Unstable_MenuList/Unstable_MenuList.tsx
@@ -19,13 +19,7 @@ export type Unstable_MenuListClassKey = Unstable_ListClassKey;
 
 const Unstable_MenuList = forwardRef<unknown, Unstable_MenuListProps>(
   function Unstable_MenuList(props, ref) {
-    const {
-      classes: classesProp,
-      className,
-      ListSubheaderProps,
-      subheader,
-      ...other
-    } = props;
+    const { ListSubheaderProps, subheader, ...other } = props;
 
     const subheaderId = useId(ListSubheaderProps?.id);
 

--- a/libs/spark/src/Unstable_Paper/Unstable_Paper.tsx
+++ b/libs/spark/src/Unstable_Paper/Unstable_Paper.tsx
@@ -44,7 +44,6 @@ const Unstable_Paper = forwardRef<unknown, Unstable_PaperProps>(
   function Unstable_Paper(props, ref) {
     const {
       classes: classesProp,
-      className,
       elevation = 1,
       variant = 'elevation',
       ...other

--- a/libs/spark/src/Unstable_RadioField/Unstable_RadioField.tsx
+++ b/libs/spark/src/Unstable_RadioField/Unstable_RadioField.tsx
@@ -65,7 +65,7 @@ const Unstable_RadioField = forwardRef<unknown, Unstable_RadioFieldProps>(
     const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
 
     return (
-      <div className={clsx(className, classes.root)}>
+      <div className={clsx(classes.root, className)}>
         <Unstable_FormControlLabel
           control={
             <Unstable_Radio inputProps={{ 'aria-describedby': helperTextId }} />


### PR DESCRIPTION
Some components were swallowing classes / class name props and/or combining them in the wrong order.