### PR TITLE
feat(Tabs): initial implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.4...vNext) (YYYY-MM-DD)
 
-No changes.
+### Features
+
+- **Unstable_Tab**
+  - Initial implementation.
+- **Unstable_TabPanel**
+  - Initial implementation.
+- **Unstable_Tabs**
+  - Initial implementation. Replaces `TabsContext`.
+- **Unstable_TabsList**
+  - Initial implementation. Replaces `TabList`.
 
 ## [v2.0.0-alpha.4](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.3...v2.0.0-alpha.4) (2022-11-10)
 

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import React from 'react';
+import { Unstable_Tab, Unstable_TabProps, Unstable_Tabs } from '..';
+import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+
+export const _retyped = Unstable_Tab as typeof Unstable_Tab;
+
+export default {
+  title: '@ps/Tab',
+  component: _retyped,
+  excludeStories: ['_retyped'],
+  parameters: { actions: { argTypesRegex: '^on.*' } },
+  decorators: [containFocusIndicator],
+  argTypes: {},
+  args: {
+    children: <>Label</>,
+  },
+} as Meta;
+
+const Template = (args) => (
+  <Unstable_Tabs defaultValue="0">
+    <Unstable_Tab {...args} />
+  </Unstable_Tabs>
+);
+
+type Story = DefaultStory<Unstable_TabProps>;
+
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
+
+export const STP: Story = Template.bind({});
+STP.decorators = [sparkThemeProvider];
+STP.storyName = '(STP)';
+
+export const Hover: Story = Template.bind({});
+Hover.parameters = { pseudo: { hover: true } };
+Hover.storyName = ':hover';
+
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.parameters = { pseudo: { focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
+
+export const Active: Story = Template.bind({});
+Active.parameters = { pseudo: { active: true } };
+Active.storyName = ':active';
+
+export const Disabled: Story = Template.bind({});
+Disabled.args = { disabled: true };
+Disabled.storyName = 'disabled';
+
+export const DisabledHover: Story = Template.bind({});
+DisabledHover.args = { disabled: true };
+DisabledHover.parameters = { pseudo: { hover: true } };
+DisabledHover.storyName = 'disabled :hover';
+
+export const Selected: Story = Template.bind({});
+Selected.args = { selected: true };
+Selected.storyName = 'selected';
+
+export const SelectedHover: Story = Template.bind({});
+SelectedHover.args = { selected: true };
+SelectedHover.parameters = { pseudo: { hover: true } };
+SelectedHover.storyName = 'selected :hover';
+
+export const SelectedActive: Story = Template.bind({});
+SelectedActive.args = { selected: true };
+SelectedActive.parameters = { pseudo: { active: true } };
+SelectedActive.storyName = 'selected :active';
+
+export const SelectedDisabled: Story = Template.bind({});
+SelectedDisabled.args = { selected: true, disabled: true };
+SelectedDisabled.storyName = 'selected disabled';

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import { Unstable_Tab, Unstable_TabProps, Unstable_Tabs } from '..';
+import {
+  Unstable_Tab,
+  Unstable_TabProps,
+  Unstable_Tabs,
+  Unstable_TabsProps,
+} from '..';
 import { containFocusIndicator, sparkThemeProvider } from '../../stories';
 
 export const _retyped = Unstable_Tab as typeof Unstable_Tab;
@@ -17,13 +22,21 @@ export default {
   },
 } as Meta;
 
-const Template = (args) => (
-  <Unstable_Tabs defaultValue="0">
-    <Unstable_Tab {...args} />
-  </Unstable_Tabs>
-);
+const Template = (args) => {
+  const { 'Tabs.orientation': TabsOrientation, ...other } = args;
 
-type Story = DefaultStory<Unstable_TabProps>;
+  return (
+    <Unstable_Tabs defaultValue="0" orientation={TabsOrientation}>
+      <Unstable_Tab {...other} />
+    </Unstable_Tabs>
+  );
+};
+
+type Story = DefaultStory<
+  Unstable_TabProps & {
+    'Tabs.orientation': Unstable_TabsProps['orientation'];
+  }
+>;
 
 export const Default: Story = Template.bind({});
 Default.storyName = '(default)';
@@ -70,3 +83,25 @@ SelectedActive.storyName = 'selected :active';
 export const SelectedDisabled: Story = Template.bind({});
 SelectedDisabled.args = { selected: true, disabled: true };
 SelectedDisabled.storyName = 'selected disabled';
+
+export const TabsOrientationVertical: Story = Template.bind({});
+TabsOrientationVertical.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVertical.storyName = 'Tabs.orientation=vertical';
+
+export const TabsOrientationVerticalHover: Story = Template.bind({});
+TabsOrientationVerticalHover.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalHover.parameters = { pseudo: { hover: true } };
+TabsOrientationVerticalHover.storyName = 'Tabs.orientation=vertical :hover';
+
+export const TabsOrientationVerticalFocusVisible: Story = Template.bind({});
+TabsOrientationVerticalFocusVisible.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalFocusVisible.parameters = {
+  pseudo: { focusVisible: true },
+};
+TabsOrientationVerticalFocusVisible.storyName =
+  'Tabs.orientation=vertical :focus-visible';
+
+export const TabsOrientationVerticalActive: Story = Template.bind({});
+TabsOrientationVerticalActive.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalActive.parameters = { pseudo: { active: true } };
+TabsOrientationVerticalActive.storyName = ' Tabs.orientation=vertical :active';

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.test.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.test.tsx
@@ -1,9 +1,14 @@
 import { render } from '@testing-library/react';
 import Unstable_Tab from './Unstable_Tab';
+import Unstable_Tabs from '../Unstable_Tabs';
 
 describe('Unstable_Tab', () => {
   it('Can render without ThemeProvider', () => {
-    const { baseElement } = render(<Unstable_Tab value="0" />);
+    const { baseElement } = render(
+      <Unstable_Tabs defaultValue="0">
+        <Unstable_Tab value="0" />
+      </Unstable_Tabs>
+    );
 
     expect(baseElement).toBeTruthy();
   });

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.test.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_Tab from './Unstable_Tab';
+
+describe('Unstable_Tab', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<Unstable_Tab value="0" />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
@@ -1,0 +1,130 @@
+import MuiTab, { TabProps as MuiTabProps } from '@material-ui/core/Tab';
+import clsx from 'clsx';
+import React, { ElementType, forwardRef } from 'react';
+import { ButtonBaseTypeMap } from '../ButtonBase';
+import { useTabsContext } from '../Unstable_Tabs';
+import { OverridableComponent, OverrideProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+
+export interface Unstable_TabTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends ElementType = ButtonBaseTypeMap['defaultComponent']
+> {
+  props: P &
+    Omit<
+      MuiTabProps,
+      | 'icon'
+      | 'label'
+      | 'textColor'
+      // button base
+      | 'centerRipple'
+      | 'disableFocusRipple'
+      | 'disableRipple'
+      | 'disableTouchRipple'
+      | 'focusRipple'
+      | 'TouchRippleProps'
+    >;
+  defaultComponent: D;
+  classKey: Unstable_TabClassKey;
+}
+
+export type Unstable_TabProps<
+  D extends ElementType = Unstable_TabTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_TabTypeMap<P, D>, D>;
+
+export type Unstable_TabClassKey = 'root' | 'label';
+
+type PrivateClassKey =
+  | 'private-root-disabled'
+  | 'private-root-selected'
+  | 'private-label-disabled'
+  | 'private-label-selected';
+
+const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
+  root: {
+    minHeight: 'unset',
+    maxWidth: 'unset',
+    minWidth: 'unset',
+    padding: '12px 0 12px 0',
+    // transition: theme.transitions.create('box-shadow', {
+    //   duration: theme.transitions.duration.short,
+    // }),
+    '&:hover': {
+      boxShadow: `0px 2px 0px ${theme.unstable_palette.neutral[0]}, 0px 4px 0px ${theme.unstable_palette.neutral[100]}`,
+    },
+    '&:active': {
+      zIndex: 2,
+      boxShadow: `0px 2px 0px ${theme.unstable_palette.neutral[0]}, 0px 4px 0px ${theme.unstable_palette.blue[400]}`,
+    },
+    '&.Mui-focusVisible, &:focus-visible': {
+      zIndex: 2,
+      borderRadius: 8,
+      boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+    },
+    // override v1
+    border: 'none',
+    borderRadius: 0,
+    // override MUI defaults
+    '&&': {
+      opacity: 1,
+    },
+  },
+  label: {
+    ...theme.unstable_typography.label,
+    color: theme.unstable_palette.text.body,
+    textTransform: 'none',
+  },
+  'private-root-selected': {},
+  'private-root-disabled': {
+    '&:hover': {
+      boxShadow: 'none',
+    },
+  },
+  'private-label-selected': {},
+  'private-label-disabled': {
+    color: theme.unstable_palette.text.disabled,
+  },
+});
+
+const Unstable_Tab: OverridableComponent<Unstable_TabTypeMap> = forwardRef(
+  function Unstable_Tab(props, ref) {
+    const { children, classes, disabled, selected, ...other } = props;
+
+    const context = useTabsContext();
+    if (context === null) {
+      throw new Error('No TabsContext provided');
+    }
+
+    return (
+      <MuiTab
+        classes={{
+          root: clsx(classes.root, {
+            [classes['private-root-disabled']]: disabled,
+            [classes['private-root-selected']]: selected,
+          }),
+          wrapper: clsx(classes.label, {
+            [classes['private-label-disabled']]: disabled,
+            [classes['private-label-selected']]: selected,
+          }),
+        }}
+        label={children}
+        disabled={disabled}
+        selected={selected}
+        ref={ref}
+        {...other}
+        // button base
+        disableFocusRipple
+        disableRipple
+        disableTouchRipple
+        focusRipple={false}
+      />
+    );
+  }
+);
+
+export default withStyles(styles, {
+  name: 'MuiSparkUnstable_Tab',
+})(Unstable_Tab) as typeof Unstable_Tab;

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
@@ -39,31 +39,17 @@ export type Unstable_TabClassKey = 'root' | 'label';
 
 type PrivateClassKey =
   | 'private-root-disabled'
-  | 'private-root-selected'
+  | 'private-root-orientation-horizontal'
+  | 'private-root-orientation-vertical'
   | 'private-label-disabled'
-  | 'private-label-selected';
+  | 'private-label-orientation-horizontal'
+  | 'private-label-orientation-vertical';
 
 const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
   root: {
     minHeight: 'unset',
     maxWidth: 'unset',
     minWidth: 'unset',
-    padding: '12px 0 12px 0',
-    // transition: theme.transitions.create('box-shadow', {
-    //   duration: theme.transitions.duration.short,
-    // }),
-    '&:hover': {
-      boxShadow: `0px 2px 0px ${theme.unstable_palette.neutral[0]}, 0px 4px 0px ${theme.unstable_palette.neutral[100]}`,
-    },
-    '&:active': {
-      zIndex: 2,
-      boxShadow: `0px 2px 0px ${theme.unstable_palette.neutral[0]}, 0px 4px 0px ${theme.unstable_palette.blue[400]}`,
-    },
-    '&.Mui-focusVisible, &:focus-visible': {
-      zIndex: 2,
-      borderRadius: 8,
-      boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
-    },
     // override v1
     border: 'none',
     borderRadius: 0,
@@ -77,15 +63,47 @@ const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
     color: theme.unstable_palette.text.body,
     textTransform: 'none',
   },
-  'private-root-selected': {},
   'private-root-disabled': {
     '&:hover': {
       boxShadow: 'none',
     },
   },
-  'private-label-selected': {},
+  'private-root-orientation-horizontal': {
+    padding: '16px 0',
+    '&:hover': {
+      boxShadow: `inset 0px -2px ${theme.unstable_palette.neutral[100]}`,
+    },
+    '&:active': {
+      zIndex: 2,
+      boxShadow: `inset 0px -2px ${theme.unstable_palette.blue[400]}`,
+    },
+    '&.Mui-focusVisible, &:focus-visible': {
+      zIndex: 2,
+      borderRadius: 8,
+      boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+    },
+  },
+  'private-root-orientation-vertical': {
+    padding: '12px 12px',
+    '&:hover': {
+      boxShadow: `inset -2px 0 ${theme.unstable_palette.neutral[100]}`,
+    },
+    '&:active': {
+      zIndex: 2,
+      boxShadow: `inset -2px 0px ${theme.unstable_palette.blue[400]}`,
+    },
+    '&.Mui-focusVisible, &:focus-visible': {
+      zIndex: 2,
+      borderRadius: 8,
+      boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
+    },
+  },
   'private-label-disabled': {
     color: theme.unstable_palette.text.disabled,
+  },
+  'private-label-orientation-horizontal': {},
+  'private-label-orientation-vertical': {
+    alignItems: 'flex-start',
   },
 });
 
@@ -101,14 +119,20 @@ const Unstable_Tab: OverridableComponent<Unstable_TabTypeMap> = forwardRef(
     return (
       <MuiTab
         classes={{
-          root: clsx(classes.root, {
-            [classes['private-root-disabled']]: disabled,
-            [classes['private-root-selected']]: selected,
-          }),
-          wrapper: clsx(classes.label, {
-            [classes['private-label-disabled']]: disabled,
-            [classes['private-label-selected']]: selected,
-          }),
+          root: clsx(
+            classes.root,
+            classes[`private-root-orientation-${context.orientation}`],
+            {
+              [classes['private-root-disabled']]: disabled,
+            }
+          ),
+          wrapper: clsx(
+            classes.label,
+            classes[`private-label-orientation-${context.orientation}`],
+            {
+              [classes['private-label-disabled']]: disabled,
+            }
+          ),
         }}
         label={children}
         disabled={disabled}

--- a/libs/spark/src/Unstable_Tab/index.ts
+++ b/libs/spark/src/Unstable_Tab/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_Tab';
+export * from './Unstable_Tab';

--- a/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.stories.tsx
+++ b/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import React from 'react';
+import { Unstable_TabPanel, Unstable_TabPanelProps, Unstable_Tabs } from '..';
+import { sparkThemeProvider } from '../../stories';
+
+export const _retyped = Unstable_TabPanel as typeof Unstable_TabPanel;
+
+export default {
+  title: '@ps/TabPanel',
+  component: _retyped,
+  excludeStories: ['_retyped'],
+  args: {
+    'Tabs.defaultValue': '0',
+  },
+} as Meta;
+
+const Template = (args) => {
+  const { 'Tabs.defaultValue': TabsDefaultValue, ...other } = args;
+
+  return (
+    <Unstable_Tabs defaultValue={TabsDefaultValue}>
+      <Unstable_TabPanel {...other}>Panel</Unstable_TabPanel>
+    </Unstable_Tabs>
+  );
+};
+
+type Story = DefaultStory<Unstable_TabPanelProps>;
+
+export const Value: Story = Template.bind({});
+Value.args = { value: '0' };
+Value.storyName = 'value';
+
+export const ValueSTP: Story = Template.bind({});
+ValueSTP.args = { value: '0' };
+ValueSTP.decorators = [sparkThemeProvider];
+ValueSTP.storyName = 'value (STP)';

--- a/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.test.tsx
+++ b/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import Unstable_TabPanel from './Unstable_TabPanel';
+import Unstable_Tabs from '../Unstable_Tabs';
+
+describe('Unstable_TabPanel', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(
+      <Unstable_Tabs value="0">
+        <Unstable_TabPanel value="0" />
+      </Unstable_Tabs>
+    );
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.tsx
+++ b/libs/spark/src/Unstable_TabPanel/Unstable_TabPanel.tsx
@@ -1,0 +1,31 @@
+import MuiTabPanel, {
+  TabPanelProps as MuiTabPanelProps,
+} from '@material-ui/lab/TabPanel';
+import React, { forwardRef } from 'react';
+import withStyles, { Styles } from '../withStyles';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unstable_TabPanelProps extends MuiTabPanelProps {}
+
+export type Unstable_TabPanelClassKey = 'root';
+
+const styles: Styles<Unstable_TabPanelClassKey> = {
+  /* Styles applied to the root element. */
+  root: {
+    padding: 0,
+  },
+};
+
+const Unstable_TabPanel = forwardRef<HTMLDivElement, Unstable_TabPanelProps>(
+  function Unstable_TabPanel(props, ref) {
+    const { classes, ...other } = props;
+
+    return (
+      <MuiTabPanel classes={{ root: classes.root }} ref={ref} {...other} />
+    );
+  }
+);
+
+export default withStyles(styles, {
+  name: 'MuiSparkUnstable_TabPanel',
+})(Unstable_TabPanel) as typeof Unstable_TabPanel;

--- a/libs/spark/src/Unstable_TabPanel/index.ts
+++ b/libs/spark/src/Unstable_TabPanel/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_TabPanel';
+export * from './Unstable_TabPanel';

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
@@ -55,6 +55,13 @@ DefaultValueSTP.args = { defaultValue: '0' };
 DefaultValueSTP.decorators = [sparkThemeProvider];
 DefaultValueSTP.storyName = 'defaultValue (STP)';
 
+export const DefaultValueOrientationVertical: Story = Template.bind({});
+DefaultValueOrientationVertical.args = {
+  defaultValue: '0',
+  orientation: 'vertical',
+};
+DefaultValueOrientationVertical.storyName = 'defaultValue orientation=vertical';
+
 export const Value: Story = Template.bind({});
 Value.args = { value: '0' };
 Value.decorators = [statefulValue, enableHooks];

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import React from 'react';
+import {
+  Unstable_Tab,
+  Unstable_TabPanel,
+  Unstable_Tabs,
+  Unstable_TabsList,
+  Unstable_TabsProps,
+} from '..';
+import {
+  containFocusIndicator,
+  enableHooks,
+  largeWidth,
+  sparkThemeProvider,
+  statefulValue,
+} from '../../stories';
+
+export const _retyped = Unstable_Tabs as typeof Unstable_Tabs;
+
+export default {
+  title: '@ps/Tabs',
+  component: _retyped,
+  excludeStories: ['_retyped'],
+  decorators: [largeWidth, containFocusIndicator],
+  args: {
+    'TabsList.aria-label': 'tabs story',
+  },
+} as Meta;
+
+const Template = (args) => {
+  const { 'TabsList.aria-label': TabsListAriaLabel, ...other } = args;
+
+  return (
+    <Unstable_Tabs {...other}>
+      <Unstable_TabsList aria-label={TabsListAriaLabel}>
+        <Unstable_Tab value="0">Label 0</Unstable_Tab>
+        <Unstable_Tab value="1">Label 1</Unstable_Tab>
+        <Unstable_Tab value="2">Label 2</Unstable_Tab>
+      </Unstable_TabsList>
+      <Unstable_TabPanel value="0">Panel 0</Unstable_TabPanel>
+      <Unstable_TabPanel value="1">Panel 1</Unstable_TabPanel>
+      <Unstable_TabPanel value="2">Panel 2</Unstable_TabPanel>
+    </Unstable_Tabs>
+  );
+};
+
+type Story = DefaultStory<Unstable_TabsProps>;
+
+export const DefaultValue: Story = Template.bind({});
+DefaultValue.args = { defaultValue: '0' };
+DefaultValue.storyName = 'defaultValue';
+
+export const DefaultValueSTP: Story = Template.bind({});
+DefaultValueSTP.args = { defaultValue: '0' };
+DefaultValueSTP.decorators = [sparkThemeProvider];
+DefaultValueSTP.storyName = 'defaultValue (STP)';
+
+export const Value: Story = Template.bind({});
+Value.args = { value: '0' };
+Value.decorators = [statefulValue, enableHooks];
+Value.storyName = 'value';

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.test.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_Tabs from './Unstable_Tabs';
+
+describe('Unstable_Tabs', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<Unstable_Tabs value="0" />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.tsx
@@ -52,9 +52,22 @@ export type Unstable_TabsProps<
 
 export type Unstable_TabsClassKey = 'root';
 
-const styles: Styles<Unstable_TabsClassKey> = {
+type PrivateClassKey =
+  | 'private-root-orientation-horizontal'
+  | 'private-root-orientation-vertical';
+
+const styles: Styles<Unstable_TabsClassKey | PrivateClassKey> = {
   /* Styles applied to the root element. */
-  root: {},
+  root: {
+    display: 'flex',
+  },
+  /* Private */
+  'private-root-orientation-horizontal': {
+    flexDirection: 'column',
+  },
+  'private-root-orientation-vertical': {
+    flexDirection: 'row',
+  },
 };
 
 const Unstable_Tabs: OverridableComponent<Unstable_TabsTypeMap> = forwardRef(
@@ -100,7 +113,15 @@ const Unstable_Tabs: OverridableComponent<Unstable_TabsTypeMap> = forwardRef(
     );
 
     return (
-      <div className={clsx(classes.root, className)} ref={ref} {...other}>
+      <div
+        className={clsx(
+          classes.root,
+          classes[`private-root-orientation-${orientation}`],
+          className
+        )}
+        ref={ref}
+        {...other}
+      >
         <Context.Provider value={contextValue}>
           <MuiTabContext value={value}>{children}</MuiTabContext>
         </Context.Provider>

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.tsx
@@ -1,0 +1,114 @@
+import MuiTabContext from '@material-ui/lab/TabContext';
+import clsx from 'clsx';
+import {
+  ElementType,
+  forwardRef,
+  SyntheticEvent,
+  useCallback,
+  useMemo,
+} from 'react';
+import { OverridableComponent, OverrideProps, useControlled } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+import Context, { Unstable_TabsContextValue } from './Unstable_TabsContext';
+
+export interface Unstable_TabsTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends ElementType = 'div'
+> {
+  props: P & {
+    /**
+     * The value of the currently selected `Tab`.
+     * If you don't want any selected `Tab`, you can set this prop to `false`.
+     */
+    value?: string | false;
+    /**
+     * The default value. Use when the component is not controlled.
+     */
+    defaultValue?: string | false;
+    /**
+     * The component orientation (layout flow direction).
+     */
+    orientation?: 'horizontal' | 'vertical';
+    /**
+     * Callback invoked when new value is being set.
+     */
+    onChange?: (
+      event: SyntheticEvent,
+      value: number | string | boolean
+    ) => void;
+  };
+  defaultComponent: D;
+  classKey: Unstable_TabsClassKey;
+}
+
+export type Unstable_TabsProps<
+  D extends ElementType = Unstable_TabsTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_TabsTypeMap<P, D>, D> & {
+  component?: D;
+};
+
+export type Unstable_TabsClassKey = 'root';
+
+const styles: Styles<Unstable_TabsClassKey> = {
+  /* Styles applied to the root element. */
+  root: {},
+};
+
+const Unstable_Tabs: OverridableComponent<Unstable_TabsTypeMap> = forwardRef(
+  function Unstable_Tabs(props, ref) {
+    const {
+      children,
+      classes,
+      className,
+      defaultValue,
+      onChange,
+      orientation = 'horizontal',
+      value: valueProp,
+      ...other
+    } = props;
+
+    const [value, setValue] = useControlled({
+      // coerce to string since v4 only accepts string
+      controlled: valueProp === false ? '_false' : valueProp,
+      default: defaultValue === false ? '_false' : defaultValue,
+      name: 'Tabs',
+      state: 'value',
+    });
+
+    const onSelected = useCallback(
+      (event: SyntheticEvent, newValue: string) => {
+        setValue(newValue);
+        if (onChange) {
+          onChange(event, newValue);
+        }
+      },
+      [onChange, setValue]
+    );
+
+    const contextValue = useMemo<Unstable_TabsContextValue>(
+      () =>
+        ({
+          onSelected,
+          orientation,
+          value,
+          // missing `idPrefix` but not actually necessary
+        } as Unstable_TabsContextValue),
+      [onSelected, orientation, value]
+    );
+
+    return (
+      <div className={clsx(classes.root, className)} ref={ref} {...other}>
+        <Context.Provider value={contextValue}>
+          <MuiTabContext value={value}>{children}</MuiTabContext>
+        </Context.Provider>
+      </div>
+    );
+  }
+);
+
+export default withStyles(styles, {
+  name: 'MuiSparkUnstable_Tabs',
+})(Unstable_Tabs) as typeof Unstable_Tabs;

--- a/libs/spark/src/Unstable_Tabs/Unstable_TabsContext.ts
+++ b/libs/spark/src/Unstable_Tabs/Unstable_TabsContext.ts
@@ -1,0 +1,46 @@
+import {
+  TabContextValue as MuiTabContextValue,
+  useTabContext as useMuiTabContext,
+} from '@material-ui/lab/TabContext';
+import { createContext, useContext } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unstable_TabsContextValue
+  extends Omit<MuiTabContextValue, 'value'> {
+  /**
+   * Callback for setting new value.
+   */
+  onSelected: (
+    event: React.SyntheticEvent,
+    value: number | string | false
+  ) => void;
+  /**
+   * The component orientation (layout flow direction).
+   */
+  orientation?: 'horizontal' | 'vertical';
+  /**
+   * The currently selected tab's value.
+   */
+  value: number | string | false;
+}
+
+/**
+ * @type {React.Context<{ idPrefix: string; value: string } | null>}
+ */
+const Context = createContext<Unstable_TabsContextValue | null>(null);
+
+if (process.env.NODE_ENV !== 'production') {
+  Context.displayName = 'TabsContext';
+}
+
+export const useTabsContext = () => {
+  const value = useContext(Context);
+  const muiValue = useMuiTabContext();
+  if (value === null) {
+    return value;
+  } else {
+    return { ...muiValue, ...value };
+  }
+};
+
+export default Context;

--- a/libs/spark/src/Unstable_Tabs/index.ts
+++ b/libs/spark/src/Unstable_Tabs/index.ts
@@ -1,0 +1,4 @@
+export { default } from './Unstable_Tabs';
+export * from './Unstable_Tabs';
+
+export * from './Unstable_TabsContext';

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import React from 'react';
+import {
+  Unstable_Tab,
+  Unstable_Tabs,
+  Unstable_TabsList,
+  Unstable_TabsListProps,
+} from '..';
+import {
+  containFocusIndicator,
+  largeWidth,
+  sparkThemeProvider,
+} from '../../stories';
+
+export const _retyped = Unstable_TabsList as typeof Unstable_TabsList;
+
+export default {
+  title: '@ps/TabsList',
+  component: _retyped,
+  excludeStories: ['_retyped'],
+  decorators: [largeWidth, containFocusIndicator],
+  args: {
+    'Tabs.defaultValue': '0',
+    'aria-label': 'Example of three tabs',
+  },
+} as Meta;
+
+const Template = (args) => {
+  const { 'Tabs.defaultValue': TabsDefaultValue, ...other } = args;
+
+  return (
+    <Unstable_Tabs defaultValue={TabsDefaultValue}>
+      <Unstable_TabsList {...other}>
+        <Unstable_Tab value="0">Label 0</Unstable_Tab>
+        <Unstable_Tab value="1">Label 1</Unstable_Tab>
+        <Unstable_Tab value="2">Label 2</Unstable_Tab>
+      </Unstable_TabsList>
+    </Unstable_Tabs>
+  );
+};
+
+type Story = DefaultStory<Unstable_TabsListProps>;
+
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
+
+export const STP: Story = Template.bind({});
+STP.decorators = [sparkThemeProvider];
+STP.storyName = '(STP)';
+
+export const Hover: Story = Template.bind({});
+Hover.parameters = { pseudo: { hover: true } };
+Hover.storyName = ':hover';
+
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.parameters = { pseudo: { focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
+
+export const Active: Story = Template.bind({});
+Active.parameters = { pseudo: { active: true } };
+Active.storyName = ':active';

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
@@ -5,6 +5,7 @@ import {
   Unstable_Tabs,
   Unstable_TabsList,
   Unstable_TabsListProps,
+  Unstable_TabsProps,
 } from '..';
 import {
   containFocusIndicator,
@@ -26,10 +27,17 @@ export default {
 } as Meta;
 
 const Template = (args) => {
-  const { 'Tabs.defaultValue': TabsDefaultValue, ...other } = args;
+  const {
+    'Tabs.orientation': TabsOrientation,
+    'Tabs.defaultValue': TabsDefaultValue,
+    ...other
+  } = args;
 
   return (
-    <Unstable_Tabs defaultValue={TabsDefaultValue}>
+    <Unstable_Tabs
+      defaultValue={TabsDefaultValue}
+      orientation={TabsOrientation}
+    >
       <Unstable_TabsList {...other}>
         <Unstable_Tab value="0">Label 0</Unstable_Tab>
         <Unstable_Tab value="1">Label 1</Unstable_Tab>
@@ -39,7 +47,11 @@ const Template = (args) => {
   );
 };
 
-type Story = DefaultStory<Unstable_TabsListProps>;
+type Story = DefaultStory<
+  Unstable_TabsListProps & {
+    'Tabs.orientation': Unstable_TabsProps['orientation'];
+  }
+>;
 
 export const Default: Story = Template.bind({});
 Default.storyName = '(default)';
@@ -59,3 +71,25 @@ FocusVisible.storyName = ':focus-visible';
 export const Active: Story = Template.bind({});
 Active.parameters = { pseudo: { active: true } };
 Active.storyName = ':active';
+
+export const TabsOrientationVertical: Story = Template.bind({});
+TabsOrientationVertical.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVertical.storyName = 'Tabs.orientation=vertical';
+
+export const TabsOrientationVerticalHover: Story = Template.bind({});
+TabsOrientationVerticalHover.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalHover.parameters = { pseudo: { hover: true } };
+TabsOrientationVerticalHover.storyName = 'Tabs.orientation=vertical :hover';
+
+export const TabsOrientationVerticalFocusVisible: Story = Template.bind({});
+TabsOrientationVerticalFocusVisible.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalFocusVisible.parameters = {
+  pseudo: { focusVisible: true },
+};
+TabsOrientationVerticalFocusVisible.storyName =
+  'Tabs.orientation=vertical :focus-visible';
+
+export const TabsOrientationVerticalActive: Story = Template.bind({});
+TabsOrientationVerticalActive.args = { 'Tabs.orientation': 'vertical' };
+TabsOrientationVerticalActive.parameters = { pseudo: { active: true } };
+TabsOrientationVerticalActive.storyName = 'Tabs.orientation=vertical :active';

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.test.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import Unstable_Tabs from '../Unstable_Tabs';
+import Unstable_TabsList from './Unstable_TabsList';
+
+describe('Unstable_TabsList', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(
+      <Unstable_Tabs value="0">
+        <Unstable_TabsList />
+      </Unstable_Tabs>
+    );
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.tsx
@@ -1,0 +1,112 @@
+import MuiTabList, {
+  TabListTypeMap as MuiTabListTypeMap,
+  TabListProps as MuiTabListProps,
+} from '@material-ui/lab/TabList';
+import { forwardRef } from 'react';
+import { useTabsContext } from '../Unstable_Tabs/Unstable_TabsContext';
+import { OverridableComponent, OverrideProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+
+export interface Unstable_TabsListTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends React.ElementType = MuiTabListTypeMap['defaultComponent']
+> {
+  props: P &
+    Omit<
+      MuiTabListProps,
+      | 'centered'
+      | 'indicatorColor'
+      | 'onChange'
+      | 'orientation'
+      | 'selectionFollowsFocus'
+      | 'ScrollButtonComponent'
+      | 'scrollButtons'
+      | 'TabScrollButtonProps'
+      | 'textColor'
+      | 'variant'
+    >;
+  defaultComponent: D;
+  classKey: Unstable_TabsListClassKey;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export type Unstable_TabsListProps<
+  D extends React.ElementType = Unstable_TabsListTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_TabsListTypeMap<P, D>, D>;
+
+export type Unstable_TabsListClassKey =
+  | 'root'
+  | 'tablist'
+  | 'flexContainer'
+  | 'indicator';
+
+// all the padding/margin work is to get Tab focus shadows to not be cutoff
+const styles: Styles<Unstable_TabsListClassKey> = (theme) => ({
+  /* Styles applied to the root element. */
+  root: {
+    minHeight: 52,
+    marginLeft: -4,
+    paddingLeft: 4,
+    marginRight: -4,
+    paddingRight: 4,
+  },
+  /* Styles applied to the tablist element (child of root element). */
+  tablist: {
+    marginLeft: -4,
+    marginRight: -4,
+    overflowX: 'scroll',
+    padding: 4,
+    // from MUI (Tabs.styles.scrollable)
+    // Hide dimensionless scrollbar on MacOS
+    scrollbarWidth: 'none', // Firefox
+    '&::-webkit-scrollbar': {
+      display: 'none', // Safari + Chrome
+    },
+  },
+  /* Styles applied to the flex container element (child of scroller element). */
+  flexContainer: {
+    boxShadow: `0px 2px ${theme.unstable_palette.neutral[0]}, 0px 4px ${theme.unstable_palette.neutral[80]}`,
+    gap: 32,
+  },
+  /* Styles applied to the indicator element (child of scroller element). */
+  indicator: {
+    backgroundColor: theme.unstable_palette.blue[600],
+  },
+});
+
+const Unstable_TabsList: OverridableComponent<Unstable_TabsListTypeMap> = forwardRef(
+  function Unstable_TabsList(props, ref) {
+    const { classes, ...other } = props;
+
+    const context = useTabsContext();
+    if (context === null) {
+      throw new Error('No TabsContext provided');
+    }
+
+    const onChange = (event, value) => {
+      context.onSelected(event, value);
+    };
+
+    return (
+      <MuiTabList
+        classes={{
+          root: classes.root,
+          scroller: classes.tablist,
+          flexContainer: classes.flexContainer,
+          indicator: classes.indicator,
+        }}
+        onChange={onChange}
+        orientation={context.orientation}
+        ref={ref}
+        {...other}
+      />
+    );
+  }
+);
+
+export default withStyles(styles, {
+  name: 'MuiSparkUnstable_TabsList',
+})(Unstable_TabsList) as typeof Unstable_TabsList;

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.tsx
@@ -2,6 +2,7 @@ import MuiTabList, {
   TabListTypeMap as MuiTabListTypeMap,
   TabListProps as MuiTabListProps,
 } from '@material-ui/lab/TabList';
+import clsx from 'clsx';
 import { forwardRef } from 'react';
 import { useTabsContext } from '../Unstable_Tabs/Unstable_TabsContext';
 import { OverridableComponent, OverrideProps } from '../utils';
@@ -43,20 +44,28 @@ export type Unstable_TabsListClassKey =
   | 'flexContainer'
   | 'indicator';
 
+type PrivateClassKey =
+  | 'private-flexContainer-orientation-horizontal'
+  | 'private-flexContainer-orientation-vertical'
+  | 'private-indicator-orientation-horizontal'
+  | 'private-indicator-orientation-vertical';
+
 // all the padding/margin work is to get Tab focus shadows to not be cutoff
-const styles: Styles<Unstable_TabsListClassKey> = (theme) => ({
+const styles: Styles<Unstable_TabsListClassKey | PrivateClassKey> = (
+  theme
+) => ({
   /* Styles applied to the root element. */
   root: {
-    minHeight: 52,
-    marginLeft: -4,
-    paddingLeft: 4,
-    marginRight: -4,
-    paddingRight: 4,
+    margin: -4,
+    padding: 4,
+    // override v1
+    boxShadow: 'none',
+    // override MUI
+    minHeight: 'unset',
   },
   /* Styles applied to the tablist element (child of root element). */
   tablist: {
-    marginLeft: -4,
-    marginRight: -4,
+    margin: -4,
     overflowX: 'scroll',
     padding: 4,
     // from MUI (Tabs.styles.scrollable)
@@ -65,15 +74,31 @@ const styles: Styles<Unstable_TabsListClassKey> = (theme) => ({
     '&::-webkit-scrollbar': {
       display: 'none', // Safari + Chrome
     },
+    // override MUI
+    width: 'unset',
   },
   /* Styles applied to the flex container element (child of scroller element). */
-  flexContainer: {
-    boxShadow: `0px 2px ${theme.unstable_palette.neutral[0]}, 0px 4px ${theme.unstable_palette.neutral[80]}`,
-    gap: 32,
-  },
+  flexContainer: {},
   /* Styles applied to the indicator element (child of scroller element). */
   indicator: {
     backgroundColor: theme.unstable_palette.blue[600],
+  },
+  /* Private */
+  'private-flexContainer-orientation-horizontal': {
+    // boxShadow: `0px 2px ${theme.unstable_palette.neutral[0]}, 0px 4px ${theme.unstable_palette.neutral[80]}`,
+    boxShadow: `inset 0px -2px ${theme.unstable_palette.neutral[80]}`,
+    gap: 32,
+  },
+  'private-flexContainer-orientation-vertical': {
+    // boxShadow: `2px 0px ${theme.unstable_palette.neutral[0]}, 4px 0 ${theme.unstable_palette.neutral[80]}`,
+    boxShadow: `inset -2px 0 ${theme.unstable_palette.neutral[80]}`,
+    gap: 12,
+  },
+  'private-indicator-orientation-horizontal': {
+    bottom: 4,
+  },
+  'private-indicator-orientation-vertical': {
+    right: 4,
   },
 });
 
@@ -95,8 +120,14 @@ const Unstable_TabsList: OverridableComponent<Unstable_TabsListTypeMap> = forwar
         classes={{
           root: classes.root,
           scroller: classes.tablist,
-          flexContainer: classes.flexContainer,
-          indicator: classes.indicator,
+          flexContainer: clsx(
+            classes.flexContainer,
+            classes[`private-flexContainer-orientation-${context.orientation}`]
+          ),
+          indicator: clsx(
+            classes.indicator,
+            classes[`private-indicator-orientation-${context.orientation}`]
+          ),
         }}
         onChange={onChange}
         orientation={context.orientation}

--- a/libs/spark/src/Unstable_TabsList/index.ts
+++ b/libs/spark/src/Unstable_TabsList/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_TabsList';
+export * from './Unstable_TabsList';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -341,6 +341,18 @@ export * from './Unstable_Switch';
 export { default as Unstable_SwitchField } from './Unstable_SwitchField';
 export * from './Unstable_SwitchField';
 
+export { default as Unstable_Tab } from './Unstable_Tab';
+export * from './Unstable_Tab';
+
+export { default as Unstable_TabPanel } from './Unstable_TabPanel';
+export * from './Unstable_TabPanel';
+
+export { default as Unstable_Tabs } from './Unstable_Tabs';
+export * from './Unstable_Tabs';
+
+export { default as Unstable_TabsList } from './Unstable_TabsList';
+export * from './Unstable_TabsList';
+
 export { default as Unstable_Tag } from './Unstable_Tag';
 export * from './Unstable_Tag';
 

--- a/libs/spark/src/utils/index.ts
+++ b/libs/spark/src/utils/index.ts
@@ -10,6 +10,8 @@ export * from './StandardProps';
 
 export { default as useClassesCapture } from './useClassesCapture';
 
+export { default as useControlled } from './useControlled';
+
 export { default as useId } from './useId';
 
 export { default as useMergeClasses } from './useMergeClasses';

--- a/libs/spark/src/utils/useControlled.ts
+++ b/libs/spark/src/utils/useControlled.ts
@@ -1,0 +1,2 @@
+export { useControlled as default } from '@material-ui/core/utils';
+export type { UseControlledProps } from '@material-ui/core/utils/useControlled';

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -35,12 +35,16 @@ export const statefulValue: DecoratorFn = (Story, context) => {
     setValue(context.args.value);
   }, [context.args.checked, context.args.value]);
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>, value) => {
     // don't change uncontrolled to controlled
     if (event.target.checked !== undefined) {
       setChecked(event.target.checked);
     }
-    setValue(event.target.value);
+    if (value !== undefined) {
+      setValue(value);
+    } else {
+      setValue(event.target.value);
+    }
   };
 
   const handleClick = (
@@ -87,7 +91,7 @@ const ContainFocusIndicatorDiv = styled('div')({
   // without setting it to fit, the story snapshot will expand to 100%
   width: 'fit-content',
   // prevent larger-than-necessary height because of added browser-default space for ascender/descenders.
-  display: 'flex',
+  display: 'grid',
   // prevent overflowing past viewport
   maxWidth: '100%',
 });
@@ -106,12 +110,25 @@ const MediumWidthDiv = styled('div')({
 });
 
 /**
- * [Internal] A Storybook decorator that is a medium width ( 256px) container.
+ * [Internal] A Storybook decorator that is a medium width (256px) container.
  */
 export const mediumWidth: DecoratorFn = (Story) => (
   <MediumWidthDiv>
     <Story />
   </MediumWidthDiv>
+);
+
+const LargeWidthDiv = styled('div')({
+  width: 512,
+});
+
+/**
+ * [Internal] A Storybook decorator that is a large width (512px) container.
+ */
+export const largeWidth: DecoratorFn = (Story) => (
+  <LargeWidthDiv>
+    <Story />
+  </LargeWidthDiv>
 );
 
 const ContainElevationDiv = styled('div')({


### PR DESCRIPTION
Implements four components that are inter-dependent: `Tabs`, `TabsList`, `Tab`, `TabPanel`. Overall, the pattern tries to bridge the gap between [MUI v4's accessible-by-default Tabs pattern](https://v4.mui.com/components/tabs/#experimental-api) (with `TabContext`, `TabList`, Tab`, `TabPanel`) and [MUI v5 (Base)'s Tabs pattern](https://mui.com/base/react-tabs/) naming, internal state, and API.

The v4 pattern falls short of v5 in two respects when it comes to state. It cannot be uncontrolled (consumer must always declare, handle, pass state), and the value and change handler are passed to separate elements (former to `TabContext`, latter to `TabList`). So, the unstable Tabs component mimics the v5 internals by adding `defaultValue`, a better `value` prop, using the `isControlled` hook for state, and providing a change handler in context to the unstable Tab List, which in turn removes the handler from its API. However, the implementation makes no attempt to mimic v5's "auto-value" API, as that involves a series of quite complex code that is just not worth it for us. I believe consumers will be happy to get by with this.