### PR TITLE
feat(Unstable_ListItem): add nested prop

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -10,15 +10,21 @@ _This section details previews of breaking changes or experimental features that
   - Fixed wrong ordering of class names.
 - **Unstable_CheckboxListItem**
   - Fixed swallowing `className` prop.
+  - See **Unstable_ListItem** props API changes.
 - **Unstable_CheckboxMenuItem**
   - Fixed swallowing `className` prop.
   - Removed focus effect on inner checkbox element.
+  - See **Unstable_ListItem** props API changes.
 - **Unstable_FormControlLabel**
   - Fixed wrong ordering of class names.
+- **Unstable_ListItem**
+  - Props API Changes:
+    - `nested`: added; values: `undefined | true | false` where `true` is default.
 - **Unstable_Menu**
   - Fixed swallowing `classes` and `className` props.
 - **Unstable_MenuItem**
   - Fixed swallowing `className` prop.
+  - See **Unstable_ListItem** props API changes.
 - **Unstable_MenuList**
   - Fixed swallowing `classes` and `className` props.
 - **Unstable_Paper**

--- a/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
+++ b/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
@@ -206,6 +206,10 @@ LeadingElIconButtonSelectedDisabled.args = {
 LeadingElIconButtonSelectedDisabled.storyName =
   'leadingEl=(Icon) button selected disabled';
 
+export const Nested: Story = Template.bind({});
+Nested.args = { nested: true };
+Nested.storyName = 'nested';
+
 export const Primary: Story = Template.bind({});
 Primary.args = { children: undefined, primary: 'Primary text' };
 Primary.storyName = 'primary';
@@ -213,6 +217,10 @@ Primary.storyName = 'primary';
 export const PrimaryAction: Story = Template.bind({});
 PrimaryAction.args = { primaryAction: '(Checkbox)' };
 PrimaryAction.storyName = 'primaryAction=(Checkbox)';
+
+export const PrimaryActionNested: Story = Template.bind({});
+PrimaryActionNested.args = { primaryAction: '(Checkbox)', nested: true };
+PrimaryActionNested.storyName = 'primaryAction=(Checkbox) nested';
 
 export const PrimaryActionSecondaryActionButton: Story = Template.bind({});
 PrimaryActionSecondaryActionButton.args = {

--- a/libs/spark/src/Unstable_ListItem/Unstable_ListItem.tsx
+++ b/libs/spark/src/Unstable_ListItem/Unstable_ListItem.tsx
@@ -47,6 +47,10 @@ export interface Unstable_ListItemTypeMap<
        */
       leadingEl?: ReactNode;
       /**
+       * Indent all elements to create an appearance of a nested list item.
+       */
+      nested?: boolean;
+      /**
        * The primary content element.
        */
       primary?: ReactNode;
@@ -118,6 +122,7 @@ export type Unstable_ListItemClassKey =
   | 'contentGroupWrapReverse'
   | 'flexWrapWrap'
   | 'flexWrapWrapReverse'
+  | 'nested'
   | 'primary'
   | 'primaryAction'
   | 'primaryAndSecondary'
@@ -277,6 +282,10 @@ const useStyles = makeStyles<Unstable_ListItemClassKey>(
     disabled: {},
     /* Pseudo-class applied to the root element when `selected={true}`. */
     selected: {},
+    /* Styles applied to the root element when `nested={true}`. */
+    nested: {
+      paddingInlineStart: 24,
+    },
   }),
   { name: 'MuiSparkUnstable_ListItem' }
 );
@@ -297,6 +306,7 @@ const Unstable_ListItem: OverridableComponent<
     focusableButton = true,
     leadingEl,
     inset = false,
+    nested = false,
     primary,
     primaryAction,
     primaryTypographyProps,
@@ -389,6 +399,7 @@ const Unstable_ListItem: OverridableComponent<
           [clsx(classes.flexWrapWrapReverse, classesProp?.flexWrapWrapReverse)]:
             flexWrap === 'wrap-reverse',
           [clsx(classes.button, classesProp?.button)]: button,
+          [clsx(classes.nested, classesProp?.nested)]: nested,
         }),
         selected: clsx(classes.selected, classesProp?.selected),
         disabled: clsx(classes.disabled, classesProp?.disabled),


### PR DESCRIPTION
Very useful when having a primary action of a checkbox and needing to indent the entire element (not just the content group) under an item with an indeterminate grouping