### PR TITLE
fix(spark): console warning of not-found exports

### DIFF
--- a/libs/spark/src/FormControl/FormControl.ts
+++ b/libs/spark/src/FormControl/FormControl.ts
@@ -1,5 +1,5 @@
-export {
-  default,
+export { default } from '@material-ui/core/FormControl';
+export type {
   FormControlClassKey,
   FormControlProps,
   FormControlState,


### PR DESCRIPTION
Requires type prefix since there's no other named exports that aren't types.