### PR TITLE
feat(Button): add color prop

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - **DropdownAnchor**
   - Minor design change of Chevron Down icon.
+- **Unstable_Button**
+  - Support ghost variant on inverse background with new color prop (mirror of Icon Button's API).
+  - Design changes:
+    - Corrected the background color of the stroked variant to white.
+  - Props API:
+    - `color`: added
 - **Unstable_Select**
   - Minor design change of Chevron Down icon.
 - **Unstable_Tab**

--- a/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Unstable_Avatar, Unstable_Button, Unstable_ButtonProps } from '..';
+import {
+  theme,
+  Unstable_Avatar,
+  Unstable_Button,
+  Unstable_ButtonProps,
+} from '..';
 import {
   ChevronDown,
   containFocusIndicator,
@@ -89,6 +94,29 @@ const SizeByVariantTemplate = (args) => (
             {...args}
             variant={variant}
             size={size}
+          />
+        ))}
+      </div>
+    ))}
+    {sizes.map((size) => (
+      <div
+        key={size}
+        style={{
+          display: 'flex',
+          gap: 4,
+          alignItems: 'flex-start',
+          backgroundColor: theme.unstable_palette.background.inverse,
+          margin: -4,
+          padding: 4,
+        }}
+      >
+        {variants.map((variant) => (
+          <Unstable_Button
+            key={variant}
+            {...args}
+            variant={variant}
+            size={size}
+            color="inverse"
           />
         ))}
       </div>

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -6,7 +6,7 @@ import {
 } from '@material-ui/core/Button';
 import { OverridableComponent, OverrideProps } from '../utils';
 import { buildVariant } from '../theme/typography';
-import { lighten, darken } from '@material-ui/core/styles';
+import { lighten, darken, alpha } from '@material-ui/core/styles';
 import { Unstable_AvatarProps } from '../Unstable_Avatar';
 import withStyles, { Styles } from '../withStyles';
 
@@ -31,6 +31,10 @@ export interface Unstable_ButtonTypeMap<
       | 'focusRipple'
       | 'TouchRippleProps'
     > & {
+      /**
+       * The color of the component.
+       */
+      color?: 'standard' | 'inverse';
       /**
        * The variant to use.
        */
@@ -68,8 +72,14 @@ export type Unstable_ButtonClassKey =
 
 type PrivateClassKey =
   | 'private-root-variant-primary'
+  | 'private-root-variant-primary-color-standard'
+  | 'private-root-variant-primary-color-inverse'
   | 'private-root-variant-stroked'
+  | 'private-root-variant-stroked-color-standard'
+  | 'private-root-variant-stroked-color-inverse'
   | 'private-root-variant-ghost'
+  | 'private-root-variant-ghost-color-standard'
+  | 'private-root-variant-ghost-color-inverse'
   | 'private-root-variant-destructive'
   | 'private-root-size-small'
   | 'private-root-size-medium'
@@ -77,8 +87,14 @@ type PrivateClassKey =
   | 'private-root-ariaExpanded'
   | 'private-root-disabled'
   | 'private-label-variant-primary'
+  | 'private-label-variant-primary-color-standard'
+  | 'private-label-variant-primary-color-inverse'
   | 'private-label-variant-stroked'
+  | 'private-label-variant-stroked-color-standard'
+  | 'private-label-variant-stroked-color-inverse'
   | 'private-label-variant-ghost'
+  | 'private-label-variant-ghost-color-standard'
+  | 'private-label-variant-ghost-color-inverse'
   | 'private-label-variant-destructive'
   | 'private-label-size-small'
   | 'private-label-size-medium'
@@ -172,9 +188,11 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
       },
     },
   },
+  'private-root-variant-primary-color-standard': {},
+  'private-root-variant-primary-color-inverse': {},
   'private-root-variant-stroked': {
     '&&': {
-      backgroundColor: 'transparent',
+      backgroundColor: theme.unstable_palette.neutral[0],
       borderColor: theme.unstable_palette.neutral[90],
       '&:hover': {
         backgroundColor: theme.unstable_palette.neutral[70],
@@ -184,15 +202,41 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
       },
     },
   },
+  'private-root-variant-stroked-color-standard': {},
+  'private-root-variant-stroked-color-inverse': {},
   'private-root-variant-ghost': {
     '&&': {
       backgroundColor: 'transparent',
+    },
+  },
+  'private-root-variant-ghost-color-standard': {
+    '&&': {
       '&:hover': {
-        backgroundColor: theme.unstable_palette.neutral[70],
+        backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.08),
       },
       '&:active': {
-        backgroundColor: theme.unstable_palette.blue[100],
+        backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
       },
+      '&[aria-expanded="true"]': {
+        backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.8),
+      },
+      '&:disabled': {
+        backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
+      },
+    },
+  },
+  'private-root-variant-ghost-color-inverse': {
+    '&:hover': {
+      backgroundColor: alpha(theme.unstable_palette.neutral[0], 0.08),
+    },
+    '&:active': {
+      backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
+    },
+    '&[aria-expanded="true"]': {
+      backgroundColor: alpha(theme.unstable_palette.neutral[90], 0.4),
+    },
+    '&:disabled': {
+      backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
     },
   },
   'private-root-variant-destructive': {
@@ -245,11 +289,19 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
   'private-label-variant-primary': {
     color: theme.unstable_palette.neutral[0],
   },
+  'private-label-variant-primary-color-standard': {},
+  'private-label-variant-primary-color-inverse': {},
   'private-label-variant-stroked': {
     color: theme.unstable_palette.brand.blue,
   },
-  'private-label-variant-ghost': {
+  'private-label-variant-stroked-color-standard': {},
+  'private-label-variant-stroked-color-inverse': {},
+  'private-label-variant-ghost': {},
+  'private-label-variant-ghost-color-standard': {
     color: theme.unstable_palette.brand.blue,
+  },
+  'private-label-variant-ghost-color-inverse': {
+    color: theme.unstable_palette.neutral[0],
   },
   'private-label-variant-destructive': {
     color: theme.unstable_palette.neutral[0],
@@ -304,13 +356,13 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
       'aria-expanded': ariaExpanded,
       children,
       classes,
+      color = 'standard',
       disabled,
       leadingAvatar,
       leadingIcon,
       size = 'medium',
       trailingIcon,
       variant = 'primary',
-      color: _color,
       ...other
     } = props;
 
@@ -367,6 +419,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
             classes.root,
             classes[`private-root-size-${size}`],
             classes[`private-root-variant-${variant}`],
+            classes[`private-root-variant-${variant}-color-${color}`],
             {
               [classes['private-root-ariaExpanded']]: ariaExpanded,
               [classes['private-root-disabled']]: disabled,
@@ -376,6 +429,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
             classes.label,
             classes[`private-label-size-${size}`],
             classes[`private-label-variant-${variant}`],
+            classes[`private-label-variant-${variant}-color-${color}`],
             {
               [classes['private-label-ariaExpanded']]: ariaExpanded,
               [classes['private-label-disabled']]: disabled,

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -84,7 +84,6 @@ type PrivateClassKey =
   | 'private-root-size-small'
   | 'private-root-size-medium'
   | 'private-root-size-large'
-  | 'private-root-ariaExpanded'
   | 'private-root-disabled'
   | 'private-label-variant-primary'
   | 'private-label-variant-primary-color-standard'
@@ -186,6 +185,9 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
       '&:active': {
         backgroundColor: darken(theme.unstable_palette.background.brand, 0.2),
       },
+      '&[aria-expanded="true"]': {
+        backgroundColor: theme.unstable_palette.background.inverse,
+      },
     },
   },
   'private-root-variant-primary-color-standard': {},
@@ -199,6 +201,9 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
       },
       '&:active': {
         backgroundColor: theme.unstable_palette.blue[100],
+      },
+      '&[aria-expanded="true"]': {
+        backgroundColor: theme.unstable_palette.background.inverse,
       },
     },
   },
