### PR TITLE
feat(spark): add own form control context

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -35,6 +35,7 @@ API surface:
   - [feat] added "success" prop
     - values: `true | false`
     - default: `false`
+  - [feat] add default support for accessibility by linking the descendent input (Input or Select), label (FormLabel), and helper text (FormHelperText).
 - **Unstable_FormHelperText**
   - [feat] added "size" prop
     - values: `"small" | "medium"`

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -32,6 +32,9 @@ API surface:
   - [feat] added "size" prop
     - values: `"small" | "medium"`
     - default: `"medium"`
+  - [feat] added "success" prop
+    - values: `true | false`
+    - default: `false`
 - **Unstable_FormHelperText**
   - [feat] added "size" prop
     - values: `"small" | "medium"`
@@ -71,6 +74,8 @@ API surface:
   - see **Unstable_FormControl**
 - **useFormControl**
   - [feat] added as a top-level directory
+- **useFormControl_unstable**
+  - [feat] init
 - **useRadioGroupMore**
   - [feat] added as a top-level directory
   - [breaking] removed (renamed to **useRadioGroupExtra_unstable**)

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -5,6 +5,7 @@ import MuiFormControl, {
 import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import clsx from 'clsx';
+import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
 
 export interface Unstable_FormControlTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -17,7 +18,11 @@ export interface Unstable_FormControlTypeMap<
       'classes' | 'color' | 'hiddenLabel' | 'margin' | 'size' | 'variant'
     > & {
       /**
-       * The size of the form control.
+       * If `true`, the descendant components should be displayed in an success state.
+       */
+      success?: boolean;
+      /**
+       * The size of the descendant components.
        */
       size?: 'medium' | 'small';
     };
@@ -49,16 +54,24 @@ const styles: Styles<Unstable_FormControlClassKey | PrivateClassKey> = {
 
 const Unstable_FormControl: OverridableComponent<Unstable_FormControlTypeMap> = forwardRef(
   function Unstable_FormControl(props, ref) {
-    const { classes, color: _color, size = 'medium', ...other } = props;
+    const {
+      classes,
+      color: _color,
+      size = 'medium',
+      success = false,
+      ...other
+    } = props;
 
     return (
-      <MuiFormControl
-        classes={{
-          root: clsx(classes.root, classes[`private-root-size-${size}`]),
-        }}
-        ref={ref}
-        {...other}
-      />
+      <Unstable_FormControlExtraContext.Provider value={{ success, size }}>
+        <MuiFormControl
+          classes={{
+            root: clsx(classes.root, classes[`private-root-size-${size}`]),
+          }}
+          ref={ref}
+          {...other}
+        />
+      </Unstable_FormControlExtraContext.Provider>
     );
   }
 );

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -2,7 +2,7 @@ import React, { ElementType, forwardRef } from 'react';
 import MuiFormControl, {
   FormControlProps as MuiFormControlProps,
 } from '@material-ui/core/FormControl';
-import { OverridableComponent, OverrideProps } from '../utils';
+import { OverridableComponent, OverrideProps, useId } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import clsx from 'clsx';
 import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
@@ -57,13 +57,20 @@ const Unstable_FormControl: OverridableComponent<Unstable_FormControlTypeMap> = 
     const {
       classes,
       color: _color,
+      id: idProp,
       size = 'medium',
       success = false,
       ...other
     } = props;
 
+    const id = useId(idProp);
+    const labelId = `${id}-label`;
+    const helperTextId = `${id}-helper-text`;
+
     return (
-      <Unstable_FormControlExtraContext.Provider value={{ success, size }}>
+      <Unstable_FormControlExtraContext.Provider
+        value={{ helperTextId, id, labelId, success, size }}
+      >
         <MuiFormControl
           classes={{
             root: clsx(classes.root, classes[`private-root-size-${size}`]),

--- a/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
+++ b/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
@@ -2,6 +2,18 @@ import { createContext } from 'react';
 
 export interface Unstable_FormControlExtraContextValue {
   /**
+   * The id of the descendent input.
+   */
+  id?: string;
+  /**
+   * The id of the descendent label.
+   */
+  labelId?: string;
+  /**
+   * The id of the descendent helper text.
+   */
+  helperTextId?: string;
+  /**
    * The size of the descendant components
    */
   size?: 'medium' | 'small';

--- a/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
+++ b/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
@@ -1,0 +1,25 @@
+import { createContext } from 'react';
+
+export interface Unstable_FormControlExtraContextValue {
+  /**
+   * The size of the descendant components
+   */
+  size?: 'medium' | 'small';
+  /**
+   * If `true`, then descendant components will be displayed in a success state.
+   */
+  success?: boolean;
+}
+
+const Unstable_FormControlExtraContext = createContext<Unstable_FormControlExtraContextValue>(
+  {
+    size: 'medium',
+    success: false,
+  }
+);
+
+if (process.env.NODE_ENV !== 'production') {
+  Unstable_FormControlExtraContext.displayName = 'FormControlExtraContext';
+}
+
+export default Unstable_FormControlExtraContext;

--- a/libs/spark/src/Unstable_FormControlExtraContext/index.ts
+++ b/libs/spark/src/Unstable_FormControlExtraContext/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_FormControlExtraContext';
+export * from './Unstable_FormControlExtraContext';

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -1,10 +1,9 @@
 import React, { ElementType, forwardRef, ReactNode } from 'react';
 import clsx from 'clsx';
 import { OverridableComponent, OverrideProps } from '../utils';
-import { formControlState } from '../Unstable_FormControl';
-import useFormControl from '../useFormControl';
 import withStyles, { Styles } from '../withStyles';
 import { buildVariant } from '../theme/typography';
+import useFormControl_unstable from '../useFormControl_unstable';
 
 export interface Unstable_FormHelperTextTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -136,42 +135,29 @@ const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeM
       className,
       // @ts-expect-error not picked up as a prop from `OverridableComponent`
       component: Component = 'p',
-      disabled,
-      error,
-      filled,
-      focused,
+      disabled: _disabled,
+      error: _error,
+      filled: _filled,
+      focused: _focused,
       leadingIcon,
       reserveLineHeight,
-      required,
-      size = 'medium',
+      required: _required,
+      size: _size,
       ...other
     } = props;
 
-    const muiFormControl = useFormControl();
-    const fcs = formControlState({
-      props,
-      muiFormControl,
-      states: [
-        'variant',
-        'margin',
-        'disabled',
-        'error',
-        'filled',
-        'focused',
-        'required',
-      ],
-    });
+    const formControl = useFormControl_unstable(props);
 
     return (
       <Component
         className={clsx(
           classes.root,
-          classes[`private-root-size-${size}`],
+          classes[`private-root-size-${formControl.size}`],
           {
-            [classes.disabled]: fcs.disabled,
-            [classes.error]: fcs.error,
-            [classes.focused]: fcs.focused,
-            [classes.required]: fcs.required,
+            [classes.disabled]: formControl.disabled,
+            [classes.error]: formControl.error,
+            [classes.focused]: formControl.focused,
+            [classes.required]: formControl.required,
           },
           className
         )}

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -139,6 +139,7 @@ const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeM
       error: _error,
       filled: _filled,
       focused: _focused,
+      id: idProp,
       leadingIcon,
       reserveLineHeight,
       required: _required,
@@ -161,6 +162,7 @@ const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeM
           },
           className
         )}
+        id={idProp || formControl.helperTextId}
         ref={ref}
         {...other}
       >

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -85,7 +85,14 @@ const styles: Styles<Unstable_FormLabelClassKey | PrivateClassKey> = (
 
 const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> = forwardRef(
   function Unstable_FormLabel(props, ref) {
-    const { classes, color: _color, size: _size, ...other } = props;
+    const {
+      classes,
+      color: _color,
+      htmlFor: htmlForProp,
+      id: idProp,
+      size: _size,
+      ...other
+    } = props;
 
     const formControl = useFormControl_unstable(props);
 
@@ -98,6 +105,8 @@ const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> = forw
           ),
           asterisk: classes.asterisk,
         }}
+        htmlFor={htmlForProp || formControl.id}
+        id={idProp || formControl.labelId}
         ref={ref}
         {...other}
       />

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -6,6 +6,7 @@ import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import clsx from 'clsx';
 import { buildVariant } from '../theme/typography';
+import useFormControl_unstable from '../useFormControl_unstable';
 
 export interface Unstable_FormLabelTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -84,12 +85,17 @@ const styles: Styles<Unstable_FormLabelClassKey | PrivateClassKey> = (
 
 const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> = forwardRef(
   function Unstable_FormLabel(props, ref) {
-    const { classes, color: _color, size = 'medium', ...other } = props;
+    const { classes, color: _color, size: _size, ...other } = props;
+
+    const formControl = useFormControl_unstable(props);
 
     return (
       <MuiFormLabel
         classes={{
-          root: clsx(classes.root, classes[`private-root-size-${size}`]),
+          root: clsx(
+            classes.root,
+            classes[`private-root-size-${formControl.size}`]
+          ),
           asterisk: classes.asterisk,
         }}
         ref={ref}

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -7,6 +7,7 @@ import {
 import Unstable_InputAdornment from '../Unstable_InputAdornment';
 import withStyles, { StyledComponentProps, Styles } from '../withStyles';
 import { buildVariant } from '../theme/typography';
+import useFormControl_unstable from '../useFormControl_unstable';
 
 export interface Unstable_InputProps
   extends Omit<
@@ -172,32 +173,46 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
       leadingEl,
       multiline,
       placeholder,
-      size = 'medium',
-      success,
+      size: _size,
+      success: _success,
       trailingEl,
       value,
       ...other
     } = props;
 
+    const formControl = useFormControl_unstable(props);
+
     return (
       <MuiInputBase
         classes={{
-          root: clsx(classes.root, classes[`private-root-size-${size}`], {
-            [classes['private-root-value']]: value,
-            [classes['private-root-multiline']]: multiline,
-            [classes[`private-root-size-${size}-leadingEl`]]: leadingEl,
-            [classes[`private-root-size-${size}-trailingEl`]]: trailingEl,
-            [classes['private-root-success']]: success,
-          }),
-          input: clsx(classes.input, classes[`private-input-size-${size}`], {
-            [classes['private-input-placeholder']]: placeholder,
-            [classes['private-input-leadingEl']]: leadingEl,
-            [classes['private-input-trailingEl']]: trailingEl,
-          }),
+          root: clsx(
+            classes.root,
+            classes[`private-root-size-${formControl.size}`],
+            {
+              [classes['private-root-value']]: value,
+              [classes['private-root-multiline']]: multiline,
+              [classes[
+                `private-root-size-${formControl.size}-leadingEl`
+              ]]: leadingEl,
+              [classes[
+                `private-root-size-${formControl.size}-trailingEl`
+              ]]: trailingEl,
+              [classes['private-root-success']]: formControl.success,
+            }
+          ),
+          input: clsx(
+            classes.input,
+            classes[`private-input-size-${formControl.size}`],
+            {
+              [classes['private-input-placeholder']]: placeholder,
+              [classes['private-input-leadingEl']]: leadingEl,
+              [classes['private-input-trailingEl']]: trailingEl,
+            }
+          ),
         }}
         endAdornment={
           trailingEl ? (
-            <Unstable_InputAdornment position="end" size={size}>
+            <Unstable_InputAdornment position="end" size={formControl.size}>
               {trailingEl}
             </Unstable_InputAdornment>
           ) : undefined
@@ -206,7 +221,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
         placeholder={placeholder}
         startAdornment={
           leadingEl ? (
-            <Unstable_InputAdornment position="start" size={size}>
+            <Unstable_InputAdornment position="start" size={formControl.size}>
               {leadingEl}
             </Unstable_InputAdornment>
           ) : undefined

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -169,7 +169,9 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
 const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
   function Unstable_Input(props, ref) {
     const {
+      'aria-describedby': ariaDescribedByProp,
       classes,
+      id: idProp,
       leadingEl,
       multiline,
       placeholder,
@@ -184,6 +186,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
 
     return (
       <MuiInputBase
+        aria-describedby={ariaDescribedByProp || formControl.helperTextId}
         classes={{
           root: clsx(
             classes.root,
@@ -217,6 +220,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
             </Unstable_InputAdornment>
           ) : undefined
         }
+        id={idProp || formControl.id}
         multiline={multiline}
         placeholder={placeholder}
         startAdornment={

--- a/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
+++ b/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { ElementType, forwardRef } from 'react';
 import { buildVariant } from '../theme/typography';
+import useFormControl_unstable from '../useFormControl_unstable';
 import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 
@@ -94,18 +95,20 @@ const Unstable_InputAdornment: OverridableComponent<Unstable_InputAdornmentTypeM
       // @ts-expect-error prop does not exist :/
       component: Component = 'div',
       position,
-      size = 'medium',
+      size: _size,
       ...other
     } = props;
+
+    const formControl = useFormControl_unstable(props);
 
     return (
       <Component
         className={clsx(
           classes.root,
           classes[`private-root-position-${position}`],
-          classes[`private-root-size-${size}`],
+          classes[`private-root-size-${formControl.size}`],
           {
-            [classes[`private-root-size-${size}-children-string`]]:
+            [classes[`private-root-size-${formControl.size}-children-string`]]:
               typeof props.children === 'string',
           },
           className

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -173,6 +173,7 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
 const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
   function Unstable_Select(props, ref) {
     const {
+      'aria-describedby': ariaDescribedByProp,
       autoWidth = false,
       children,
       classes,
@@ -180,10 +181,10 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
       displayEmpty = true,
       getTagProps,
       IconComponent = Unstable_ChevronDown,
-      id,
+      id: idProp,
       input,
       inputProps,
-      labelId,
+      labelId: labelIdProp,
       MenuProps = {} as Unstable_SelectProps['MenuProps'],
       multiple = false,
       native = false,
@@ -261,6 +262,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
     }
 
     return cloneElement(InputComponent, {
+      'aria-describedby': ariaDescribedByProp || formControl.helperTextId,
       disabled,
       inputComponent,
       inputProps: {
@@ -269,11 +271,11 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
         type: undefined, // We render a select. We can ignore the type provided by the `Input`.
         multiple,
         ...(native
-          ? { id }
+          ? { id: idProp || formControl.id }
           : {
               autoWidth,
               displayEmpty,
-              labelId,
+              labelId: labelIdProp || formControl.labelId,
               MenuProps: {
                 ...MenuProps,
                 anchorOrigin: anchorOriginMenuProp,
@@ -304,7 +306,10 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
               onOpen,
               open,
               renderValue,
-              SelectDisplayProps: { id, ...SelectDisplayProps },
+              SelectDisplayProps: {
+                id: idProp || formControl.id,
+                ...SelectDisplayProps,
+              },
             }),
         ...inputProps,
         classes: {

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -17,6 +17,7 @@ import {
   usePaperStyles_unstable,
 } from '../Unstable_Paper';
 import withStyles, { Styles } from '../withStyles';
+import useFormControl_unstable from '../useFormControl_unstable';
 
 declare module '@material-ui/core/NativeSelect/NativeSelect' {
   export const styles: (
@@ -192,11 +193,13 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
       preventMultipleOverflow = false,
       renderValue: renderValueProp,
       renderValueAsTag = false,
-      size = 'medium',
+      size: _size,
       SelectDisplayProps,
       value,
       ...other
     } = props;
+
+    const formControl = useFormControl_unstable(props);
 
     const {
       getContentAnchorEl: getContentAnchorElMenuProp = null,
@@ -322,13 +325,13 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
           icon: clsx(
             classes.icon,
             inputProps?.classes?.icon,
-            classes[`private-icon-size-${size}`]
+            classes[`private-icon-size-${formControl.size}`]
           ),
           iconOpen: clsx(classes.iconOpen, inputProps?.classes?.iconOpen),
         },
         ...(input ? input.props.inputProps : {}),
       },
-      size,
+      size: formControl.size,
       value,
       ref,
       ...other,

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -16,7 +16,6 @@ import Unstable_FormHelperText, {
   Unstable_FormHelperTextProps,
 } from '../Unstable_FormHelperText';
 import Unstable_Select, { Unstable_SelectProps } from '../Unstable_Select';
-import { useId } from '../utils';
 
 export interface Unstable_TextFieldProps
   extends Omit<
@@ -160,7 +159,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       FormHelperTextProps,
       fullWidth = false,
       helperText,
-      id: idProp,
       FormLabelProps,
       inputProps,
       InputProps,
@@ -186,8 +184,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       ...other
     } = props;
 
-    const id = useId(idProp);
-
     if (process.env.NODE_ENV !== 'production') {
       if (select && !children) {
         console.error(
@@ -206,11 +202,8 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       InputMore['aria-describedby'] = undefined;
     }
 
-    const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
-    const labelId = label && id ? `${id}-label` : undefined;
     const InputElement = (
       <Unstable_Input
-        aria-describedby={helperTextId}
         autoComplete={autoComplete}
         autoFocus={autoFocus}
         disabled={disabled}
@@ -224,7 +217,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         trailingEl={trailingEl}
         type={type}
         value={value}
-        id={id}
         inputRef={inputRef}
         onBlur={onBlur}
         onChange={onChange}
@@ -248,20 +240,11 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         {...other}
       >
         {label ? (
-          <Unstable_FormLabel htmlFor={id} id={labelId} {...FormLabelProps}>
-            {label}
-          </Unstable_FormLabel>
+          <Unstable_FormLabel {...FormLabelProps}>{label}</Unstable_FormLabel>
         ) : null}
 
         {select ? (
-          <Unstable_Select
-            aria-describedby={helperTextId}
-            id={id}
-            labelId={labelId}
-            value={value}
-            input={InputElement}
-            {...SelectProps}
-          >
+          <Unstable_Select value={value} input={InputElement} {...SelectProps}>
             {children}
           </Unstable_Select>
         ) : (
@@ -269,7 +252,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         )}
 
         {helperText ? (
-          <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
+          <Unstable_FormHelperText {...FormHelperTextProps}>
             {helperText}
           </Unstable_FormHelperText>
         ) : null}

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -135,10 +135,6 @@ export interface Unstable_TextFieldProps
    */
   SelectProps?: Partial<Unstable_SelectProps>;
   /**
-   * If `true`, the input will indicate a success.
-   */
-  success?: boolean;
-  /**
    * The content of the `endAdornment` (an `InputAdornment`), usually an `Icon`, `IconButton`, or `string`.
    */
   trailingEl?: ReactNode;
@@ -182,7 +178,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       minRows,
       select = false,
       SelectProps,
-      size = 'medium',
+      size,
       success,
       trailingEl,
       type,
@@ -225,8 +221,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         name={name}
         maxRows={maxRows}
         minRows={minRows}
-        size={size}
-        success={success}
         trailingEl={trailingEl}
         type={type}
         value={value}
@@ -250,15 +244,11 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         ref={(ref as unknown) as RefObject<HTMLDivElement>}
         required={required}
         size={size}
+        success={success}
         {...other}
       >
         {label ? (
-          <Unstable_FormLabel
-            htmlFor={id}
-            id={labelId}
-            size={size}
-            {...FormLabelProps}
-          >
+          <Unstable_FormLabel htmlFor={id} id={labelId} {...FormLabelProps}>
             {label}
           </Unstable_FormLabel>
         ) : null}
@@ -268,7 +258,6 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
             aria-describedby={helperTextId}
             id={id}
             labelId={labelId}
-            size={size}
             value={value}
             input={InputElement}
             {...SelectProps}
@@ -280,11 +269,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
         )}
 
         {helperText ? (
-          <Unstable_FormHelperText
-            id={helperTextId}
-            size={size}
-            {...FormHelperTextProps}
-          >
+          <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
             {helperText}
           </Unstable_FormHelperText>
         ) : null}

--- a/libs/spark/src/useFormControl_unstable/index.ts
+++ b/libs/spark/src/useFormControl_unstable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useFormControl_unstable';

--- a/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
+++ b/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
@@ -1,0 +1,63 @@
+import { useFormControl } from '@material-ui/core/FormControl';
+import { useContext } from 'react';
+import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
+
+const useFormControl_unstable = (parameters: {
+  disabled?: boolean;
+  error?: boolean;
+  fullWidth?: boolean;
+  required?: boolean;
+  size?: 'medium' | 'small';
+  success?: boolean;
+}) => {
+  const muiFormControl = useFormControl();
+  const formControlExtra = useContext(Unstable_FormControlExtraContext);
+
+  let disabled = parameters.disabled;
+  if (typeof parameters.disabled === 'undefined') {
+    disabled = muiFormControl?.disabled;
+  }
+
+  let error = parameters.error;
+  if (typeof parameters.error === 'undefined') {
+    error = muiFormControl?.error;
+  }
+
+  let fullWidth = parameters.fullWidth;
+  if (typeof parameters.fullWidth === 'undefined') {
+    fullWidth = muiFormControl?.fullWidth;
+  }
+
+  let required = parameters.required;
+  if (typeof parameters.required === 'undefined') {
+    required = muiFormControl?.required;
+  }
+
+  let size = parameters.size;
+  if (typeof parameters.size === 'undefined') {
+    size = formControlExtra.size;
+  }
+
+  let success = parameters.success;
+  if (typeof parameters.success === 'undefined') {
+    success = formControlExtra.success;
+  }
+
+  return {
+    disabled,
+    error,
+    fullWidth,
+    required,
+    size,
+    success,
+    // MUI : internal-determined
+    filled: muiFormControl?.filled,
+    focused: muiFormControl?.focused,
+    onBlur: muiFormControl?.onBlur,
+    onEmpty: muiFormControl?.onEmpty,
+    onFilled: muiFormControl?.onFilled,
+    onFocus: muiFormControl?.onFocus,
+  };
+};
+
+export default useFormControl_unstable;

--- a/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
+++ b/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
@@ -50,6 +50,10 @@ const useFormControl_unstable = (parameters: {
     required,
     size,
     success,
+    // PDS : not prop-controlled
+    id: formControlExtra.id,
+    labelId: formControlExtra.labelId,
+    helperTextId: formControlExtra.helperTextId,
     // MUI : internal-determined
     filled: muiFormControl?.filled,
     focused: muiFormControl?.focused,


### PR DESCRIPTION
Abstracts the manual specifications of form control props that aren't specified by MUI like success, and internalizes the accessibility id handling previously owned by Text Field -- this makes Text Field an unnecessary abstraction.