### PR TITLE
fix(Select): icon size, spacing when size="small"

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -13,6 +13,7 @@ API surface:
   - [fix] overflowing out of parent that is smaller than the default width
 - **Unstable_Select**
   - see **Unstable_Input**
+  - [fix] wrong icon size and spacing when `size="small"`
 - **Unstable_TextField**
   - see **Unstable_FormControl**, **Unstable_Input**, **Unstable_Select**
 

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -125,7 +125,6 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
     icon: {
       ...styles.icon,
       color: theme.unstable_palette.text.icon,
-      marginRight: 14,
       transition: 'transform 250ms ease',
       /* disabled -- can get from internal context => can't condition on prop */
       '.Mui-disabled > &': {
@@ -161,11 +160,13 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
     },
     'private-icon-size-medium': {
       fontSize: theme.unstable_typography.pxToRem(24),
+      marginRight: 16,
       top: 'calc(50% - 12px)',
     },
     'private-icon-size-small': {
-      fontSize: theme.unstable_typography.pxToRem(16),
-      top: 'calc(50% - 8px)',
+      fontSize: theme.unstable_typography.pxToRem(20),
+      marginRight: 8,
+      top: 'calc(50% - 10px)',
     },
   };
 };


### PR DESCRIPTION
Design changed a little bit, margin was off either way.