@@ -218,7 +223,7 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
         backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
       },
       '&[aria-expanded="true"]': {
-        backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.8),
+        backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.9),
       },
       '&:disabled': {
         backgroundColor: alpha(theme.unstable_palette.neutral[200], 0.2),
@@ -248,6 +253,9 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
       '&:active': {
         backgroundColor: darken(theme.unstable_palette.red[700], 0.2),
       },
+      '&[aria-expanded="true"]': {
+        backgroundColor: theme.unstable_palette.background.inverse,
+      },
     },
   },
   'private-root-size-small': {
@@ -263,11 +271,6 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
   'private-root-size-large': {
     '&&': {
       padding: '20px 32px',
-    },
-  },
-  'private-root-ariaExpanded': {
-    '&&': {
-      backgroundColor: theme.unstable_palette.background.inverse,
     },
   },
   'private-root-disabled': {
@@ -421,7 +424,6 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
             classes[`private-root-variant-${variant}`],
             classes[`private-root-variant-${variant}-color-${color}`],
             {
-              [classes['private-root-ariaExpanded']]: ariaExpanded,
               [classes['private-root-disabled']]: disabled,
             }
           ),

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -196,8 +196,6 @@ const Unstable_IconButton: OverridableComponent<Unstable_IconButtonTypeMap> = fo
       disabled,
       size = 'medium',
       variant = 'primary',
-      // `color` happens to be an html attribute as well; conflicts with Mui prop type
-      color: _color,
       ...other
     } = props;
 


### PR DESCRIPTION
Adds support for the `color` prop to Unstable Button, the same as Unstable Icon Button (added in #417). Useful for rendering the ghost variant on an inverse background.