### PR TITLE
refactor(spark): include private classes in withStyles block

### DIFF
--- a/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
+++ b/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import makeStyles from '../makeStyles';
 import Unstable_Alert, {
   Unstable_AlertClassKey,
   Unstable_AlertProps,
@@ -13,98 +12,20 @@ export interface Unstable_BannerProps extends Unstable_AlertProps {}
 export type Unstable_BannerClassKey = Unstable_AlertClassKey;
 
 type PrivateClassKey =
-  | 'root-severity-error'
-  | 'root-severity-info'
-  | 'root-severity-success'
-  | 'root-severity-warning'
-  | 'icon-severity-error'
-  | 'icon-severity-info'
-  | 'icon-severity-success'
-  | 'icon-severity-warning'
-  | 'message-severity-error'
-  | 'message-severity-info'
-  | 'message-severity-success'
-  | 'message-severity-warning';
+  | 'private-root-severity-error'
+  | 'private-root-severity-info'
+  | 'private-root-severity-success'
+  | 'private-root-severity-warning'
+  | 'private-icon-severity-error'
+  | 'private-icon-severity-info'
+  | 'private-icon-severity-success'
+  | 'private-icon-severity-warning'
+  | 'private-message-severity-error'
+  | 'private-message-severity-info'
+  | 'private-message-severity-success'
+  | 'private-message-severity-warning';
 
-const usePrivateStyles = makeStyles<PrivateClassKey>(
-  (theme) => ({
-    'root-severity-error': {
-      backgroundColor: theme.unstable_palette.red[700],
-    },
-    'root-severity-info': {
-      backgroundColor: theme.unstable_palette.blue[700],
-    },
-    'root-severity-success': {
-      backgroundColor: theme.unstable_palette.green[700],
-    },
-    'root-severity-warning': {
-      backgroundColor: theme.unstable_palette.yellow[600],
-    },
-    'icon-severity-error': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'icon-severity-info': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'icon-severity-success': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'icon-severity-warning': {
-      color: theme.unstable_palette.neutral[600],
-    },
-    'message-severity-error': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'message-severity-info': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'message-severity-success': {
-      color: theme.unstable_palette.neutral[0],
-    },
-    'message-severity-warning': {
-      color: theme.unstable_palette.neutral[600],
-    },
-  }),
-  { name: 'MuiSparkPrivate-Banner' }
-);
-
-const Unstable_Banner = forwardRef<unknown, Unstable_BannerProps>(
-  function Unstable_Banner(props, ref) {
-    const {
-      classes,
-      severity = 'info',
-      CloseProps: ClosePropsProp,
-      ...other
-    } = props;
-
-    const privateClasses = usePrivateStyles();
-
-    let CloseProps: Unstable_AlertProps['CloseProps'] = ClosePropsProp;
-    if (['info', 'success', 'error'].includes(severity)) {
-      CloseProps = { color: 'inverse', ...CloseProps };
-    }
-
-    return (
-      <Unstable_Alert
-        classes={{
-          root: clsx(classes.root, privateClasses[`root-severity-${severity}`]),
-          icon: clsx(classes.icon, privateClasses[`icon-severity-${severity}`]),
-          message: clsx(
-            classes.message,
-            privateClasses[`message-severity-${severity}`]
-          ),
-          action: classes.action,
-        }}
-        severity={severity}
-        ref={ref}
-        CloseProps={CloseProps}
-        {...other}
-      />
-    );
-  }
-);
-
-export default withStyles<Unstable_BannerClassKey>(
+const withClasses = withStyles<Unstable_BannerClassKey | PrivateClassKey>(
   (theme) => ({
     root: {
       alignItems: 'flex-start',
@@ -128,6 +49,85 @@ export default withStyles<Unstable_BannerClassKey>(
       justifySelf: 'flex-end',
       marginTop: -2,
     },
+    /* Private */
+    'private-root-severity-error': {
+      backgroundColor: theme.unstable_palette.red[700],
+    },
+    'private-root-severity-info': {
+      backgroundColor: theme.unstable_palette.blue[700],
+    },
+    'private-root-severity-success': {
+      backgroundColor: theme.unstable_palette.green[700],
+    },
+    'private-root-severity-warning': {
+      backgroundColor: theme.unstable_palette.yellow[600],
+    },
+    'private-icon-severity-error': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-icon-severity-info': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-icon-severity-success': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-icon-severity-warning': {
+      color: theme.unstable_palette.neutral[600],
+    },
+    'private-message-severity-error': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-message-severity-info': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-message-severity-success': {
+      color: theme.unstable_palette.neutral[0],
+    },
+    'private-message-severity-warning': {
+      color: theme.unstable_palette.neutral[600],
+    },
   }),
   { name: 'MuiSparkUnstable_Banner' }
-)(Unstable_Banner) as typeof Unstable_Banner;
+);
+
+const Unstable_Banner = forwardRef<unknown, Unstable_BannerProps>(
+  function Unstable_Banner(props, ref) {
+    const {
+      classes,
+      severity = 'info',
+      CloseProps: ClosePropsProp,
+      ...other
+    } = props;
+
+    let CloseProps: Unstable_AlertProps['CloseProps'] = ClosePropsProp;
+    if (['info', 'success', 'error'].includes(severity)) {
+      CloseProps = { color: 'inverse', ...CloseProps };
+    }
+
+    return (
+      <Unstable_Alert
+        classes={{
+          root: clsx(
+            classes.root,
+            classes[`private-root-severity-${severity}`]
+          ),
+          icon: clsx(
+            classes.icon,
+            classes[`private-icon-severity-${severity}`]
+          ),
+          message: clsx(
+            classes.message,
+            classes[`private-message-severity-${severity}`]
+          ),
+          action: classes.action,
+        }}
+        severity={severity}
+        ref={ref}
+        CloseProps={CloseProps}
+        {...other}
+      />
+    );
+  }
+);
+
+export default withClasses(Unstable_Banner) as typeof Unstable_Banner;

--- a/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
+++ b/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
-import makeStyles from '../makeStyles';
 import Unstable_Alert, {
   Unstable_AlertClassKey,
   Unstable_AlertProps,
@@ -20,77 +19,18 @@ export interface Unstable_SectionMessageProps
 export type Unstable_SectionMessageClassKey = Unstable_AlertClassKey | 'title';
 
 type PrivateClassKey =
-  | 'root-severity-error'
-  | 'root-severity-info'
-  | 'root-severity-success'
-  | 'root-severity-warning'
-  | 'icon-severity-error'
-  | 'icon-severity-info'
-  | 'icon-severity-success'
-  | 'icon-severity-warning';
+  | 'private-root-severity-error'
+  | 'private-root-severity-info'
+  | 'private-root-severity-success'
+  | 'private-root-severity-warning'
+  | 'private-icon-severity-error'
+  | 'private-icon-severity-info'
+  | 'private-icon-severity-success'
+  | 'private-icon-severity-warning';
 
-const usePrivateStyles = makeStyles<PrivateClassKey>(
-  (theme) => ({
-    'root-severity-error': {
-      backgroundColor: theme.unstable_palette.red[100],
-      borderColor: theme.unstable_palette.red[700],
-    },
-    'root-severity-info': {
-      backgroundColor: theme.unstable_palette.blue[100],
-      borderColor: theme.unstable_palette.blue[600],
-    },
-    'root-severity-success': {
-      backgroundColor: theme.unstable_palette.green[100],
-      borderColor: theme.unstable_palette.green[600],
-    },
-    'root-severity-warning': {
-      backgroundColor: theme.unstable_palette.yellow[100],
-      borderColor: theme.unstable_palette.yellow[600],
-    },
-    'icon-severity-error': {
-      color: theme.unstable_palette.red[700],
-    },
-    'icon-severity-info': {
-      color: theme.unstable_palette.blue[600],
-    },
-    'icon-severity-success': {
-      color: theme.unstable_palette.green[600],
-    },
-    'icon-severity-warning': {
-      color: theme.unstable_palette.yellow[600],
-    },
-  }),
-  { name: 'MuiSparkPrivate-SectionMessage' }
-);
-
-const Unstable_SectionMessage = forwardRef<
-  unknown,
-  Unstable_SectionMessageProps
->(function Unstable_SectionMessage(props, ref) {
-  const { children, classes, severity = 'info', title, ...other } = props;
-
-  const privateClasses = usePrivateStyles({ severity });
-
-  return (
-    <Unstable_Alert
-      classes={{
-        root: clsx(classes.root, privateClasses[`root-severity-${severity}`]),
-        icon: clsx(classes.icon, privateClasses[`icon-severity-${severity}`]),
-        message: classes.message,
-        action: classes.action,
-      }}
-      severity={severity}
-      ref={ref}
-      {...other}
-    >
-      {title ? <div className={classes.title}>{title}</div> : null}
-
-      {children}
-    </Unstable_Alert>
-  );
-});
-
-export default withStyles<Unstable_SectionMessageClassKey>(
+const withClasses = withStyles<
+  Unstable_SectionMessageClassKey | PrivateClassKey
+>(
   (theme) => ({
     root: {
       alignItems: 'flex-start',
@@ -120,6 +60,64 @@ export default withStyles<Unstable_SectionMessageClassKey>(
       color: theme.unstable_palette.text.heading,
       marginBottom: 4,
     },
+    /* Private */
+    'private-root-severity-error': {
+      backgroundColor: theme.unstable_palette.red[100],
+      borderColor: theme.unstable_palette.red[700],
+    },
+    'private-root-severity-info': {
+      backgroundColor: theme.unstable_palette.blue[100],
+      borderColor: theme.unstable_palette.blue[600],
+    },
+    'private-root-severity-success': {
+      backgroundColor: theme.unstable_palette.green[100],
+      borderColor: theme.unstable_palette.green[600],
+    },
+    'private-root-severity-warning': {
+      backgroundColor: theme.unstable_palette.yellow[100],
+      borderColor: theme.unstable_palette.yellow[600],
+    },
+    'private-icon-severity-error': {
+      color: theme.unstable_palette.red[700],
+    },
+    'private-icon-severity-info': {
+      color: theme.unstable_palette.blue[600],
+    },
+    'private-icon-severity-success': {
+      color: theme.unstable_palette.green[600],
+    },
+    'private-icon-severity-warning': {
+      color: theme.unstable_palette.yellow[600],
+    },
   }),
   { name: 'MuiSparkUnstable_SectionMessage' }
-)(Unstable_SectionMessage) as typeof Unstable_SectionMessage;
+);
+
+const Unstable_SectionMessage = forwardRef<
+  unknown,
+  Unstable_SectionMessageProps
+>(function Unstable_SectionMessage(props, ref) {
+  const { children, classes, severity = 'info', title, ...other } = props;
+
+  return (
+    <Unstable_Alert
+      classes={{
+        root: clsx(classes.root, classes[`private-root-severity-${severity}`]),
+        icon: clsx(classes.icon, classes[`private-icon-severity-${severity}`]),
+        message: classes.message,
+        action: classes.action,
+      }}
+      severity={severity}
+      ref={ref}
+      {...other}
+    >
+      {title ? <div className={classes.title}>{title}</div> : null}
+
+      {children}
+    </Unstable_Alert>
+  );
+});
+
+export default withClasses(
+  Unstable_SectionMessage
+) as typeof Unstable_SectionMessage;

--- a/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
+++ b/libs/spark/src/Unstable_SvgIcon/Unstable_SvgIcon.tsx
@@ -6,7 +6,6 @@ import {
 } from '@material-ui/core/SvgIcon';
 import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles from '../withStyles';
-import makeStyles from '../makeStyles';
 
 export interface Unstable_SvgIconTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -42,52 +41,57 @@ export type Unstable_SvgIconProps<
 export type Unstable_SvgIconClassKey = 'root';
 
 type PrivateClassKey =
-  | 'color-normal'
-  | 'color-secondary'
-  | 'color-inverse'
-  | 'color-inverseSecondary'
-  | 'fontSize-small'
-  | 'fontSize-medium'
-  | 'fontSize-large'
-  | 'fontSize-xlarge';
+  | 'private-color-inherit'
+  | 'private-color-normal'
+  | 'private-color-secondary'
+  | 'private-color-inverse'
+  | 'private-color-inverseSecondary'
+  | 'private-fontSize-inherit'
+  | 'private-fontSize-small'
+  | 'private-fontSize-medium'
+  | 'private-fontSize-large'
+  | 'private-fontSize-xlarge';
 
-const usePrivateStyles = makeStyles<PrivateClassKey>(
+// :NOTE:
+//  - Duotone layer selector is & > *[opacity=".12"]
+//  - Duocolor layer selector is & > *[opacity=".4"]
+
+const withClasses = withStyles<Unstable_SvgIconClassKey | PrivateClassKey>(
   (theme) => ({
-    // :NOTE:
-    //  - Duotone layer selector is & > *[opacity=".12"]
-    //  - Duocolor layer selector is & > *[opacity=".4"]
-    'color-inherit': {
+    root: {},
+    /* Private */
+    'private-color-inherit': {
       color: 'inherit',
     },
-    'color-normal': {
+    'private-color-normal': {
       color: theme.unstable_palette.text.icon,
     },
-    'color-secondary': {
+    'private-color-secondary': {
       color: theme.unstable_palette.text.secondaryIcon,
     },
-    'color-inverse': {
+    'private-color-inverse': {
       color: theme.unstable_palette.text.inverseIcon,
     },
-    'color-inverseSecondary': {
+    'private-color-inverseSecondary': {
       color: theme.unstable_palette.text.inverseSecondaryIcon,
     },
-    'fontSize-inherit': {
+    'private-fontSize-inherit': {
       fontSize: 'inherit',
     },
-    'fontSize-small': {
+    'private-fontSize-small': {
       fontSize: theme.unstable_typography.pxToRem(16),
     },
-    'fontSize-medium': {
+    'private-fontSize-medium': {
       fontSize: theme.unstable_typography.pxToRem(24),
     },
-    'fontSize-large': {
+    'private-fontSize-large': {
       fontSize: theme.unstable_typography.pxToRem(32),
     },
-    'fontSize-xlarge': {
+    'private-fontSize-xlarge': {
       fontSize: theme.unstable_typography.pxToRem(48),
     },
   }),
-  { name: 'MuiSparkPrivate-SvgIcon' }
+  { name: 'MuiSparkUnstable_SvgIcon' }
 );
 
 const Unstable_SvgIcon: OverridableComponent<Unstable_SvgIconTypeMap> = forwardRef(
@@ -99,15 +103,13 @@ const Unstable_SvgIcon: OverridableComponent<Unstable_SvgIconTypeMap> = forwardR
       ...other
     } = props;
 
-    const privateClasses = usePrivateStyles();
-
     return (
       <MuiSvgIcon
         classes={{
           root: clsx(
             classes.root,
-            privateClasses[`color-${color}`],
-            privateClasses[`fontSize-${fontSize}`]
+            classes[`private-color-${color}`],
+            classes[`private-fontSize-${fontSize}`]
           ),
         }}
         ref={ref}
@@ -117,7 +119,4 @@ const Unstable_SvgIcon: OverridableComponent<Unstable_SvgIconTypeMap> = forwardR
   }
 );
 
-export default withStyles<Unstable_SvgIconClassKey>(
-  { root: {} },
-  { name: 'MuiSparkUnstable_SvgIcon' }
-)(Unstable_SvgIcon) as typeof Unstable_SvgIcon;
+export default withClasses(Unstable_SvgIcon) as typeof Unstable_SvgIcon;

--- a/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
+++ b/libs/spark/src/Unstable_Typography/Unstable_Typography.tsx
@@ -5,7 +5,6 @@ import {
   TypographyProps as MuiTypographyProps,
 } from '@material-ui/core/Typography';
 import { OverridableComponent, OverrideProps } from '../utils';
-import makeStyles from '../makeStyles';
 import { Unstable_TypographyVariant } from '../theme/unstable_typography';
 import withStyles from '../withStyles';
 
@@ -45,145 +44,146 @@ export type Unstable_TypographyProps<
 export type Unstable_TypographyClassKey = 'root';
 
 type PrivateClassKey =
-  | 'color-inherit'
-  | 'color-normal'
-  | 'color-inverse'
-  | 'variant-display'
-  | 'variant-T32'
-  | 'variant-T28'
-  | 'variant-T22'
-  | 'variant-T18'
-  | 'variant-T14'
-  | 'variant-body'
-  | 'variant-label'
-  | 'variant-description'
-  | 'variant-code'
-  | 'color-normal-variant-display'
-  | 'color-normal-variant-T32'
-  | 'color-normal-variant-T28'
-  | 'color-normal-variant-T22'
-  | 'color-normal-variant-T18'
-  | 'color-normal-variant-T14'
-  | 'color-normal-variant-body'
-  | 'color-normal-variant-label'
-  | 'color-normal-variant-description'
-  | 'color-normal-variant-code'
-  | 'color-inverse-variant-display'
-  | 'color-inverse-variant-T32'
-  | 'color-inverse-variant-T28'
-  | 'color-inverse-variant-T22'
-  | 'color-inverse-variant-T18'
-  | 'color-inverse-variant-T14'
-  | 'color-inverse-variant-body'
-  | 'color-inverse-variant-label'
-  | 'color-inverse-variant-description'
-  | 'color-inverse-variant-code';
+  | 'private-color-inherit'
+  | 'private-color-normal'
+  | 'private-color-inverse'
+  | 'private-variant-display'
+  | 'private-variant-T32'
+  | 'private-variant-T28'
+  | 'private-variant-T22'
+  | 'private-variant-T18'
+  | 'private-variant-T14'
+  | 'private-variant-body'
+  | 'private-variant-label'
+  | 'private-variant-description'
+  | 'private-variant-code'
+  | 'private-color-normal-variant-display'
+  | 'private-color-normal-variant-T32'
+  | 'private-color-normal-variant-T28'
+  | 'private-color-normal-variant-T22'
+  | 'private-color-normal-variant-T18'
+  | 'private-color-normal-variant-T14'
+  | 'private-color-normal-variant-body'
+  | 'private-color-normal-variant-label'
+  | 'private-color-normal-variant-description'
+  | 'private-color-normal-variant-code'
+  | 'private-color-inverse-variant-display'
+  | 'private-color-inverse-variant-T32'
+  | 'private-color-inverse-variant-T28'
+  | 'private-color-inverse-variant-T22'
+  | 'private-color-inverse-variant-T18'
+  | 'private-color-inverse-variant-T14'
+  | 'private-color-inverse-variant-body'
+  | 'private-color-inverse-variant-label'
+  | 'private-color-inverse-variant-description'
+  | 'private-color-inverse-variant-code';
 
-const usePrivateStyles = makeStyles<PrivateClassKey>(
+const withClasses = withStyles<Unstable_TypographyClassKey | PrivateClassKey>(
   (theme) => ({
-    'color-normal': {},
-    'color-inverse': {},
-    'color-inherit': {
+    root: {},
+    'private-color-normal': {},
+    'private-color-inverse': {},
+    'private-color-inherit': {
       color: 'inherit',
     },
-    'variant-display': {
+    'private-variant-display': {
       ...theme.unstable_typography.display,
     },
-    'variant-T32': {
+    'private-variant-T32': {
       ...theme.unstable_typography['T32'],
     },
-    'variant-T28': {
+    'private-variant-T28': {
       ...theme.unstable_typography['T28'],
     },
-    'variant-T22': {
+    'private-variant-T22': {
       ...theme.unstable_typography['T22'],
     },
-    'variant-T18': {
+    'private-variant-T18': {
       ...theme.unstable_typography['T18'],
     },
-    'variant-T14': {
+    'private-variant-T14': {
       ...theme.unstable_typography['T14'],
     },
-    'variant-body': {
+    'private-variant-body': {
       ...theme.unstable_typography['body'],
       '& strong, b': {
         fontWeight: 600,
       },
     },
-    'variant-label': {
+    'private-variant-label': {
       ...theme.unstable_typography['label'],
     },
-    'variant-description': {
+    'private-variant-description': {
       ...theme.unstable_typography['description'],
       '& strong, b': {
         fontWeight: 700,
       },
     },
-    'variant-code': {
+    'private-variant-code': {
       ...theme.unstable_typography['code'],
     },
-    'color-normal-variant-display': {
+    'private-color-normal-variant-display': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-T32': {
+    'private-color-normal-variant-T32': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-T28': {
+    'private-color-normal-variant-T28': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-T22': {
+    'private-color-normal-variant-T22': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-T18': {
+    'private-color-normal-variant-T18': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-T14': {
+    'private-color-normal-variant-T14': {
       color: theme.unstable_palette.text.heading,
     },
-    'color-normal-variant-body': {
+    'private-color-normal-variant-body': {
       color: theme.unstable_palette.text.body,
     },
-    'color-normal-variant-label': {
+    'private-color-normal-variant-label': {
       color: theme.unstable_palette.text.body,
     },
-    'color-normal-variant-description': {
+    'private-color-normal-variant-description': {
       color: theme.unstable_palette.text.body,
     },
-    'color-normal-variant-code': {
+    'private-color-normal-variant-code': {
       color: theme.unstable_palette.text.body,
     },
-    'color-inverse-variant-display': {
+    'private-color-inverse-variant-display': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-T32': {
+    'private-color-inverse-variant-T32': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-T28': {
+    'private-color-inverse-variant-T28': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-T22': {
+    'private-color-inverse-variant-T22': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-T18': {
+    'private-color-inverse-variant-T18': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-T14': {
+    'private-color-inverse-variant-T14': {
       color: theme.unstable_palette.text.inverseHeading,
     },
-    'color-inverse-variant-body': {
+    'private-color-inverse-variant-body': {
       color: theme.unstable_palette.text.inverseBody,
     },
-    'color-inverse-variant-label': {
+    'private-color-inverse-variant-label': {
       color: theme.unstable_palette.text.inverseBody,
     },
-    'color-inverse-variant-description': {
+    'private-color-inverse-variant-description': {
       color: theme.unstable_palette.text.inverseBody,
     },
-    'color-inverse-variant-code': {
+    'private-color-inverse-variant-code': {
       color: theme.unstable_palette.text.inverseBody,
     },
   }),
-  { name: 'MuiSparkPrivate-Typography' }
+  { name: 'MuiSparkUnstable_Typography' }
 );
 
 const variantToComponent: Record<Unstable_TypographyVariant, string> = {
@@ -210,16 +210,14 @@ const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = fo
       ...other
     } = props;
 
-    const privateClasses = usePrivateStyles();
-
     return (
       <MuiTypography
         classes={{
           root: clsx(
             classes.root,
-            privateClasses[`color-${color}`],
-            privateClasses[`variant-${variant}`],
-            privateClasses[`color-${color}-variant-${variant}`]
+            classes[`private-color-${color}`],
+            classes[`private-variant-${variant}`],
+            classes[`private-color-${color}-variant-${variant}`]
           ),
         }}
         component={component || variantToComponent[variant]}
@@ -230,7 +228,4 @@ const Unstable_Typography: OverridableComponent<Unstable_TypographyTypeMap> = fo
   }
 );
 
-export default withStyles<Unstable_TypographyClassKey>(
-  { root: {} },
-  { name: 'MuiSparkUnstable_Typography' }
-)(Unstable_Typography) as typeof Unstable_Typography;
+export default withClasses(Unstable_Typography) as typeof Unstable_Typography;


### PR DESCRIPTION
Improvement on #584 , #585 , #581 , #577

Avoids makeStyles invocations being generated before withStyles and thus having lower priority when they should be higher. Still satisfies that private classes are not visible to consumers by keeping the split class keys and forwarding the public, slot-based on to the props/type-map.