### PR TITLE
fix(Unstable_Tooltip): React is not defined

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.12...vNext) (yyyy-mm-dd)
 
+### Unstable Preview
+
+_This section details previews of breaking changes or experimental features that are subject to breaking changes at any time._
+
+- **Unstable_Tooltip**
+  - Fixed "React is not defined" error
+
 ## [v1.0.0-alpha.12](https://github.com/prenda-school/prenda-spark/compare/v1.0.0-alpha.11...v1.0.0-alpha.12) (2022-08-22)
 
 ### Unstable Preview

--- a/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.tsx
+++ b/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.tsx
@@ -4,7 +4,7 @@ import {
   TooltipProps as MuiTooltipProps,
 } from '@material-ui/core/Tooltip';
 import clsx from 'clsx';
-import { forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import makeStyles from '../makeStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
Some consumers (like PW) can't have the transform that eliminates this requirement