### PR TITLE
fix(Input): fullWidth not working; overflowing parent

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.9...vNext) (YYYY-MM-DD)
 
-No changes.
+API surface:
+
+- **Unstable_Input**
+  - [fix] `fullWidth` not working
+  - [fix] overflowing out of parent that is smaller than the default width
+- **Unstable_Select**
+  - see **Unstable_Input**
+- **Unstable_TextField**
+  - see **Unstable_Input**
 
 ## [v2.0.0-alpha.9](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.8...v2.0.0-alpha.9) (2022-12-02)
 

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -43,6 +43,7 @@ export interface Unstable_InputProps
 export type Unstable_InputClassKey = 'root' | 'input';
 
 type PrivateClassKey =
+  | 'private-root-fullWidth'
   | 'private-root-value'
   | 'private-root-multiline'
   | 'private-root-size-small'
@@ -78,7 +79,8 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
     color: theme.unstable_palette.text.body,
     letterSpacing: 0,
     margin: 0,
-    width: theme.unstable_typography.pxToRem(320),
+    maxWidth: theme.unstable_typography.pxToRem(320),
+    width: '100%',
     '&:hover': {
       backgroundColor: theme.unstable_palette.neutral[60],
     },
@@ -111,6 +113,9 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
     },
   },
   /* Private */
+  'private-root-fullWidth': {
+    maxWidth: '100%',
+  },
   'private-root-value': {
     backgroundColor: theme.unstable_palette.neutral[60],
     border: theme.unstable_borders.bold,
@@ -172,6 +177,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
       'aria-describedby': ariaDescribedByProp,
       classes,
       id: idProp,
+      fullWidth,
       leadingEl,
       multiline,
       placeholder,
@@ -192,6 +198,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
             classes.root,
             classes[`private-root-size-${formControl.size}`],
             {
+              [classes['private-root-fullWidth']]: fullWidth,
               [classes['private-root-value']]: value,
               [classes['private-root-multiline']]: multiline,
               [classes[`private-root-size-${formControl.size}-leadingEl`]]:


### PR DESCRIPTION
Does two things really. Since we want our inputs to be a different width than browser default, we want to keep the custom width that Input has by default. However it was facing an issue that it would keep this width even when its parent was smaller, and when full width was set -- full width also wasn't handled correctly. To achieve all ends, the width is always 100% and the max width changes instead. This allows full width and auto-adjusting to a smaller-than-desired parent.