### PR TITLE
Validate Dropdown composition with unstable components

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Features
 
-- **useDropdownContext**
-  - Added return value property, `isOpen: boolean` to know whether the dropdown is open or not.
+- **DropdownAnchor**
+  - When component is **Unstable_Button**, adds default trailing icon and styles (to override, simply set `trailingIcon`).
 - **DropdownMenu**
   - Allow overriding component.
   - Improve offset from Dropdown Anchor when open.
@@ -18,6 +18,8 @@
     - `component`: added, default of `Menu`.
 - **Unstable_SwitchField**
   - Increase label font weight.
+- **useDropdownContext**
+  - Added return value property, `isOpen: boolean` to know whether the dropdown is open or not.
 
 ## [v2.0.0-alpha.3](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.2...v2.0.0-alpha.3) (2022-07-11)
 

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Features
 
+- **DropdownMenu**
+  - Allow overriding component.
+  - Improve offset from Dropdown Anchor when open.
+  - Props API:
+    - `component`: added, default of `Menu`.
 - **Unstable_SwitchField**
   - Increase label font weight.
 

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.3...vNext) (YYYY-MM-DD)
 
+### Fixes
+
+- **Unstable_Menu**
+  - Missing elevation styles.
+
 ### Features
 
 - **DropdownMenu**

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Features
 
+- **useDropdownContext**
+  - Added return value property, `isOpen: boolean` to know whether the dropdown is open or not.
 - **DropdownMenu**
   - Allow overriding component.
   - Improve offset from Dropdown Anchor when open.

--- a/libs/spark/src/Dropdown/Dropdown.stories.tsx
+++ b/libs/spark/src/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,136 @@
+import React, { CSSProperties, ReactNode } from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+import { ChevronDown } from '@prenda/spark-icons';
+import {
+  DropdownAnchor,
+  DropdownContext,
+  DropdownMenu,
+  Unstable_AvatarButton,
+  Unstable_Button,
+  Unstable_IconButton,
+  Unstable_Menu,
+} from '..';
+import Unstable_MenuMeta from '../Unstable_Menu/Unstable_Menu.stories';
+
+const anchorComponents = {
+  default: undefined,
+  Unstable_Button,
+  Unstable_IconButton,
+  Unstable_AvatarButton,
+};
+
+const menuComponents = { default: undefined, Unstable_Menu };
+
+export default {
+  title: '@ps/Dropdown (pattern)',
+  argTypes: {
+    /* Dropdown Anchor props */
+    'DropdownAnchor.component': {
+      options: Object.keys(anchorComponents),
+      mapping: anchorComponents,
+      control: {
+        type: 'select',
+      },
+    },
+    'DropdownAnchor.disabled': { control: 'boolean' },
+
+    /* Dropdown Menu props */
+    'DropdownMenu.component': {
+      options: Object.keys(menuComponents),
+      mapping: menuComponents,
+      control: {
+        type: 'select',
+      },
+    },
+    'DropdownMenu.placement': {
+      control: 'select',
+      options: ['bottom-left', 'bottom-right', 'top-left', 'top-right'],
+    },
+    'DropdownMenu.children': Unstable_MenuMeta.argTypes.children,
+  },
+  args: {
+    'DropdownAnchor.component': 'Unstable_Button',
+    'DropdownMenu.component': 'Unstable_Menu',
+    'DropdownMenu.children': Unstable_MenuMeta.argTypes.children.options[0],
+    'DropdownMenu.placement': 'bottom-left',
+  },
+} as Meta;
+
+function getPositioningStyles(placement): CSSProperties {
+  let top, left, right, bottom: number;
+  if (placement === 'bottom-left') {
+    top = 0;
+    left = 0;
+  } else if (placement === 'bottom-right') {
+    top = 0;
+    right = 0;
+  } else if (placement === 'top-left') {
+    bottom = 0;
+    left = 0;
+  } else if (placement === 'top-right') {
+    bottom = 0;
+    right = 0;
+  }
+
+  return { position: 'absolute', top, left, right, bottom };
+}
+
+const Template: Story = (props) => {
+  const {
+    'DropdownAnchor.component': dropdownAnchorComponent,
+    'DropdownAnchor.disabled': dropdownAnchorDisabled,
+    'DropdownMenu.children': dropdownMenuChildren,
+    'DropdownMenu.component': dropdownMenuComponent,
+    'DropdownMenu.placement': dropdownMenuPlacement,
+  } = props;
+
+  const anchorProps: {
+    component?: unknown;
+    endIcon?: ReactNode;
+    children?: ReactNode;
+    src?: string;
+  } = {
+    children: 'Label',
+  };
+  if (dropdownAnchorComponent !== undefined) {
+    anchorProps.component = dropdownAnchorComponent;
+  }
+  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_Button') {
+    anchorProps.endIcon = <ChevronDown />;
+  }
+  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_IconButton') {
+    anchorProps.children = <ChevronDown />;
+  }
+  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_AvatarButton') {
+    anchorProps.src = '/img/guide-1.png';
+    delete anchorProps.children;
+  }
+
+  const menuProps: { component?: unknown; children: ReactNode } = {
+    children: dropdownMenuChildren,
+  };
+  if (dropdownMenuComponent !== undefined) {
+    menuProps.component = dropdownMenuComponent;
+  }
+
+  const positioningStyles = getPositioningStyles(dropdownMenuPlacement);
+
+  return (
+    // menu height + (largest) anchor el height + space between; menu width
+    <div style={{ position: 'relative', height: 182 + 48 + 8, width: 256 }}>
+      <div style={positioningStyles}>
+        <DropdownContext>
+          <DropdownAnchor disabled={dropdownAnchorDisabled} {...anchorProps} />
+          <DropdownMenu
+            placement={dropdownMenuPlacement}
+            PaperProps={{ style: { width: 256 } }}
+            {...menuProps}
+          />
+        </DropdownContext>
+      </div>
+    </div>
+  );
+};
+
+export const Composition: Story = Template.bind({});
+Composition.storyName = '(composition)';

