### PR TITLE
chore(spark): increase Tooltip stories delay & fix changelog date

### DIFF
--- a/libs/spark-icons/CHANGELOG.md
+++ b/libs/spark-icons/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 No changes.
 
-## [v2.0.0-alpha.3](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2022-07-11)
+## [v2.0.0-alpha.3](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2022-11-07)
 
 No changes.
 

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **Unstable_SwitchField**
   - Increase label font weight.
 
-## [v2.0.0-alpha.3](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2022-07-11)
+## [v2.0.0-alpha.3](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2022-11-07)
 
 ### Fixes
 

--- a/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.stories.tsx
+++ b/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.stories.tsx
@@ -23,7 +23,7 @@ export default {
   excludeStories: ['_retyped'],
   decorators: [pad],
   parameters: {
-    chromatic: { delay: 1000 },
+    chromatic: { delay: 3000 },
   },
   args: {
     title: 'Title',


### PR DESCRIPTION
Couple chores:
- Wrong date from v2.0.0-alpha.3 changelog in #614.
- Still getting arbitrary Tooltip snapshot changes