### PR TITLE
fix: type import/export included in esm JS build

### DIFF
--- a/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.tsx
@@ -5,8 +5,8 @@ import {
   CheckboxProps as MuiCheckboxProps,
 } from '@material-ui/core/Checkbox';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
 import Unstable_CheckboxIcon from './Unstable_CheckboxIcon';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_CheckboxProps
   extends Omit<

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.tsx
@@ -5,8 +5,8 @@ import {
   FormControlLabelProps as MuiFormControlLabelProps,
 } from '@material-ui/core/FormControlLabel';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
 import { formControlState, useFormControl } from '../Unstable_FormControl';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_FormControlLabelProps
   extends Omit<MuiFormControlLabelProps, 'classes'>,

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.tsx
@@ -4,7 +4,7 @@ import MuiFormGroup, {
 } from '@material-ui/core/FormGroup';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_FormGroupProps
   extends Omit<MuiFormGroupProps, 'classes'>,

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -5,8 +5,8 @@ import {
   InputBaseProps as MuiInputBaseProps,
 } from '@material-ui/core/InputBase';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
 import Unstable_InputAdornment from '../Unstable_InputAdornment';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_InputProps
   extends Omit<

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.tsx
@@ -5,9 +5,9 @@ import {
   RadioProps as MuiRadioProps,
 } from '@material-ui/core/Radio';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
 import Unstable_RadioIcon from './Unstable_RadioIcon';
 import { useRadioGroupMore } from '../Unstable_RadioGroup';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_RadioProps
   extends Omit<

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -4,9 +4,9 @@ import MuiRadioGroup, {
 } from '@material-ui/core/RadioGroup';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
 import { formControlState, useFormControl } from '../Unstable_FormControl';
 import RadioGroupMoreContext from './RadioGroupMoreContext';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_RadioGroupProps
   extends Omit<MuiRadioGroupProps, 'classes'>,

--- a/libs/spark/src/Unstable_Switch/Unstable_Switch.tsx
+++ b/libs/spark/src/Unstable_Switch/Unstable_Switch.tsx
@@ -5,7 +5,7 @@ import {
   SwitchProps as MuiSwitchProps,
 } from '@material-ui/core/Switch';
 import makeStyles from '../makeStyles';
-import { StyledComponentProps } from '../utils';
+import { StyledComponentProps } from '../withStyles';
 
 export interface Unstable_SwitchProps
   extends Omit<

--- a/libs/spark/src/utils/StandardProps.ts
+++ b/libs/spark/src/utils/StandardProps.ts
@@ -1,8 +1,6 @@
 import { CSSProperties, Ref } from 'react';
 import { StyledComponentProps } from '../withStyles';
 
-export { StyledComponentProps };
-
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
  * certain `classes`, on which one can also set a top-level `className` and inline

--- a/libs/spark/src/withStyles/withStyles.ts
+++ b/libs/spark/src/withStyles/withStyles.ts
@@ -9,7 +9,19 @@ import {
 import type { Theme } from '../theme';
 import initialTheme from '../theme/initialTheme';
 
-export * from '@material-ui/core/styles/withStyles';
+// enumerate all exports since `tsc` incorrectly identifies the re-exports in '@material-ui/core/styles/withStyles' as JS objects and not TS types.
+export type {
+  CreateCSSProperties,
+  CSSProperties,
+  ClassNameMap,
+  StyledComponentProps,
+  Styles,
+  WithStylesOptions,
+  StyleRulesCallback,
+  BaseCSSProperties,
+  StyleRules,
+  WithStyles,
+} from '@material-ui/core/styles/withStyles';
 
 export default function withStyles<
   ClassKey extends string,


### PR DESCRIPTION
Fixes an issue that first appeared when building Bridge. The "esm" build output is all JS files and thus should be stripped of all type variables. However, `StyledComponentProps` was still appearing in `esm/utils/StandardProps`. We think that TSC has a hard time recognizing something is just a type when its imported and re-exported. This change seems to prevent TSC from making mistakes.