### PR TITLE
chore(Tooltip): fix snapshots changing

### DIFF
--- a/libs/spark/.storybook/preview.js
+++ b/libs/spark/.storybook/preview.js
@@ -1,26 +1,13 @@
 import React, { Fragment } from 'react';
 import { addDecorator } from '@storybook/react';
-import isChromatic from 'chromatic/isChromatic';
 import {
   CssBaseline,
   FontFacesBaseline,
   Unstable_FontFacesBaseline,
-  withStyles,
 } from '../src';
-
-const ChromaticCssBaseline = withStyles((theme) => ({
-  '@global': {
-    '*': {
-      animationPlayState: 'paused !important',
-      transition: 'none !important',
-      scrollBehavior: 'auto !important',
-    },
-  },
-}))(() => null);
 
 addDecorator((Story) => (
   <Fragment>
-    {isChromatic() ? <ChromaticCssBaseline /> : null}
     <CssBaseline />
     <FontFacesBaseline />
     <Unstable_FontFacesBaseline />

--- a/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.stories.tsx
+++ b/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.stories.tsx
@@ -22,6 +22,9 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   decorators: [pad],
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
   args: {
     title: 'Title',
   },


### PR DESCRIPTION
Iteration on #402 and #582 . 

Removed global styles that would disable / immediately pause animations since Tooltip's snapshots were indeterminate as a result.

Added a delay to Tooltip's snapshots specifically, hoping that after full animation, their end position is determinate.