--- a/libs/spark/src/Dropdown/Dropdown.stories.tsx
+++ b/libs/spark/src/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,6 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { ChevronDown } from '@prenda/spark-icons';
+import { MoreHorizFilled } from '@prenda/spark-icons';
 import {
   DropdownAnchor,
   DropdownContext,
@@ -53,6 +53,7 @@ export default {
     'DropdownMenu.component': 'Unstable_Menu',
     'DropdownMenu.children': Unstable_MenuMeta.argTypes.children.options[0],
     'DropdownMenu.placement': 'bottom-left',
+    'DropdownMenu.PaperProps': { style: { width: 256 } },
   },
 } as Meta;
 
@@ -82,32 +83,30 @@ const Template: Story = (props) => {
     'DropdownMenu.children': dropdownMenuChildren,
     'DropdownMenu.component': dropdownMenuComponent,
     'DropdownMenu.placement': dropdownMenuPlacement,
+    'DropdownMenu.PaperProps': dropdownMenuPaperProps,
   } = props;
 
-  const anchorProps: {
-    component?: unknown;
-    endIcon?: ReactNode;
-    children?: ReactNode;
-    src?: string;
-  } = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const anchorProps: any = {
     children: 'Label',
+    disabled: dropdownAnchorDisabled,
   };
   if (dropdownAnchorComponent !== undefined) {
     anchorProps.component = dropdownAnchorComponent;
   }
-  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_Button') {
-    anchorProps.endIcon = <ChevronDown />;
-  }
   if (dropdownAnchorComponent?._PDS_ID === 'Unstable_IconButton') {
-    anchorProps.children = <ChevronDown />;
+    anchorProps.children = <MoreHorizFilled />;
   }
   if (dropdownAnchorComponent?._PDS_ID === 'Unstable_AvatarButton') {
     anchorProps.src = '/img/guide-1.png';
     delete anchorProps.children;
   }
 
