### PR TITLE
chore(storybook): improve support for `fullWidth`

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,9 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
 
       - name: Install dependencies
         run: npm i

--- a/.github/workflows/ci:main.yml
+++ b/.github/workflows/ci:main.yml
@@ -14,14 +14,14 @@ jobs:
         run: sudo sysctl fs.inotify.max_user_watches=524288
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 14
 
       - name: NPM clean install
         run: npm ci

--- a/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.stories.tsx
+++ b/libs/spark/src/Unstable_AvatarButton/Unstable_AvatarButton.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_AvatarButton, Unstable_AvatarButtonProps } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadowInline,
   inverseBackground,
   sparkThemeProvider,
   User,
@@ -15,7 +15,6 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  decorators: [containFocusIndicator],
   argTypes: {
     children: {
       control: 'select',
@@ -102,6 +101,7 @@ ChildrenInitialsExpanded.storyName = 'children=(Initials) aria-expanded';
 
 export const ChildrenInitialsFocusVisible: Story = Template.bind({});
 ChildrenInitialsFocusVisible.args = { children: '(Initials)' };
+ChildrenInitialsFocusVisible.decorators = [containBoxShadowInline];
 ChildrenInitialsFocusVisible.parameters = { pseudo: { focusVisible: true } };
 ChildrenInitialsFocusVisible.storyName = 'children=(Initials) :focus-visible';
 

--- a/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
+++ b/libs/spark/src/Unstable_Button/Unstable_Button.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '..';
 import {
   ChevronDown,
-  containFocusIndicator,
+  containBoxShadowInline,
   Plus,
   sparkThemeProvider,
 } from '../../stories';
@@ -20,7 +20,6 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  decorators: [containFocusIndicator],
   argTypes: {
     leadingAvatar: {
       control: 'select',
@@ -49,6 +48,9 @@ export default {
         ChevronDown: <ChevronDown />,
       },
     },
+    disabled: {
+      control: 'boolean',
+    },
   },
   args: {
     children: <>Label</>,
@@ -65,6 +67,10 @@ Default.storyName = '(default)';
 export const STP: Story = Template.bind({});
 STP.decorators = [sparkThemeProvider];
 STP.storyName = '(STP)';
+
+export const FullWidth: Story = Template.bind({});
+FullWidth.args = { fullWidth: true };
+FullWidth.storyName = 'fullWidth';
 
 const variants: Array<Unstable_ButtonProps['variant']> = [
   'primary',
@@ -159,13 +165,17 @@ SizeByVariantExpandedSTP.decorators = [sparkThemeProvider];
 SizeByVariantExpandedSTP.storyName = 'size ⨯ variant aria-expanded (STP)';
 
 export const SizeByVariantFocusVisible: Story = SizeByVariantTemplate.bind({});
+SizeByVariantFocusVisible.decorators = [containBoxShadowInline];
 SizeByVariantFocusVisible.parameters = { pseudo: { focusVisible: true } };
 SizeByVariantFocusVisible.storyName = 'size ⨯ variant :focus-visible';
 
 export const SizeByVariantFocusVisibleSTP: Story = SizeByVariantTemplate.bind(
   {}
 );
-SizeByVariantFocusVisibleSTP.decorators = [sparkThemeProvider];
+SizeByVariantFocusVisibleSTP.decorators = [
+  sparkThemeProvider,
+  containBoxShadowInline,
+];
 SizeByVariantFocusVisibleSTP.parameters = { pseudo: { focusVisible: true } };
 SizeByVariantFocusVisibleSTP.storyName = 'size ⨯ variant :focus-visible (STP)';
 

--- a/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.stories.tsx
+++ b/libs/spark/src/Unstable_Checkbox/Unstable_Checkbox.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_Checkbox, Unstable_CheckboxProps } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadowInline,
   enableHooks,
   sparkThemeProvider,
   statefulValue,
@@ -14,7 +14,7 @@ export default {
   title: '@ps/Checkbox',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadowInline],
   args: {
     inputProps: { 'aria-label': 'Label' },
   },

--- a/libs/spark/src/Unstable_CheckboxField/Unstable_CheckboxField.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxField/Unstable_CheckboxField.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_CheckboxField, Unstable_CheckboxFieldProps } from '..';
-import { containFocusIndicator } from '../../stories';
+import { containBoxShadowInline } from '../../stories';
 
 export const _retyped = Unstable_CheckboxField as typeof Unstable_CheckboxField;
 
@@ -9,7 +9,7 @@ export default {
   title: '@ps/CheckboxField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadowInline],
 } as Meta;
 
 const Template = (args) => <Unstable_CheckboxField {...args} />;

--- a/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.stories.tsx
@@ -5,7 +5,7 @@ import {
   Unstable_CheckboxGroupField,
   Unstable_CheckboxGroupFieldProps,
 } from '..';
-import { containFocusIndicator, Info } from '../../stories';
+import { containBoxShadow, Info } from '../../stories';
 
 export const _retyped =
   Unstable_CheckboxGroupField as typeof Unstable_CheckboxGroupField;
@@ -14,7 +14,7 @@ export default {
   title: '@ps/CheckboxGroupField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadow],
   argTypes: {
     children: {
       control: 'select',
@@ -128,6 +128,16 @@ LabelHelperTextError.args = {
 };
 LabelHelperTextError.storyName =
   'children=(CheckboxFields) label helperText error';
+
+export const LabelHelperTextFullWidth: Story = Template.bind({});
+LabelHelperTextFullWidth.args = {
+  children: '(CheckboxFields)',
+  label: 'Label',
+  helperText: 'Helper text',
+  fullWidth: true,
+};
+LabelHelperTextFullWidth.storyName =
+  'children=(CheckboxFields) label helperText fullWidth';
 
 export const LabelHelperTextRequired: Story = Template.bind({});
 LabelHelperTextRequired.args = {

--- a/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.stories.tsx
@@ -5,11 +5,7 @@ import {
   Unstable_CheckboxListItem,
   Unstable_CheckboxListItemProps,
 } from '..';
-import {
-  containFocusIndicator,
-  enableHooks,
-  statefulValue,
-} from '../../stories';
+import { containBoxShadow, enableHooks, statefulValue } from '../../stories';
 import { default as Unstable_ListItemMeta } from '../Unstable_ListItem/Unstable_ListItem.stories';
 
 export const _retyped =
@@ -19,7 +15,7 @@ export default {
   title: '@ps/CheckboxListItem',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks],
   args: { children: <>Label</> },
   argTypes: {
     secondaryAction: Unstable_ListItemMeta.argTypes.secondaryAction,
@@ -38,6 +34,12 @@ export const ValueHover: Story = Template.bind({});
 ValueHover.args = { value: 'value', checked: false };
 ValueHover.parameters = { pseudo: { hover: true } };
 ValueHover.storyName = 'value :hover';
+
+export const ValueFocusVisible: Story = Template.bind({});
+ValueFocusVisible.args = { value: 'value', checked: false };
+ValueFocusVisible.decorators = [containBoxShadow];
+ValueFocusVisible.parameters = { pseudo: { focusVisible: true } };
+ValueFocusVisible.storyName = 'value :focus-visible';
 
 export const ValueChecked: Story = Template.bind({});
 ValueChecked.args = { value: 'value', checked: true };

--- a/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/Unstable_CheckboxMenuItem.stories.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_CheckboxMenuItem, Unstable_CheckboxMenuItemProps } from '..';
-import {
-  containFocusIndicator,
-  enableHooks,
-  statefulValue,
-} from '../../stories';
+import { containBoxShadow, enableHooks, statefulValue } from '../../stories';
 import { default as Unstable_CheckboxListItemMeta } from '../Unstable_CheckboxListItem/Unstable_CheckboxListItem.stories';
 
 export const _retyped =
@@ -15,7 +11,7 @@ export default {
   title: '@ps/CheckboxMenuItem',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks],
   args: {
     children: <>Label</>,
   },
@@ -29,6 +25,7 @@ const Template = (args) => <Unstable_CheckboxMenuItem {...args} />;
 type Story = DefaultStory<Unstable_CheckboxMenuItemProps>;
 
 export const FocusVisible: Story = Template.bind({});
+FocusVisible.decorators = [containBoxShadow];
 FocusVisible.parameters = { pseudo: { focusVisible: true } };
 FocusVisible.storyName = ':focus-visible';
 

--- a/libs/spark/src/Unstable_ContentGroup/Unstable_ContentGroup.stories.tsx
+++ b/libs/spark/src/Unstable_ContentGroup/Unstable_ContentGroup.stories.tsx
@@ -13,7 +13,6 @@ import {
 } from '..';
 import {
   CheckCircleDuotone,
-  containFocusIndicator,
   Cross,
   ExternalLink,
   Heart,
@@ -53,7 +52,6 @@ export default {
   title: '@ps/ContentGroup',
   component: _retyped,
   excludeStories: ['_retyped', 'MicroschoolThumbnailTemplate'],
-  decorators: [containFocusIndicator],
   argTypes: {
     button: { control: 'boolean' },
     leadingEl: {

--- a/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.stories.tsx
+++ b/libs/spark/src/Unstable_FormControlLabel/Unstable_FormControlLabel.stories.tsx
@@ -6,7 +6,7 @@ import {
   Unstable_FormControlLabelProps,
   Unstable_Radio,
 } from '..';
-import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+import { containBoxShadowInline, sparkThemeProvider } from '../../stories';
 
 export const _retyped =
   Unstable_FormControlLabel as typeof Unstable_FormControlLabel;
@@ -15,7 +15,7 @@ export default {
   title: '@ps/FormControlLabel',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadowInline],
   argTypes: {
     control: {
       control: 'select',

--- a/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.stories.tsx
+++ b/libs/spark/src/Unstable_FormGroup/Unstable_FormGroup.stories.tsx
@@ -6,7 +6,7 @@ import {
   Unstable_FormGroup,
   Unstable_FormGroupProps,
 } from '..';
-import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+import { containBoxShadow, sparkThemeProvider } from '../../stories';
 
 export const _retyped = Unstable_FormGroup as typeof Unstable_FormGroup;
 
@@ -14,7 +14,7 @@ export default {
   title: '@ps/FormGroup',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadow],
   argTypes: {
     children: {
       control: 'select',

--- a/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
+++ b/libs/spark/src/Unstable_IconButton/Unstable_IconButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme, Unstable_IconButton, Unstable_IconButtonProps } from '..';
 import {
   ChevronDown,
-  containFocusIndicator,
+  containBoxShadowInline,
   Info,
   Plus,
   sparkThemeProvider,
@@ -16,7 +16,6 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  decorators: [containFocusIndicator],
   argTypes: {
     children: {
       control: 'select',
@@ -136,13 +135,17 @@ SizeByVariantExpandedSTP.decorators = [sparkThemeProvider];
 SizeByVariantExpandedSTP.storyName = 'size ⨯ variant aria-expanded (STP)';
 
 export const SizeByVariantFocusVisible: Story = SizeByVariantTemplate.bind({});
+SizeByVariantFocusVisible.decorators = [containBoxShadowInline];
 SizeByVariantFocusVisible.parameters = { pseudo: { focusVisible: true } };
 SizeByVariantFocusVisible.storyName = 'size ⨯ variant :focus-visible';
 
 export const SizeByVariantFocusVisibleSTP: Story = SizeByVariantTemplate.bind(
   {}
 );
-SizeByVariantFocusVisibleSTP.decorators = [sparkThemeProvider];
+SizeByVariantFocusVisibleSTP.decorators = [
+  sparkThemeProvider,
+  containBoxShadowInline,
+];
 SizeByVariantFocusVisibleSTP.parameters = { pseudo: { focusVisible: true } };
 SizeByVariantFocusVisibleSTP.storyName = 'size ⨯ variant :focus-visible (STP)';
 

--- a/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
@@ -5,7 +5,7 @@ import {
   Unstable_InputProps as _Unstable_InputProps,
 } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadow,
   enableHooks,
   Gear,
   Info,
@@ -40,7 +40,7 @@ export default {
   title: '@ps/Input',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadow],
   argTypes: {
     leadingEl: {
       control: 'select',
@@ -99,9 +99,17 @@ export const Error: Story = Template.bind({});
 Error.args = { error: true };
 Error.storyName = 'error';
 
+export const FullWidth: Story = Template.bind({});
+FullWidth.args = { fullWidth: true };
+FullWidth.storyName = 'fullWidth';
+
 export const LeadingEl: Story = Template.bind({});
 LeadingEl.args = { leadingEl: '<Gear />' };
 LeadingEl.storyName = 'leadingEl';
+
+export const LeadingElSizeSmall: Story = Template.bind({});
+LeadingElSizeSmall.args = { leadingEl: '<Gear />', size: 'small' };
+LeadingElSizeSmall.storyName = 'leadingEl size="small" ';
 
 export const Success: Story = Template.bind({});
 Success.args = { success: true };
@@ -110,6 +118,10 @@ Success.storyName = 'success';
 export const TrailingEl: Story = Template.bind({});
 TrailingEl.args = { trailingEl: '<Info />' };
 TrailingEl.storyName = 'trailingEl';
+
+export const TrailingElSizeSmall: Story = Template.bind({});
+TrailingElSizeSmall.args = { trailingEl: '<Info />', size: 'small' };
+TrailingElSizeSmall.storyName = 'trailingEl size="small" ';
 
 export const MultilineMinRows: Story = Template.bind({});
 MultilineMinRows.args = { multiline: true, minRows: 3 };

--- a/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme, Unstable_Link, Unstable_LinkProps } from '..';
-import { containBoxShadowInline, inverseBackground } from '../../stories';
+import {
+  containBoxShadowInline,
+  inverseBackground,
+  mediumWidth,
+} from '../../stories';
 
 export const _retyped = Unstable_Link as typeof Unstable_Link;
 
@@ -131,6 +135,7 @@ const NowrapTemplate = (args) => (
 
 export const Nowrap: Story = NowrapTemplate.bind({});
 Nowrap.args = { nowrap: true };
+Nowrap.decorators = [mediumWidth];
 Nowrap.storyName = 'nowrap';
 
 const VariantAliasTemplate = (args) => (

--- a/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
+++ b/libs/spark/src/Unstable_Link/Unstable_Link.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme, Unstable_Link, Unstable_LinkProps } from '..';
-import { containFocusIndicator, inverseBackground } from '../../stories';
+import { containBoxShadowInline, inverseBackground } from '../../stories';
 
 export const _retyped = Unstable_Link as typeof Unstable_Link;
 
@@ -9,7 +9,6 @@ export default {
   title: '@ps/Link',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
   args: {
     children: <>Text</>,
     href: '#',
@@ -28,6 +27,7 @@ Hover.parameters = { pseudo: { visited: false, hover: true } };
 Hover.storyName = ':hover';
 
 export const FocusVisible: Story = Template.bind({});
+FocusVisible.decorators = [containBoxShadowInline];
 FocusVisible.parameters = { pseudo: { visited: false, focusVisible: true } };
 FocusVisible.storyName = ':focus-visible';
 
@@ -40,6 +40,7 @@ VisitedHover.parameters = { pseudo: { visited: true, hover: true } };
 VisitedHover.storyName = ':visited :hover';
 
 export const VisitedFocusVisible: Story = Template.bind({});
+VisitedFocusVisible.decorators = [containBoxShadowInline];
 VisitedFocusVisible.parameters = {
   pseudo: { visited: true, focusVisible: true },
 };
@@ -56,6 +57,7 @@ StandaloneHover.storyName = 'standalone :hover';
 
 export const StandaloneFocusVisible: Story = Template.bind({});
 StandaloneFocusVisible.args = { standalone: true };
+StandaloneFocusVisible.decorators = [containBoxShadowInline];
 StandaloneFocusVisible.parameters = {
   pseudo: { visited: false, focusVisible: true },
 };
@@ -73,6 +75,7 @@ StandaloneVisitedHover.storyName = 'standalone :visited :hover';
 
 export const StandaloneVisitedFocusVisible: Story = Template.bind({});
 StandaloneVisitedFocusVisible.args = { standalone: true };
+StandaloneVisitedFocusVisible.decorators = [containBoxShadowInline];
 StandaloneVisitedFocusVisible.parameters = {
   pseudo: { visited: true, focusVisible: true },
 };

--- a/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
+++ b/libs/spark/src/Unstable_ListItem/Unstable_ListItem.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from '..';
 import {
   CheckCircleDuotone,
-  containFocusIndicator,
+  containBoxShadow,
   Heart,
   Home3,
   Microschool,
@@ -28,7 +28,6 @@ export default {
   title: '@ps/ListItem',
   component: _retyped,
   excludeStories: ['_retyped', 'MicroschoolThumbnailTemplate'],
-  decorators: [containFocusIndicator],
   argTypes: {
     button: { control: 'boolean' },
     primaryAction: {
@@ -102,6 +101,7 @@ ButtonActive.storyName = 'button :active';
 
 export const ButtonFocusVisible: Story = Template.bind({});
 ButtonFocusVisible.args = { button: true };
+ButtonFocusVisible.decorators = [containBoxShadow];
 ButtonFocusVisible.parameters = { pseudo: { focusVisible: true } };
 ButtonFocusVisible.storyName = 'button :focus-visible';
 
@@ -129,6 +129,7 @@ ButtonSelectedActive.storyName = 'button selected :active';
 
 export const ButtonSelectedFocusVisible: Story = Template.bind({});
 ButtonSelectedFocusVisible.args = { button: true, selected: true };
+ButtonSelectedFocusVisible.decorators = [containBoxShadow];
 ButtonSelectedFocusVisible.parameters = { pseudo: { focusVisible: true } };
 ButtonSelectedFocusVisible.storyName = 'button selected :focus-visible';
 

--- a/libs/spark/src/Unstable_MenuItem/Unstable_MenuItem.stories.tsx
+++ b/libs/spark/src/Unstable_MenuItem/Unstable_MenuItem.stories.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_Avatar, Unstable_MenuItem, Unstable_MenuItemProps } from '..';
-import {
-  containFocusIndicator,
-  enableHooks,
-  statefulValue,
-} from '../../stories';
+import { containBoxShadow, enableHooks, statefulValue } from '../../stories';
 import { default as Unstable_ListItemMeta } from '../Unstable_ListItem/Unstable_ListItem.stories';
 
 export const _retyped = Unstable_MenuItem as typeof Unstable_MenuItem;
@@ -14,7 +10,7 @@ export default {
   title: '@ps/MenuItem',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks],
   args: {
     children: <>Label</>,
   },
@@ -30,6 +26,11 @@ type Story = DefaultStory<Unstable_MenuItemProps>;
 
 export const Default: Story = Template.bind({});
 Default.storyName = '(default)';
+
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.decorators = [containBoxShadow];
+FocusVisible.parameters = { pseudo: { focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
 
 // ============
 // = Examples =

--- a/libs/spark/src/Unstable_MenuList/Unstable_MenuList.stories.tsx
+++ b/libs/spark/src/Unstable_MenuList/Unstable_MenuList.stories.tsx
@@ -5,6 +5,7 @@ import {
   Unstable_MenuList,
   Unstable_MenuListProps,
 } from '..';
+import { containBoxShadow } from '../../stories';
 
 export const _retyped = Unstable_MenuList as typeof Unstable_MenuList;
 
@@ -14,7 +15,6 @@ export default {
   excludeStories: ['_retyped'],
   args: {
     children: '(MenuItem x4)',
-    style: { maxWidth: 256 },
   },
   argTypes: {
     children: {
@@ -35,6 +35,11 @@ type Story = DefaultStory<Unstable_MenuListProps>;
 
 export const Default: Story = Template.bind({});
 Default.storyName = '(default)';
+
+export const FocusVisible: Story = Template.bind({});
+FocusVisible.decorators = [containBoxShadow];
+FocusVisible.parameters = { pseudo: { focusVisible: true } };
+FocusVisible.storyName = ':focus-visible';
 
 export const DisablePadding: Story = Template.bind({});
 DisablePadding.args = { disablePadding: true };

--- a/libs/spark/src/Unstable_Radio/Unstable_Radio.stories.tsx
+++ b/libs/spark/src/Unstable_Radio/Unstable_Radio.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_Radio, Unstable_RadioProps } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadowInline,
   enableHooks,
   sparkThemeProvider,
   statefulValue,
@@ -14,7 +14,7 @@ export default {
   title: '@ps/Radio',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadowInline],
   args: {
     inputProps: { 'aria-label': 'Label' },
   },

--- a/libs/spark/src/Unstable_RadioField/Unstable_RadioField.stories.tsx
+++ b/libs/spark/src/Unstable_RadioField/Unstable_RadioField.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_RadioField, Unstable_RadioFieldProps } from '..';
-import { containFocusIndicator } from '../../stories';
+import { containBoxShadowInline } from '../../stories';
 
 export const _retyped = Unstable_RadioField as typeof Unstable_RadioField;
 
@@ -9,7 +9,7 @@ export default {
   title: '@ps/RadioField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadowInline],
 } as Meta;
 
 const Template = (args) => <Unstable_RadioField {...args} />;

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.stories.tsx
@@ -5,7 +5,7 @@ import {
   Unstable_RadioGroup,
   Unstable_RadioGroupProps,
 } from '..';
-import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+import { containBoxShadow, sparkThemeProvider } from '../../stories';
 
 export const _retyped = Unstable_RadioGroup as typeof Unstable_RadioGroup;
 
@@ -13,7 +13,7 @@ export default {
   title: '@ps/RadioGroup',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadow],
   argTypes: {
     children: {
       control: 'select',

--- a/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.stories.tsx
+++ b/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.stories.tsx
@@ -5,7 +5,7 @@ import {
   Unstable_RadioGroupField,
   Unstable_RadioGroupFieldProps,
 } from '..';
-import { containFocusIndicator, Info } from '../../stories';
+import { containBoxShadow, Info } from '../../stories';
 
 export const _retyped =
   Unstable_RadioGroupField as typeof Unstable_RadioGroupField;
@@ -14,7 +14,7 @@ export default {
   title: '@ps/RadioGroupField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadow],
   argTypes: {
     children: {
       control: 'select',
@@ -134,6 +134,16 @@ LabelHelperTextErrorDisabled.args = {
 };
 LabelHelperTextErrorDisabled.storyName =
   'children=(RadioFields) label helperText error disabled';
+
+export const LabelHelperTextFullWidth: Story = Template.bind({});
+LabelHelperTextErrorDisabled.args = {
+  children: '(RadioFields)',
+  label: 'Label',
+  helperText: 'Helper text',
+  fullWidth: true,
+};
+LabelHelperTextErrorDisabled.storyName =
+  'children=(RadioFields) label helperText fullWidth';
 
 export const LabelHelperTextRequired: Story = Template.bind({});
 LabelHelperTextRequired.args = {

--- a/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.stories.tsx
@@ -7,7 +7,7 @@ import {
   Unstable_SelectProps as _Unstable_SelectProps,
 } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadow,
   enableHooks,
   Home3,
   sparkThemeProvider,
@@ -45,7 +45,7 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadow],
   argTypes: {
     getTagProps: {
       control: 'select',
@@ -138,6 +138,10 @@ DisabledHover.storyName = 'disabled :hover';
 export const Error: Story = Template.bind({});
 Error.args = { error: true };
 Error.storyName = 'error';
+
+export const FullWidth: Story = Template.bind({});
+FullWidth.args = { fullWidth: true };
+FullWidth.storyName = 'fullWidth';
 
 export const LeadingEl: Story = Template.bind({});
 LeadingEl.args = { leadingEl: '<Home3 />' };

--- a/libs/spark/src/Unstable_Switch/Unstable_Switch.stories.tsx
+++ b/libs/spark/src/Unstable_Switch/Unstable_Switch.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_Switch, Unstable_SwitchProps } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadowInline,
   enableHooks,
   sparkThemeProvider,
   statefulValue,
@@ -14,7 +14,7 @@ export default {
   title: '@ps/Switch',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadowInline],
   args: {
     inputProps: { 'aria-label': 'Label' },
   },

--- a/libs/spark/src/Unstable_SwitchField/Unstable_SwitchField.stories.tsx
+++ b/libs/spark/src/Unstable_SwitchField/Unstable_SwitchField.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_SwitchField, Unstable_SwitchFieldProps } from '..';
-import { containFocusIndicator, mediumWidth } from '../../stories';
+import { containBoxShadow } from '../../stories';
 
 export const _retyped = Unstable_SwitchField as typeof Unstable_SwitchField;
 
@@ -9,7 +9,7 @@ export default {
   title: '@ps/SwitchField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadow],
 } as Meta;
 
 const Template = (args) => <Unstable_SwitchField {...args} />;
@@ -25,7 +25,6 @@ LabelFullWidth.args = {
   label: 'Label',
   fullWidth: true,
 };
-LabelFullWidth.decorators = [mediumWidth];
 LabelFullWidth.storyName = 'label fullWidth';
 
 export const LabelHelperText: Story = Template.bind({});
@@ -61,6 +60,5 @@ LabelLabelPlacementStartFullWidth.args = {
   labelPlacement: 'start',
   fullWidth: true,
 };
-LabelLabelPlacementStartFullWidth.decorators = [mediumWidth];
 LabelLabelPlacementStartFullWidth.storyName =
   'label labelPlacement=start fullWidth';

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.stories.tsx
@@ -6,7 +6,7 @@ import {
   Unstable_Tabs,
   Unstable_TabsProps,
 } from '..';
-import { containFocusIndicator, sparkThemeProvider } from '../../stories';
+import { containBoxShadowInline, sparkThemeProvider } from '../../stories';
 
 export const _retyped = Unstable_Tab as typeof Unstable_Tab;
 
@@ -15,7 +15,7 @@ export default {
   component: _retyped,
   excludeStories: ['_retyped'],
   parameters: { actions: { argTypesRegex: '^on.*' } },
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadowInline],
   argTypes: {},
   args: {
     children: <>Label</>,

--- a/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
+++ b/libs/spark/src/Unstable_Tabs/Unstable_Tabs.stories.tsx
@@ -8,9 +8,8 @@ import {
   Unstable_TabsProps,
 } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadow,
   enableHooks,
-  largeWidth,
   sparkThemeProvider,
   statefulValue,
 } from '../../stories';
@@ -21,7 +20,7 @@ export default {
   title: '@ps/Tabs',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [largeWidth, containFocusIndicator],
+  decorators: [containBoxShadow],
   args: {
     'TabsList.aria-label': 'tabs story',
   },

--- a/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
+++ b/libs/spark/src/Unstable_TabsList/Unstable_TabsList.stories.tsx
@@ -7,11 +7,7 @@ import {
   Unstable_TabsListProps,
   Unstable_TabsProps,
 } from '..';
-import {
-  containFocusIndicator,
-  largeWidth,
-  sparkThemeProvider,
-} from '../../stories';
+import { containBoxShadow, sparkThemeProvider } from '../../stories';
 
 export const _retyped = Unstable_TabsList as typeof Unstable_TabsList;
 
@@ -19,7 +15,7 @@ export default {
   title: '@ps/TabsList',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [largeWidth, containFocusIndicator],
+  decorators: [containBoxShadow],
   args: {
     'Tabs.defaultValue': '0',
     'aria-label': 'Example of three tabs',

--- a/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
+++ b/libs/spark/src/Unstable_Tag/Unstable_Tag.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_Tag, Unstable_TagProps } from '..';
 import {
-  containFocusIndicator,
+  containBoxShadowInline,
   Filter,
   sparkThemeProvider,
 } from '../../stories';
@@ -17,7 +17,7 @@ export default {
   title: '@ps/Tag',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [containFocusIndicator],
+  decorators: [containBoxShadowInline],
   parameters: {
     actions: {
       // override default actions regex

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.stories.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { Unstable_TextField, Unstable_TextFieldProps } from '..';
 import { default as Unstable_SelectMeta } from '../Unstable_Select/Unstable_Select.stories';
 import {
-  containFocusIndicator,
+  containBoxShadow,
   enableHooks,
   Gear,
   Info,
@@ -17,7 +17,7 @@ export default {
   title: '@ps/TextField',
   component: _retyped,
   excludeStories: ['_retyped'],
-  decorators: [statefulValue, enableHooks, containFocusIndicator],
+  decorators: [statefulValue, enableHooks, containBoxShadow],
   args: {
     // start component as "controlled"
     value: '',
@@ -112,6 +112,14 @@ LabelHelperTextError.args = {
   error: true,
 };
 LabelHelperTextError.storyName = 'label helperText error';
+
+export const LabelHelperTextFullWidth: Story = Template.bind({});
+LabelHelperTextFullWidth.args = {
+  label: 'Label',
+  helperText: 'Helper text',
+  fullWidth: true,
+};
+LabelHelperTextFullWidth.storyName = 'label helperText fullWidth';
 
 export const LabelHelperTextLeadingEl: Story = Template.bind({});
 LabelHelperTextLeadingEl.args = {

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -84,24 +84,18 @@ export const inverseBackground = (Story, context) => (
   </InverseBackgroundSpan>
 );
 
-const ContainFocusIndicatorDiv = styled('div')({
-  // width of focus indicator
+const ContainBoxShadowDiv = styled('div')({
+  // width of box shadows like focus indicator, input state severity
   padding: 4,
-  // without setting it to fit, the story snapshot will expand to 100%
-  width: 'fit-content',
-  // prevent larger-than-necessary height because of added browser-default space for ascender/descenders.
-  display: 'grid',
-  // prevent overflowing past viewport
-  maxWidth: '100%',
 });
 
 /**
  * [Internal] A Storybook decorator that applies padding so that the standard focus indicator is captured in Chromatic snapshots.
  */
-export const containFocusIndicator = (Story, context) => (
-  <ContainFocusIndicatorDiv>
+export const containBoxShadow = (Story, context) => (
+  <ContainBoxShadowDiv>
     <Story {...context} />
-  </ContainFocusIndicatorDiv>
+  </ContainBoxShadowDiv>
 );
 
 const MediumWidthDiv = styled('div')({
@@ -149,3 +143,23 @@ export const containElevation = (Story, context) => (
     <Story {...context} />
   </ContainElevationDiv>
 );
+
+const ContainBoxShadowInlineDiv = styled(ContainBoxShadowDiv)({
+  // 'inline' => prevent taking up full width available (block-level element default) (results in story snapshot being width being window width rather than element width)
+  // 'grid' / 'flex' => prevent added space for font ascender/descender (inline element default) (results in story snapshot height being larger than necessary by a pixel or two)
+  display: 'inline-grid',
+});
+
+/**
+ * [Internal] ...
+ *
+ * Prevents `fullWidth` feature.
+ */
+export const containBoxShadowInline = (Story, context) => (
+  <ContainBoxShadowInlineDiv>
+    <Story {...context} />
+  </ContainBoxShadowInlineDiv>
+);
+
+// // prevent overflowing past viewport
+// maxWidth: '100%',


### PR DESCRIPTION
- add `fullWidth` stories where applicable
- preserve block level display values so `fullWidth` stories work
- add decorator to contain box shadows while preserving inline display values

This will affect a majority of our stories. Those stories previously did not have the ability to correctly showcase `fullWidth` behavior because they shrunk the width of the snapshot, whether the component was inline or block-level display. This was an oversight and we need to preserve the display level of the component even though the majority of stories will have large snapshots as a result.

Also, the "contain box shadow" decorator should be applied as sparingly as possible. When a component will only have a box shadow when ":focus-visible" then it's fair to remove the decorator from the default config. However, for components like Input that display box shadows on prop values, it's more reasonable to decorate by default so that logic is not being mixed up -- a core purpose of the stories.