### PR TITLE
fix(Unstable_FormLabel): bad margin under STP

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -17,6 +17,8 @@ _This section details previews of breaking changes or experimental features that
   - See **Unstable_ListItem** props API changes.
 - **Unstable_FormControlLabel**
   - Fixed wrong ordering of class names.
+- **Unstable_FormLabel**
+  - Fixed wrong margin when rendered under `SparkThemeProvider`.
 - **Unstable_ListItem**
   - Props API Changes:
     - `nested`: added; values: `undefined | true | false` where `true` is default.

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -8,6 +8,8 @@ _This section details previews of breaking changes or experimental features that
 
 - **Unstable_CheckboxField**
   - Fixed wrong ordering of class names.
+- **Unstable_CheckboxGroupField**
+  - See **Unstable_FormLabel** props API changes.
 - **Unstable_CheckboxListItem**
   - Fixed swallowing `className` prop.
   - See **Unstable_ListItem** props API changes.
@@ -33,8 +35,12 @@ _This section details previews of breaking changes or experimental features that
   - Fixed swallowing `className` prop.
 - **Unstable_RadioField**
   - Fixed wrong ordering of class names.
+- **Unstable_RadioGroupField**
+  - See **Unstable_FormLabel** props API changes.
 - **Unstable_Tag**
   - Fixed wrong font weight style of small size.
+- **Unstable_TextField**
+  - See **Unstable_FormLabel** for changes.
 
 ## [v1.0.0-alpha.11](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2022-07-11)
 

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles<Unstable_FormLabelClassKey>(
     root: {
       ...theme.unstable_typography.label,
       color: theme.unstable_palette.text.heading,
+      margin: 0,
       /* focused -- can get from internal context => can't condition on prop */
       '&.Mui-focused': {
         // override Mui default


### PR DESCRIPTION
Receives a `margin-bottom: 3px` when under a SparkThemeProvider. This was not well-exemplified by the "(STP)" story since it requires inspect element'ing to see the layout box values.