-  const menuProps: { component?: unknown; children: ReactNode } = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const menuProps: any = {
     children: dropdownMenuChildren,
+    PaperProps: dropdownMenuPaperProps,
+    placement: dropdownMenuPlacement,
   };
   if (dropdownMenuComponent !== undefined) {
     menuProps.component = dropdownMenuComponent;
@@ -120,12 +119,8 @@ const Template: Story = (props) => {
     <div style={{ position: 'relative', height: 182 + 48 + 8, width: 256 }}>
       <div style={positioningStyles}>
         <DropdownContext>
-          <DropdownAnchor disabled={dropdownAnchorDisabled} {...anchorProps} />
-          <DropdownMenu
-            placement={dropdownMenuPlacement}
-            PaperProps={{ style: { width: 256 } }}
-            {...menuProps}
-          />
+          <DropdownAnchor {...anchorProps} />
+          <DropdownMenu {...menuProps} />
         </DropdownContext>
       </div>
     </div>

--- a/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
+++ b/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
@@ -1,7 +1,11 @@
+import clsx from 'clsx';
 import React, { ElementType, forwardRef } from 'react';
 import { default as Button, ButtonTypeMap } from '../Button';
 import { useDropdownContext } from '../DropdownContext';
+import { Unstable_ChevronDown } from '../internal';
+import { Unstable_ButtonProps } from '../Unstable_Button';
 import { OverridableComponent, OverrideProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
 
 export type DropdownAnchorProps<
   D extends ElementType = DropdownAnchorTypeMap['defaultComponent'],
@@ -17,28 +21,72 @@ export interface DropdownAnchorTypeMap<
   classKey: string;
 }
 
+type PrivateClassKey =
+  | 'private-button-trailingIcon'
+  | 'private-button-trailingIcon-open';
+
+const styles: Styles<PrivateClassKey> = {
+  'private-button-trailingIcon': {
+    transition: 'transform 250ms ease',
+  },
+  'private-button-trailingIcon-open': {
+    transform: 'rotate(180deg)',
+  },
+};
+
 const DropdownAnchor: OverridableComponent<DropdownAnchorTypeMap> = forwardRef(
   function DropdownAnchor(
-    { component = Button, onClick, ...other }: DropdownAnchorProps,
+    { classes, component = Button, onClick, ...other }: DropdownAnchorProps,
     ref
   ) {
-    const { id, openDropdown } = useDropdownContext();
+    const { id, isOpen, openDropdown } = useDropdownContext();
 
     const Component = component as ElementType;
+
+    const {
+      'private-button-trailingIcon': privateButtonTrailingIconClass,
+      'private-button-trailingIcon-open': privateButtonTrailingIconOpenClass,
+      ...otherClasses
+    } = classes;
+
+    const extra = {};
+    // @ts-expect-error property does not exist
+    if (Component._PDS_ID === 'Unstable_Button') {
+      // check if should add default trailing icon and styles
+      if (
+        Object.prototype.hasOwnProperty.call(other, 'trailingIcon') === false
+      ) {
+        (extra as Unstable_ButtonProps).trailingIcon = <Unstable_ChevronDown />;
+        (extra as Unstable_ButtonProps).classes = {
+          ...(other as Unstable_ButtonProps)?.classes,
+          trailingIcon: clsx(
+            privateButtonTrailingIconClass,
+            {
+              [privateButtonTrailingIconOpenClass]: isOpen,
+            },
+            (other as Unstable_ButtonProps)?.classes?.trailingIcon
+          ),
+        };
+      }
+    }
 
     return (
       <Component
         aria-controls={id}
         aria-haspopup="true"
+        classes={otherClasses}
         onClick={(event) => {
           onClick?.(event);
           openDropdown(event);
         }}
         ref={ref}
+        {...extra}
         {...other}
       />
     );
   }
 );
 
-export default DropdownAnchor;
+export default withStyles(styles, { name: 'MuiSparkDropdownAnchor' })(
+  DropdownAnchor
+) as typeof DropdownAnchor;

--- a/libs/spark/src/DropdownContext/DropdownContext.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.tsx
@@ -16,6 +16,7 @@ export interface DropdownContextValue {
   anchorEl: null | HTMLElement;
   openDropdown: (event: MouseEvent<HTMLElement>) => void;
   closeDropdown: () => void;
+  isOpen: boolean;
 }
 
 const Context = createContext<DropdownContextValue | null>(null);
@@ -46,10 +47,10 @@ export default function DropdownContext(
     setAnchorEl(null);
   };
 
-  const value = useMemo(() => ({ id, anchorEl, openDropdown, closeDropdown }), [
-    id,
-    anchorEl,
-  ]);
+  const value = useMemo(
+    () => ({ id, anchorEl, isOpen: !!anchorEl, openDropdown, closeDropdown }),
+    [id, anchorEl]
+  );
 
   return <Context.Provider value={value} {...props} />;
 }

--- a/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
+++ b/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
@@ -126,6 +126,11 @@ const Unstable_AvatarButton: OverridableComponent<Unstable_AvatarButtonTypeMap> 
   }
 );
 
