### PR TITLE
fix(Link): clashing variant type

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...vNext) (YYYY-MM-DD)
 
+### Fixes
+
+- **Unstable_Link**
+  - Clashing types for `variant` props resulting in `never`.
+
 ### Features
 
 - **theme**

--- a/libs/spark/src/Unstable_Link/Unstable_Link.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.tsx
@@ -13,7 +13,7 @@ export interface Unstable_LinkTypeMap<
   D extends ElementType = 'a'
 > {
   props: P &
-    Omit<MuiLinkProps, 'color' | 'classes' | 'underline'> & {
+    Omit<MuiLinkProps, 'color' | 'classes' | 'underline' | 'variant'> & {
       /**
        * Whether the link is displayed alone (not inline with other text). Removes "underline" text-decoration of the link.
        */


### PR DESCRIPTION
Clashing types for `variant` prop from underlying props (Link is typed as extension of Typography) resulting in `never`.