### PR TITLE
Revert "style(Button): fix text centering and overall height (#645)"

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -5,8 +5,12 @@
 API surface:
 
 - **SparkThemeProvider**
-  - [feat] changed to inject styles first
-    - [revert] change in v2.0.0-alpha.6
+  - [revert] "[feat] changed to inject styles last (previously injected first)" from v2.0.0-alpha.7
+- **Unstable_ButtonButton**
+  - [revert] "[style] corrected text centering for all browsers (Chromium, Firefox, WebKit)" from v2.0.0-alpha.7
+  - [revert] "[style] corrected height across all variants, sizes" from v2.0.0-alpha.7
+- **Unstable_IconButton**
+  - [revert] "[style] corrected height across all variants, sizes" from v2.0.0-alpha.7
 
 ## [v2.0.0-alpha.7](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.6...v2.0.0-alpha.7) (2022-11-28)
 

--- a/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
+++ b/libs/spark/src/Unstable_Banner/Unstable_Banner.tsx
@@ -46,6 +46,7 @@ const styles: Styles<Unstable_BannerClassKey | PrivateClassKey> = (theme) => ({
   },
   action: {
     justifySelf: 'flex-end',
+    marginTop: -2,
   },
   /* Private */
   'private-root-severity-error': {

--- a/libs/spark/src/Unstable_Button/Unstable_Button.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.tsx
@@ -67,7 +67,8 @@ export type Unstable_ButtonClassKey =
   | 'leadingAvatar'
   | 'leadingIcon'
   | 'trailingIcon'
-  | 'label';
+  | 'label'
+  | 'private-textBaselineShift';
 
 type PrivateClassKey =
   | 'private-root-variant-primary'
@@ -81,11 +82,8 @@ type PrivateClassKey =
   | 'private-root-variant-ghost-color-inverse'
   | 'private-root-variant-destructive'
   | 'private-root-size-small'
-  | 'private-root-size-small-leadingAvatar'
   | 'private-root-size-medium'
-  | 'private-root-size-medium-leadingAvatar'
   | 'private-root-size-large'
-  | 'private-root-size-large-leadingAvatar'
   | 'private-root-disabled'
   | 'private-label-variant-primary'
   | 'private-label-variant-primary-color-standard'
@@ -102,13 +100,17 @@ type PrivateClassKey =
   | 'private-label-size-large'
   | 'private-label-ariaExpanded'
   | 'private-label-disabled'
+  | 'private-leadingAvatar-size-small'
+  | 'private-leadingAvatar-size-medium'
+  | 'private-leadingAvatar-size-large'
   | 'private-leadingAvatar-disabled'
   | 'private-leadingIcon-size-small'
   | 'private-leadingIcon-size-medium'
   | 'private-leadingIcon-size-large'
   | 'private-trailingIcon-size-small'
   | 'private-trailingIcon-size-medium'
-  | 'private-trailingIcon-size-large';
+  | 'private-trailingIcon-size-large'
+  | 'private-textBaselineShift';
 
 // extracted since there's not an equivalent typography variant
 const buttonFontVariantSmall = buildVariant(
@@ -141,10 +143,9 @@ const buttonFontVariantLarge = buildVariant(
 
 const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
   root: {
-    backgroundClip: 'padding-box',
     // double-specificity section for overriding v1 styles from STP
     '&&': {
-      border: theme.unstable_borders.none, // v1 $root$disabled
+      border: theme.unstable_borders.transparent,
       borderRadius: theme.unstable_radii.sm,
       '&.Mui-focusVisible, &:focus-visible': {
         boxShadow: theme.unstable_shadows.focus,
@@ -168,6 +169,10 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
     display: 'flex',
     lineHeight: 1,
     margin: '0 0 0 8px',
+  },
+  'private-textBaselineShift': {
+    marginTop: theme.unstable_typography.pxToRem(1),
+    marginBottom: theme.unstable_typography.pxToRem(-1),
   },
   'private-root-variant-primary': {
     '&&': {
@@ -252,26 +257,19 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
     },
   },
   'private-root-size-small': {
-    height: `calc(32px - 14px + ${buttonFontVariantSmall.fontSize})`,
-
-    padding: '0 16px',
-  },
-  'private-root-size-small-leadingAvatar': {
-    padding: '0 8px',
+    '&&': {
+      padding: '8px 16px',
+    },
   },
   'private-root-size-medium': {
-    height: `calc(48px - 16px + ${buttonFontVariantMedium.fontSize})`,
-    padding: '0 24px',
-  },
-  'private-root-size-medium-leadingAvatar': {
-    padding: '0 16px',
+    '&&': {
+      padding: '12px 24px',
+    },
   },
   'private-root-size-large': {
-    height: `calc(64px - 18px + ${buttonFontVariantLarge.fontSize})`,
-    padding: '0 32px',
-  },
-  'private-root-size-large-leadingAvatar': {
-    padding: '0 24px',
+    '&&': {
+      padding: '20px 32px',
+    },
   },
   'private-root-disabled': {
     '&&': {
@@ -282,15 +280,12 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
   },
   'private-label-size-small': {
     ...buttonFontVariantSmall,
-    lineHeight: 0,
   },
   'private-label-size-medium': {
     ...buttonFontVariantMedium,
-    lineHeight: 0,
   },
   'private-label-size-large': {
     ...buttonFontVariantLarge,
-    lineHeight: 0,
   },
   'private-label-variant-primary': {
     color: theme.unstable_palette.neutral[0],
@@ -317,6 +312,21 @@ const styles: Styles<Unstable_ButtonClassKey | PrivateClassKey> = (theme) => ({
   },
   'private-label-disabled': {
     color: theme.unstable_palette.text.disabled,
+  },
+  'private-leadingAvatar-size-small': {
+    marginBottom: -4,
+    marginLeft: -8,
+    marginTop: -4,
+  },
+  'private-leadingAvatar-size-medium': {
+    marginBottom: -8,
+    marginLeft: -8,
+    marginTop: -8,
+  },
+  'private-leadingAvatar-size-large': {
+    marginBottom: -8,
+    marginLeft: -8,
+    marginTop: -8,
   },
   'private-leadingAvatar-disabled': {
     opacity: 0.62,
@@ -363,9 +373,13 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
         size === 'small' ? 'small' : 'medium';
       leadingEl = (
         <span
-          className={clsx(classes.leadingAvatar, {
-            [classes['private-leadingAvatar-disabled']]: disabled,
-          })}
+          className={clsx(
+            classes.leadingAvatar,
+            classes[`private-leadingAvatar-size-${size}`],
+            {
+              [classes['private-leadingAvatar-disabled']]: disabled,
+            }
+          )}
         >
           {/* @ts-expect-error can't know if actually given an Unstable_Avatar instance, so prop may be invalid */}
           {cloneElement(leadingAvatar, { size: avatarSize })}
@@ -409,9 +423,6 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
             classes[`private-root-variant-${variant}-color-${color}`],
             {
               [classes['private-root-disabled']]: disabled,
-              [classes[
-                `private-root-size-${size}-leadingAvatar`
-              ]]: !!leadingAvatar,
             }
           ),
           label: clsx(
@@ -434,7 +445,7 @@ const Unstable_Button: OverridableComponent<Unstable_ButtonTypeMap> = forwardRef
         {...other}
       >
         {leadingEl}
-        {children}
+        <span className={classes['private-textBaselineShift']}>{children}</span>
         {trailingEl}
       </MuiButton>
     );

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.tsx
@@ -79,16 +79,14 @@ const styles: Styles<Unstable_IconButtonClassKey | PrivateClassKey> = (
   theme
 ) => ({
   root: {
-    border: theme.unstable_borders.none,
+    border: theme.unstable_borders.transparent,
     borderRadius: theme.unstable_radii.sm,
-    padding: 'unset',
     '&.Mui-focusVisible, &:focus-visible': {
       boxShadow: theme.unstable_shadows.focus,
     },
   },
   label: {
     fontSize: '1.5rem',
-    width: 'unset',
   },
   'private-root-variant-primary': {
     backgroundColor: theme.unstable_palette.brand.blue,
@@ -157,12 +155,10 @@ const styles: Styles<Unstable_IconButtonClassKey | PrivateClassKey> = (
     },
   },
   'private-root-size-small': {
-    height: 'calc(32px - 24px + 1.5rem)',
-    width: 'calc(32px - 24px + 1.5rem)',
+    padding: 4,
   },
   'private-root-size-medium': {
-    height: 'calc(48px - 24px + 1.5rem)',
-    width: 'calc(48px - 24px + 1.5rem)',
+    padding: 12,
   },
   'private-label-variant-primary': {
     color: theme.unstable_palette.neutral[0],

--- a/libs/spark/src/Unstable_ModalDialog/Unstable_ModalDialog.tsx
+++ b/libs/spark/src/Unstable_ModalDialog/Unstable_ModalDialog.tsx
@@ -43,7 +43,7 @@ const styles: Styles<Unstable_ModalDialogClassKey> = {
   root: {},
   closeButton: {
     position: 'absolute',
-    top: 24,
+    top: 19,
     right: 24,
   },
   container: {},

--- a/libs/spark/src/Unstable_ModalDialogTitle/Unstable_ModalDialogTitle.tsx
+++ b/libs/spark/src/Unstable_ModalDialogTitle/Unstable_ModalDialogTitle.tsx
@@ -28,7 +28,7 @@ const styles: Styles<Unstable_ModalDialogTitleClassKey> = {
   root: {
     flex: '0 0 auto',
     margin: 0,
-    padding: '28px 24px 8px 24px',
+    padding: '24px 24px 8px 24px',
     // dialog with close button
     '&:not(:first-child)': {
       paddingRight: 68,

--- a/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
+++ b/libs/spark/src/Unstable_Toast/Unstable_Toast.tsx
@@ -27,7 +27,7 @@ const styles: Styles<Unstable_ToastClassKey | PrivateClassKey> = (theme) => ({
     borderRadius: theme.unstable_radii.sm,
     display: 'flex',
     gap: 8,
-    minHeight: 54,
+    minHeight: 56,
     padding: '11px 16px',
   },
   icon: {


### PR DESCRIPTION
This reverts commit 3cd2d3692bfa8c0f624c202a344c1066eeef2907.

Prevents buttons from overflowing correctly.