-export default withStyles(styles, { name: 'MuiSparkUnstable_AvatarButton' })(
-  Unstable_AvatarButton
-) as typeof Unstable_AvatarButton;
+const Unstable_AvatarButtonWithStyles = withStyles(styles, {
+  name: 'MuiSparkUnstable_AvatarButton',
+})(Unstable_AvatarButton) as typeof Unstable_AvatarButton;
+
+// @ts-expect-error property does not exist
+Unstable_AvatarButtonWithStyles._PDS_ID = 'Unstable_AvatarButton';
+
+export default Unstable_AvatarButtonWithStyles;

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -398,6 +398,11 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
   }
 );
 
-export default withStyles(styles, { name: 'MuiSparkUnstable_Button' })(
-  Unstable_Button
-) as typeof Unstable_Button;
+const Unstable_ButtonWithStyles = withStyles(styles, {
+  name: 'MuiSparkUnstable_Button',
+})(Unstable_Button) as typeof Unstable_Button;
+
+// @ts-expect-error property does not exist
+Unstable_ButtonWithStyles._PDS_ID = 'Unstable_Button';
+
+export default Unstable_ButtonWithStyles;

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -233,6 +233,11 @@ const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = fo
   }
 );
 
-export default withStyles(styles, { name: 'MuiSparkUnstable_IconButton' })(
-  Unstable_IconButton
-) as typeof Unstable_IconButton;
+const Unstable_IconButtonWithStyles = withStyles(styles, {
+  name: 'MuiSparkUnstable_IconButton',
+})(Unstable_IconButton) as typeof Unstable_IconButton;
+
+// @ts-expect-error property does not exist
+Unstable_IconButtonWithStyles._PDS_ID = 'Unstable_IconButton';
+
+export default Unstable_IconButtonWithStyles;

--- a/libs/spark/src/Unstable_Menu/Unstable_Menu.tsx
+++ b/libs/spark/src/Unstable_Menu/Unstable_Menu.tsx
@@ -56,7 +56,7 @@ const Unstable_Menu = forwardRef<unknown, Unstable_MenuProps>(
           ...PaperProps,
           className: clsx(
             PaperProps.className,
-            paperClasses[`elevation${elevation}`]
+            paperClasses[`private-root-variant-elevation-${elevation}`]
           ),
           elevation: 0,
         }}


### PR DESCRIPTION
Validates that the existing Dropdown Context, Anchor, and Menu can be used with unstable components like Unstable Button, Icon Button, Avatar Button, and Menu.

Changes Dropdown Menu to be an overridable component (allowing Unstable Menu to be passed). Preserves v1 API by keeping Menu has default component.

Changes Dropdown Anchor to detect when our Unstable Button is passed and add a default trailing icon and style so it rotates on open (achieving Figma design).

Adds a Dropdown pattern / composition story that supports the full range of options.

To achieve detection of the Anchor child, a private property was added to the button components, "`_PDS_ID`". The property allows for detecting it in wrappers to know and advantage the props / CSS API.