### PR TITLE
feat(Unstable_CheckboxMenuItem): remove inner checkbox focus shadow

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -12,6 +12,7 @@ _This section details previews of breaking changes or experimental features that
   - Fixed swallowing `className` prop.
 - **Unstable_CheckboxMenuItem**
   - Fixed swallowing `className` prop.
+  - Removed focus effect on inner checkbox element.
 - **Unstable_FormControlLabel**
   - Fixed wrong ordering of class names.
 - **Unstable_Menu**

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.stories.tsx
@@ -26,6 +26,10 @@ export default {
 
 const Template = (args) => <Unstable_CheckboxMenuItem {...args} />;
 
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.parameters = { pseudo: { focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
+
 export const Value: Story = Template.bind({});
 Value.args = { value: 'value', checked: false };
 Value.storyName = 'value';

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles(
       width: 'auto',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
-      '& .MuiSparkUnstable_CheckboxIcon-root': {
+      '&& .MuiSparkUnstable_CheckboxIcon-root': {
         // remove focus shadow because menu item should be only element with the styling
         boxShadow: 'none',
       },

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
@@ -90,9 +90,14 @@ const Unstable_CheckboxMenuItem: OverridableComponent<
   return (
     <Unstable_CheckboxListItem
       classes={ListItemClasses}
-      className={clsx(classes.root, classesProp?.root, {
-        [clsx(classes.selected, classesProp?.selected)]: selected,
-      })}
+      className={clsx(
+        classes.root,
+        classesProp?.root,
+        {
+          [clsx(classes.selected, classesProp?.selected)]: selected,
+        },
+        className
+      )}
       component={component}
       ref={ref as Ref<HTMLLIElement>}
       role={role}

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.tsx
@@ -37,6 +37,10 @@ const useStyles = makeStyles(
       width: 'auto',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
+      '& .MuiSparkUnstable_CheckboxIcon-root': {
+        // remove focus shadow because menu item should be only element with the styling
+        boxShadow: 'none',
+      },
       // reset selected styles since only checkbox should appear selected
       '&$selected': {
         backgroundColor: 'transparent',


### PR DESCRIPTION
Only the menu item will appear with the focus box-shadow, not the inner checkbox.