### PR TITLE
chore(spark): improve inverse background decorator

### DIFF
--- a/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.stories.tsx
+++ b/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Unstable_SvgIcon } from '..';
+import { inverseBackground } from '../../stories';
 
 export const _retyped = Unstable_SvgIcon as typeof Unstable_SvgIcon;
 
@@ -38,10 +39,12 @@ ColorSecondary.storyName = 'color=secondary';
 
 export const ColorInverse: Story = Template.bind({});
 ColorInverse.args = { color: 'inverse' };
+ColorInverse.decorators = [inverseBackground];
 ColorInverse.storyName = 'color=inverse';
 
 export const ColorInverseSecondary: Story = Template.bind({});
 ColorInverseSecondary.args = { color: 'inverseSecondary' };
+ColorInverseSecondary.decorators = [inverseBackground];
 ColorInverseSecondary.storyName = 'color=inverseSecondary';
 
 export const FontSizeInherit: Story = Template.bind({});

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -67,17 +67,18 @@ export const statefulValue: DecoratorFn = (Story, context) => {
   return <Story />;
 };
 
-const InverseBackgroundDiv = styled('div')(({ theme }) => ({
+const InverseBackgroundSpan = styled('span')(({ theme }) => ({
   backgroundColor: theme.unstable_palette.background.inverse,
+  display: 'inline-flex',
 }));
 
 /**
  * [Internal] A Storybook decorator that applies the inverse background to a story.
  */
 export const inverseBackground: DecoratorFn = (Story) => (
-  <InverseBackgroundDiv>
+  <InverseBackgroundSpan>
     <Story />
-  </InverseBackgroundDiv>
+  </InverseBackgroundSpan>
 );
 
 const ContainFocusIndicatorDiv = styled('div')({


### PR DESCRIPTION
- Make "span" element instead of "div" so it doesn't make snapshots the width of the container.
- Specify "inline-flex" so that child inline elements don't position weirdly (for example, an svg tag will sit above where expected)

Also,
- add to `SvgIcon` inverse color stories