### PR TITLE
feat(SparkThemeProvider): inject styles last

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.6...vNext) (YYYY-MM-DD)
 
-No changes.
+### Features
+
+- **SparkThemeProvider**
+  - Changed to inject styles last (previously injected first).
 
 ## [v2.0.0-alpha.5](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.5...v2.0.0-alpha.6) (2022-11-16)
 

--- a/libs/spark/src/SparkThemeProvider/SparkThemeProvider.tsx
+++ b/libs/spark/src/SparkThemeProvider/SparkThemeProvider.tsx
@@ -12,7 +12,7 @@ const generateClassName = createGenerateClassName({
 
 const SparkThemeProvider = (props) => {
   return (
-    <StylesProvider injectFirst generateClassName={generateClassName}>
+    <StylesProvider generateClassName={generateClassName}>
       <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
     </StylesProvider>
   );


### PR DESCRIPTION
Changed because of a problem I encountered in a consuming app: the `bootstrap.css` styles were applying after ours because of this injection order.