### PR TITLE
fix(Unstable_Tag): wrong font weight for small size

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -31,6 +31,8 @@ _This section details previews of breaking changes or experimental features that
   - Fixed swallowing `className` prop.
 - **Unstable_RadioField**
   - Fixed wrong ordering of class names.
+- **Unstable_Tag**
+  - Fixed wrong font weight style of small size.
 
 ## [v1.0.0-alpha.11](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2022-07-11)
 

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -68,7 +68,7 @@ const tagFontVariantMedium = buildVariant(
   "'cv05' 1, 'ss03' 1"
 );
 const tagFontVariantSmall = buildVariant(
-  600,
+  500,
   12,
   20,
   undefined,


### PR DESCRIPTION
Should be 500, not 600. See [spec ](https://www.figma.com/file/y6Ca8BdJtQEd3Of1saRieF/components?node-id=1690%3A71)