### PR TITLE
style: override Bootstrap.css where necessary

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 API surface:
 
+- **Unstable_Banner**
+  - [style] reduce gap, padding on mobile
+- **Unstable_Card**
+  - [style] reduce padding on mobile
+- **Unstable_CheckboxListItem**
+  - see **Unstable_ListItem**
+- **Unstable_CheckboxMenuItem**
+  - see **Unstable_MenuItem**
 - **Unstable_FormControl**
   - [fix] `fullWidth` not working
 - **Unstable_FormGroup**
@@ -11,9 +19,17 @@ API surface:
 - **Unstable_Input**
   - [fix] `fullWidth` not working
   - [fix] overflowing out of parent that is smaller than the default width
+- **Unstable_ListItem**
+  - [style] override Bootstrap.css
+- **Unstable_MenuItem**
+  - see **Unstable_ListItem**
+- **Unstable_SectionMessage**
+  - [style] reduce gap, padding on mobile
 - **Unstable_Select**
   - see **Unstable_Input**
   - [fix] wrong icon size and spacing when `size="small"`
+- **Unstable_Tab**
+  - [style] override Bootstrap.css
 - **Unstable_TextField**
   - see **Unstable_FormControl**, **Unstable_Input**, **Unstable_Select**
 

--- a/libs/spark/src/Unstable_ListItem/Unstable_ListItem.tsx
+++ b/libs/spark/src/Unstable_ListItem/Unstable_ListItem.tsx
@@ -77,6 +77,7 @@ const styles: Styles<Unstable_ListItemClassKey | PrivateClassKey> = (
 ) => ({
   /* Styles applied to the root element. */
   root: {
+    color: theme.unstable_palette.text.body,
     padding: '8px 16px',
   },
   /* Styles applied to the container element (added when a secondary action is given). */
@@ -103,33 +104,45 @@ const styles: Styles<Unstable_ListItemClassKey | PrivateClassKey> = (
     paddingRight: 40 + 16, // width of small icon button + gap
   },
   'private-root-button': {
+    color: theme.unstable_palette.text.body, // override Bootstrap.css
+    textDecoration: 'unset', // override Bootstrap.css
     cursor: 'pointer',
     userSelect: 'text',
-    '&:hover': {
+    WebkitTapHighlightColor: 'transparent',
+    '&:hover, &[data-focus="true"]': {
       backgroundColor: alpha(theme.unstable_palette.neutral[600], 0.08),
+      color: theme.unstable_palette.text.body, // override Bootstrap.css
+      textDecoration: 'unset', // override Bootstrap.css
+    },
+    '&:focus': {
+      outline: 'unset', // override Bootstrap.css
+      color: theme.unstable_palette.text.body, // override Bootstrap.css
+      textDecoration: 'unset', // override Bootstrap.css
     },
     '&:active': {
       backgroundColor: alpha(theme.unstable_palette.blue[300], 0.19),
     },
-    '&$selected': {
+    '&$selected, &[aria-selected="true"]': {
       backgroundColor: theme.unstable_palette.blue[600],
       color: theme.unstable_palette.text.inverseBody,
     },
-    '&$selected:hover': {
+    '&$selected:hover, &[aria-selected="true"]:hover': {
       backgroundColor: alpha(theme.unstable_palette.blue[600], 0.86),
     },
-    '&$selected:active': {
+    '&$selected:active, &[aria-selected="true"]:active': {
       backgroundColor: darken(theme.unstable_palette.blue[600], 0.2),
     },
-    '&$disabled': {
+    '&$disabled, &[aria-disabled="true"]': {
       backgroundColor: 'transparent',
       color: theme.unstable_palette.text.disabled,
       opacity: 1, // reset Mui default
     },
-    '&$selected$disabled': {
-      backgroundColor: theme.unstable_palette.neutral[80],
-      color: theme.unstable_palette.text.disabled,
-    },
+    '&$selected$disabled, &$selected[aria-disabled="true"], &[aria-selected="true"][aria-disabled="true"]':
+      {
+        backgroundColor: theme.unstable_palette.neutral[80],
+        color: theme.unstable_palette.text.disabled,
+        pointerEvents: 'none',
+      },
     '&.Mui-focusVisible, &:focus-visible': {
       // doesn't appear in story because is under `Mui-focusVisible`
       // backgroundColor: 'transparent',

--- a/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
+++ b/libs/spark/src/Unstable_Tab/Unstable_Tab.tsx
@@ -57,6 +57,18 @@ const styles: Styles<Unstable_TabClassKey | PrivateClassKey> = (theme) => ({
     '&&': {
       opacity: 1,
     },
+    textDecoration: 'unset', // override Bootstrap.css
+    color: 'unset', // override Bootstrap.css
+    '&:focus': {
+      outline: 'unset', // override Bootstrap.css
+      color: 'unset', // override Bootstrap.css
+      textDecoration: 'unset', // override Bootstrap.css
+    },
+    '&:hover': {
+      // override Bootstrap.css
+      color: 'unset', // override Bootstrap.css
+      textDecoration: 'unset', // override Bootstrap.css
+    },
   },
   label: {
     ...theme.unstable_typography.label,


### PR DESCRIPTION
- some consumers, like Prenda World, have Bootstrap.css installed/injected which competes/overrides some of our styles unless specified otherwise.
- also add forgotten changelog message from #663