### PR TITLE
feat(theme): add radius

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -12,6 +12,8 @@ Added notistack v3 (alpha) as a dependency.
 
 - **DropdownAnchor**
   - Minor design change of Chevron Down icon.
+- **theme**
+  - Add "radius" of 'zero', 'xs', 'sm', 'md', 'lg', 'xl', 'full' (`theme.unstable_radius.<...>`).
 - **Unstable_Button**
   - Support ghost variant on inverse background with new color prop (mirror of Icon Button's API).
   - Design changes:

--- a/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
+++ b/libs/spark/src/Unstable_Avatar/Unstable_Avatar.tsx
@@ -122,7 +122,7 @@ const styles: Styles<Unstable_AvatarClassKey | PrivateClassKey> = (theme) => ({
         - set min height/width to match design, and lesser-responsive height/width to scale with user's browser-set font size to maintain a11y
     */
   'private-root-size-small': {
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     minHeight: 24,
     minWidth: 24,
     height: theme.unstable_typography.pxToRem(16),
@@ -144,7 +144,7 @@ const styles: Styles<Unstable_AvatarClassKey | PrivateClassKey> = (theme) => ({
     },
   },
   'private-root-size-large': {
-    borderRadius: 8,
+    borderRadius: theme.unstable_radius.md,
     minHeight: 64,
     minWidth: 64,
     height: theme.unstable_typography.pxToRem(32),

--- a/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
+++ b/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.tsx
@@ -55,7 +55,7 @@ export type Unstable_AvatarButtonClassKey = 'root' | 'avatar';
 const styles: Styles<Unstable_AvatarButtonClassKey> = (theme) => ({
   root: {
     borderColor: 'transparent',
-    borderRadius: 8,
+    borderRadius: theme.unstable_radius.md,
     borderStyle: 'solid',
     borderWidth: 1,
     '&.Mui-focusVisible > $avatar, &:focus-visible > $avatar': {

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -146,7 +146,7 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
     // double-specificity section for overriding v1 styles from STP
     '&&': {
       borderColor: 'transparent',
-      borderRadius: 4,
+      borderRadius: theme.unstable_radius.sm,
       borderStyle: 'solid',
       borderWidth: 1,
       '&.Mui-focusVisible, &:focus-visible': {

--- a/libs/spark/src/Unstable_Checkbox/Unstable_CheckboxIcon.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_CheckboxIcon.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles<
     root: {
       display: 'flex',
       position: 'relative' as const,
-      borderRadius: 2,
+      borderRadius: theme.unstable_radius.xs,
       color: theme.unstable_palette.neutral[200],
       // Adjust for irregular svg size
       height: 17,
@@ -77,7 +77,7 @@ const useStyles = makeStyles<
     },
     /* Styles applied to the box icon. */
     box: {
-      borderRadius: 2,
+      borderRadius: theme.unstable_radius.xs,
       /* hover */
       'input:hover ~ $root > &, label:hover ~ $root > &': {
         backgroundColor: theme.unstable_palette.neutral[70],

--- a/libs/spark/src/Unstable_ContentGroup/Unstable_ContentGroup.stories.tsx
+++ b/libs/spark/src/Unstable_ContentGroup/Unstable_ContentGroup.stories.tsx
@@ -300,7 +300,7 @@ export const EnrollmentResource = (args) => (
 
 const useEnrollmentMicroschoolInformationStyles = makeStyles((theme) => ({
   root: {
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     border: `1px solid ${theme.unstable_palette.neutral[100]}`,
     minWidth: 320,
     padding: 16,
@@ -338,7 +338,7 @@ export const EnrollmentMicroschoolInformation = (args) => {
 
 const useEnrollmentGuideCodeStyles = makeStyles((theme) => ({
   root: {
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     border: `1px solid ${theme.unstable_palette.neutral[100]}`,
     minWidth: 320,
     padding: 16,
@@ -407,7 +407,7 @@ const useMicroschoolThumbnailStyles = makeStyles((theme) => ({
     paddingInlineStart: 16,
     position: 'relative',
     '& .site-photo': {
-      borderRadius: 8,
+      borderRadius: theme.unstable_radius.md,
       width: 210,
       '@media (max-width: 320px)': {
         width: '100%',

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -80,7 +80,7 @@ const styles: Styles<Unstable_IconButtonClassKey | PrivateClassKey> = (
 ) => ({
   root: {
     borderColor: 'transparent',
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     borderStyle: 'solid',
     borderWidth: 1,
     '&.Mui-focusVisible, &:focus-visible': {

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -56,7 +56,7 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: theme.unstable_palette.neutral[90],
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     color: theme.unstable_palette.text.body,
     letterSpacing: 0,
     margin: 0,
@@ -83,7 +83,7 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
   },
   /* Styles applied to the `input` element. */
   input: {
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     color: 'inherit',
     height: 'unset', // override weird default `em` height
     padding: '12px 16px',

--- a/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
+++ b/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
@@ -284,7 +284,7 @@ const useMicroschoolThumbnailContentGroupStyles = makeStyles((theme) => ({
     paddingInlineStart: 16,
     position: 'relative',
     '& .site-photo': {
-      borderRadius: 8,
+      borderRadius: theme.unstable_radius.md,
       width: 210,
       '@media (max-width: 320px)': {
         width: '100%',

--- a/libs/spark/src/Unstable_Radio/Unstable_RadioIcon.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_RadioIcon.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles<'root' | 'checked' | 'circle' | 'dot'>(
     root: {
       display: 'flex',
       position: 'relative' as const,
-      borderRadius: '50%',
+      borderRadius: theme.unstable_radius.full,
       color: theme.unstable_palette.neutral[200],
       // Adjust for irregular svg size of radio unchecked button
       height: 17,
@@ -51,7 +51,7 @@ const useStyles = makeStyles<'root' | 'checked' | 'circle' | 'dot'>(
     },
     /* Styles applied to the circle icon element. */
     circle: {
-      borderRadius: '50%',
+      borderRadius: theme.unstable_radius.full,
       transform: 'scale(1)', // (from Mui) Scale applied to prevent dot misalignment in Safari
       /* hover */
       'input:hover ~ $root > &, label:hover ~ $root > &': {

--- a/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
+++ b/libs/spark/src/Unstable_SectionMessage/Unstable_SectionMessage.tsx
@@ -33,7 +33,7 @@ const styles: Styles<Unstable_SectionMessageClassKey | PrivateClassKey> = (
 ) => ({
   root: {
     alignItems: 'flex-start',
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     display: 'flex',
     gap: 16,
     padding: 24,

--- a/libs/spark/src/Unstable_Switch/Unstable_Switch.tsx
+++ b/libs/spark/src/Unstable_Switch/Unstable_Switch.tsx
@@ -137,12 +137,12 @@ const styles: Styles<Unstable_SwitchClassKey | PrivateClassKey> = (theme) => ({
     width: 24,
   },
   'private-track-size-medium': {
-    borderRadius: 12,
+    borderRadius: theme.unstable_radius.full,
     height: 24,
     width: 48,
   },
   'private-track-size-large': {
-    borderRadius: 16,
+    borderRadius: theme.unstable_radius.full,
     height: 32,
     width: 56,
   },

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
@@ -52,7 +52,7 @@ const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
     minWidth: 'unset',
     // override v1
     border: 'none',
-    borderRadius: 0,
+    borderRadius: theme.unstable_radius.zero,
     // override MUI defaults
     '&&': {
       opacity: 1,
@@ -79,7 +79,7 @@ const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
     },
     '&.Mui-focusVisible, &:focus-visible': {
       zIndex: 2,
-      borderRadius: 8,
+      borderRadius: theme.unstable_radius.md,
       boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
     },
   },
@@ -94,7 +94,7 @@ const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
     },
     '&.Mui-focusVisible, &:focus-visible': {
       zIndex: 2,
-      borderRadius: 8,
+      borderRadius: theme.unstable_radius.md,
       boxShadow: `0px 0px 2px 4px ${theme.unstable_palette.teal[300]}`,
     },
   },

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -109,7 +109,7 @@ const tagFontVariantSmall = buildVariant(
 
 const styles: Styles<Unstable_TagClassKey | PrivateClassKey> = (theme) => ({
   root: {
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.sm,
     height: 'unset', // unset MUI
     // Determined in fn body
     color: theme.unstable_palette.text.heading,

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.tsx
@@ -131,7 +131,7 @@ const styles: Styles<Unstable_TagClassKey | PrivateClassKey> = (theme) => ({
     width: '1em',
   },
   deleteIcon: {
-    borderRadius: 2,
+    borderRadius: theme.unstable_radius.xs,
     color: 'inherit',
     height: '1em',
     margin: '0 0 0 4px',

--- a/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
+++ b/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
@@ -24,7 +24,7 @@ const styles: Styles<Unstable_ToastClassKey | PrivateClassKey> = (theme) => ({
     alignItems: 'center',
     backgroundColor: theme.unstable_palette.background.inverse,
     color: theme.unstable_palette.text.inverseBody,
-    borderRadius: 4,
+    borderRadius: theme.unstable_radius.md,
     display: 'flex',
     gap: 8,
     minHeight: 56,

--- a/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
+++ b/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
@@ -24,7 +24,7 @@ const styles: Styles<Unstable_ToastClassKey | PrivateClassKey> = (theme) => ({
     alignItems: 'center',
     backgroundColor: theme.unstable_palette.background.inverse,
     color: theme.unstable_palette.text.inverseBody,
-    borderRadius: theme.unstable_radius.md,
+    borderRadius: theme.unstable_radius.sm,
     display: 'flex',
     gap: 8,
     minHeight: 56,

--- a/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.tsx
+++ b/libs/spark/src/Unstable_Tooltip/Unstable_Tooltip.tsx
@@ -51,7 +51,7 @@ const styles: Styles<Unstable_TooltipClassKey | PrivateClassKey> = (theme) => ({
     ...theme.unstable_typography.body,
     alignItems: 'flex-start',
     backgroundColor: theme.unstable_palette.neutral[600],
-    borderRadius: 8,
+    borderRadius: theme.unstable_radius.md,
     color: theme.unstable_palette.neutral[80],
     display: 'flex',
     flexDirection: 'column',

--- a/libs/spark/src/theme/initialTheme.ts
+++ b/libs/spark/src/theme/initialTheme.ts
@@ -4,6 +4,7 @@ import shadows from './shadows';
 import typography from './typography';
 import unstable_elevations from './unstable_elevations';
 import unstable_palette from './unstable_palette';
+import unstable_radius from './unstable_radius';
 import unstable_typography from './unstable_typography';
 
 const initialTheme = createTheme({
@@ -14,6 +15,7 @@ const initialTheme = createTheme({
 
 initialTheme.unstable_elevations = unstable_elevations;
 initialTheme.unstable_palette = unstable_palette;
+initialTheme.unstable_radius = unstable_radius;
 initialTheme.unstable_typography = unstable_typography;
 
 export default initialTheme;

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -7,6 +7,7 @@ import unstable_elevations, {
   Unstable_Elevations,
 } from './unstable_elevations';
 import unstable_palette, { Unstable_Palette } from './unstable_palette';
+import unstable_radius, { Unstable_Radius } from './unstable_radius';
 import unstable_typography, {
   Unstable_TypographyOptions,
 } from './unstable_typography';
@@ -14,6 +15,7 @@ import unstable_typography, {
 export interface Theme extends MuiTheme {
   unstable_elevations: Unstable_Elevations;
   unstable_palette: Unstable_Palette;
+  unstable_radius: Unstable_Radius;
   unstable_typography: Unstable_TypographyOptions;
 }
 
@@ -28,6 +30,7 @@ const theme = createTheme({
 
 theme.unstable_elevations = unstable_elevations;
 theme.unstable_palette = unstable_palette;
+theme.unstable_radius = unstable_radius;
 theme.unstable_typography = unstable_typography;
 
 export default theme;

--- a/libs/spark/src/theme/themeAugmentation.ts
+++ b/libs/spark/src/theme/themeAugmentation.ts
@@ -16,6 +16,7 @@ import type { Theme } from './theme';
 import type { SparkVariant } from './typography';
 import type { Unstable_Elevations } from './unstable_elevations';
 import type { Unstable_Palette } from './unstable_palette';
+import { Unstable_Radius } from './unstable_radius';
 import type { Unstable_TypographyOptions } from './unstable_typography';
 
 // Augment global interfaces so consumers TS can recognize the customizations
@@ -26,6 +27,7 @@ declare module '@material-ui/core/styles/createTheme' {
   interface Theme {
     unstable_elevations: Unstable_Elevations;
     unstable_palette: Unstable_Palette;
+    unstable_radius: Unstable_Radius;
     unstable_typography: Unstable_TypographyOptions;
   }
 }
@@ -35,6 +37,7 @@ declare module '@material-ui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {
     unstable_elevations: Unstable_Elevations;
     unstable_palette: Unstable_Palette;
+    unstable_radius: Unstable_Radius;
     unstable_typography: Unstable_TypographyOptions;
   }
 }

--- a/libs/spark/src/theme/unstable_elevations.stories.tsx
+++ b/libs/spark/src/theme/unstable_elevations.stories.tsx
@@ -74,7 +74,7 @@ const _Elevations = styled(function Elevations(props) {
   },
   '& .square': {
     backgroundColor: theme.unstable_palette.neutral[0],
-    borderRadius: 8,
+    borderRadius: theme.unstable_radius.md,
     height: 80,
     width: 80,
   },

--- a/libs/spark/src/theme/unstable_palette.stories.tsx
+++ b/libs/spark/src/theme/unstable_palette.stories.tsx
@@ -63,7 +63,7 @@ const PaletteColor = styled(function PaletteColor(props: {
   ({ theme, field }) => ({
     '& .color': {
       backgroundColor: getValue(theme, field),
-      borderRadius: 16,
+      borderRadius: theme.unstable_radius.lg,
       height: 104,
       width: 177,
       marginBottom: 16,

--- a/libs/spark/src/theme/unstable_radius.stories.tsx
+++ b/libs/spark/src/theme/unstable_radius.stories.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import { styled, theme } from '..';
+
+export default {
+  title: '@ps/theme/radius',
+} as Meta;
+
+const _Radius = styled(function Elevations(props) {
+  return (
+    <div {...props}>
+      <h1 className="title">Radius</h1>
+      <span className="code">theme.unstable_radius</span>
+      <div className="content">
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.zero }}
+          >
+            <span className="name">zero</span>
+            <span className="code">radius.zero (0px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.xs }}
+          >
+            <span className="name">xs</span>
+            <span className="code">radius.xs (2px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.sm }}
+          >
+            <span className="name">sm</span>
+            <span className="code">radius.sm (4px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.md }}
+          >
+            <span className="name">md</span>
+            <span className="code">radius.md (8px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.lg }}
+          >
+            <span className="name">lg</span>
+            <span className="code">radius.lg (16px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.xl }}
+          >
+            <span className="name">xl</span>
+            <span className="code">radius.xl (32px)</span>
+          </div>
+        </div>
+        <div>
+          <div
+            className="square"
+            style={{ borderRadius: theme.unstable_radius.full }}
+          >
+            <span className="name">full</span>
+            <span className="code">radius.full</span>
+            <span className="code">(9999px)</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+})(({ theme }) => ({
+  paddingLeft: 8,
+  '& .title': {
+    ...theme.unstable_typography.T22,
+    margin: 0,
+  },
+  '& .content': {
+    display: 'flex',
+    gap: 40,
+    marginTop: 24,
+  },
+  '& .square': {
+    alignItems: 'center',
+    backgroundColor: theme.unstable_palette.neutral[0],
+    borderColor: theme.unstable_palette.neutral[90],
+    borderStyle: 'solid',
+    borderWidth: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    height: 160,
+    justifyContent: 'center',
+    width: 160,
+  },
+  '& .name': {
+    ...theme.unstable_typography.label,
+  },
+  '& .code': {
+    ...theme.unstable_typography.code,
+  },
+}));
+
+export const Radius: Story = () => <_Radius />;

--- a/libs/spark/src/theme/unstable_radius.ts
+++ b/libs/spark/src/theme/unstable_radius.ts
@@ -1,0 +1,19 @@
+import * as CSS from 'csstype';
+
+export type Radius = 'zero' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unstable_Radius
+  extends Record<Radius, CSS.Property.BorderRadius> {}
+
+const unstable_radius: Unstable_Radius = {
+  zero: 0,
+  xs: '2px',
+  sm: '4px',
+  md: '8px',
+  lg: '16px',
+  xl: '32px',
+  full: '9999px',
+};
+
+export default unstable_radius;


### PR DESCRIPTION
Adds the [border radius foundation spec](https://www.figma.com/file/w9lodWeivyS4GHdBNIYaJr/foundations?node-id=3745%3A59) as a theme property.