### PR TITLE
feat(Typography)!: change variant mapping; make private

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -42,6 +42,8 @@
 - **Unstable_TextField**
   - Props API Changes:
     - `SelectProps`: see **Unstable_Select**.
+- **Unstable_Typography**
+  - Change default `component` for heading variants to `'span'`.
 
 ### Breaking changes
 
@@ -56,6 +58,12 @@
       - `elevation={4}` -> `elevation={400}`
       - `elevation={5}` -> `elevation={500}`
       - `elevation={6..24}` -> `elevation={500}`
+- **Unstable_Typography**
+  - Props API:
+    - `variantMapping`: removed.
+  - Migration:
+    - Props API:
+      - `variantMapping={...}` -> ` ` (remove) (use `component` prop directly)
 
 ## [v2.0.0-alpha.2](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.1...v2.0.0-alpha.2) (2022-09-08)
 

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -14,7 +14,10 @@ export interface Unstable_TypographyTypeMap<
   D extends ElementType = 'span'
 > {
   props: P &
-    Omit<MuiTypographyProps, 'classes' | 'variant' | 'color'> & {
+    Omit<
+      MuiTypographyProps,
+      'classes' | 'variant' | 'variantMapping' | 'color'
+    > & {
       variant?:
         | 'display'
         | 'T32'
@@ -127,13 +130,13 @@ const useStyles = makeStyles<Unstable_TypographyClassKey>(
   { name: 'MuiSparkUnstable_Typography' }
 );
 
-const defaultVariantMapping: Record<Unstable_TypographyVariant, string> = {
-  display: 'h1',
-  T32: 'h2',
-  T28: 'h3',
-  T22: 'h4',
-  T18: 'h5',
-  T14: 'h6',
+const variantToComponent: Record<Unstable_TypographyVariant, string> = {
+  display: 'span',
+  T32: 'span',
+  T28: 'span',
+  T22: 'span',
+  T18: 'span',
+  T14: 'span',
   body: 'p',
   label: 'span',
   description: 'p',
@@ -158,7 +161,7 @@ const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = fo
         classes={{
           root: clsx(classes.root, classesProp?.root),
         }}
-        component={component || defaultVariantMapping[variant]}
+        component={component || variantToComponent[variant]}
         ref={ref}
         {...other}
       />


### PR DESCRIPTION
The default of many instances of heading Typography's produces inaccessible pages because almost every design does not use variants as a given heading level. This always has to be determined independent of the heading variant, so we might as well not default to anything but "span".