### PR TITLE
feat(Dropdown): add v2 implementation

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -14,6 +14,17 @@ API surface:
   - see **Unstable_ListItem**
 - **Unstable_CheckboxMenuItem**
   - see **Unstable_MenuItem**
+- **Unstable_Dropdown**
+  - [feat] added
+  - Replaces v1 **DropdownContext**
+- **Unstable_DropdownContext**
+  - [feat] added
+- **Unstable_DropdownMenu**
+  - [feat] added
+  - Replaces v1 **DropdownMenu**
+- **Unstable_DropdownTrigger**
+  - [feat] added
+  - Replaces v1 **DropdownButton**
 - **Unstable_FormControl**
   - [fix] `fullWidth` not working
 - **Unstable_FormGroup**
@@ -40,6 +51,8 @@ API surface:
     - `toasts.enqueue.info(message, options)`
     - `toasts.enqueue.success(message, options)`
     - `toasts.enqueue.warning(message, options)`of the toast while preserving the API:
+- **useDropdown_unstable**
+  - [feat] added
 - **useToasts_unstable**
   - see **Unstable_ToastsContext**
   - [feat] change default placement to `"bottom-center"`

--- a/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.spec.tsx
+++ b/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Unstable_Dropdown from './Unstable_Dropdown';
+
+describe('Unstable_Dropdown', () => {
+  it('is truthy', () => {
+    const { baseElement } = render(<Unstable_Dropdown />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.stories.tsx
+++ b/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.stories.tsx
@@ -1,18 +1,18 @@
 import React, { CSSProperties } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import {
-  DropdownAnchor,
-  DropdownContext,
-  DropdownMenu,
   Unstable_AvatarButton,
   Unstable_Button,
+  Unstable_Dropdown,
+  Unstable_DropdownMenu,
+  Unstable_DropdownTrigger,
   Unstable_IconButton,
   Unstable_Menu,
 } from '..';
 import Unstable_MenuMeta from '../Unstable_Menu/Unstable_Menu.stories';
 import { MoreHorizFilled } from '../../stories';
 
-const anchorComponents = {
+const triggerComponents = {
   default: undefined,
   Unstable_Button,
   Unstable_IconButton,
@@ -22,17 +22,17 @@ const anchorComponents = {
 const menuComponents = { default: undefined, Unstable_Menu };
 
 export default {
-  title: '@ps/Dropdown (pattern)',
+  title: '@ps/Dropdown',
   argTypes: {
-    /* Dropdown Anchor props */
-    'DropdownAnchor.component': {
-      options: Object.keys(anchorComponents),
-      mapping: anchorComponents,
+    /* Dropdown Trigger props */
+    'DropdownTrigger.component': {
+      options: Object.keys(triggerComponents),
+      mapping: triggerComponents,
       control: {
         type: 'select',
       },
     },
-    'DropdownAnchor.disabled': { control: 'boolean' },
+    'DropdownTrigger.disabled': { control: 'boolean' },
 
     /* Dropdown Menu props */
     'DropdownMenu.component': {
@@ -49,8 +49,6 @@ export default {
     'DropdownMenu.children': Unstable_MenuMeta.argTypes.children,
   },
   args: {
-    'DropdownAnchor.component': 'Unstable_Button',
-    'DropdownMenu.component': 'Unstable_Menu',
     'DropdownMenu.children': Unstable_MenuMeta.argTypes.children.options[0],
     'DropdownMenu.placement': 'bottom-left',
     'DropdownMenu.PaperProps': { style: { width: 256 } },
@@ -78,8 +76,8 @@ function getPositioningStyles(placement): CSSProperties {
 
 const Template: Story = (props) => {
   const {
-    'DropdownAnchor.component': dropdownAnchorComponent,
-    'DropdownAnchor.disabled': dropdownAnchorDisabled,
+    'DropdownTrigger.component': dropdownTriggerComponent,
+    'DropdownTrigger.disabled': dropdownTriggerDisabled,
     'DropdownMenu.children': dropdownMenuChildren,
     'DropdownMenu.component': dropdownMenuComponent,
     'DropdownMenu.placement': dropdownMenuPlacement,
@@ -87,19 +85,19 @@ const Template: Story = (props) => {
   } = props;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const anchorProps: any = {
+  const triggerProps: any = {
     children: 'Label',
-    disabled: dropdownAnchorDisabled,
+    disabled: dropdownTriggerDisabled,
   };
-  if (dropdownAnchorComponent !== undefined) {
-    anchorProps.component = dropdownAnchorComponent;
+  if (dropdownTriggerComponent !== undefined) {
+    triggerProps.component = dropdownTriggerComponent;
   }
-  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_IconButton') {
-    anchorProps.children = <MoreHorizFilled />;
+  if (dropdownTriggerComponent?._PDS_ID === 'Unstable_IconButton') {
+    triggerProps.children = <MoreHorizFilled />;
   }
-  if (dropdownAnchorComponent?._PDS_ID === 'Unstable_AvatarButton') {
-    anchorProps.src = '/img/guide-1.png';
-    delete anchorProps.children;
+  if (dropdownTriggerComponent?._PDS_ID === 'Unstable_AvatarButton') {
+    triggerProps.src = '/img/guide-1.png';
+    delete triggerProps.children;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -116,12 +114,12 @@ const Template: Story = (props) => {
 
   return (
     // menu height + (largest) anchor el height + space between; menu width
-    <div style={{ position: 'relative', height: 182 + 48 + 8, width: 256 }}>
+    <div style={{ position: 'relative', height: 273 + 48 + 8, width: 256 }}>
       <div style={positioningStyles}>
-        <DropdownContext>
-          <DropdownAnchor {...anchorProps} />
-          <DropdownMenu {...menuProps} />
-        </DropdownContext>
+        <Unstable_Dropdown>
+          <Unstable_DropdownTrigger {...triggerProps} />
+          <Unstable_DropdownMenu {...menuProps} />
+        </Unstable_Dropdown>
       </div>
     </div>
   );

--- a/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.tsx
+++ b/libs/spark/src/Unstable_Dropdown/Unstable_Dropdown.tsx
@@ -1,0 +1,47 @@
+import React, {
+  MouseEvent,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import Unstable_DropdownContext from '../Unstable_DropdownContext/Unstable_DropdownContext';
+import { useUniqueId } from '../utils';
+
+export interface Unstable_DropdownProps {
+  /**
+   * The content of the component.
+   */
+  children?: ReactNode;
+}
+
+export const Unstable_Dropdown = (
+  props: Unstable_DropdownProps
+): JSX.Element => {
+  const id = useUniqueId();
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const open = useCallback((event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const close = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      id,
+      anchorEl,
+      isOpen: !!anchorEl,
+      open,
+      close,
+    }),
+    [id, anchorEl, open, close]
+  );
+
+  return <Unstable_DropdownContext.Provider value={value} {...props} />;
+};
+
+export default Unstable_Dropdown;

--- a/libs/spark/src/Unstable_Dropdown/index.ts
+++ b/libs/spark/src/Unstable_Dropdown/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_Dropdown';
+export * from './Unstable_Dropdown';

--- a/libs/spark/src/Unstable_DropdownContext/Unstable_DropdownContext.ts
+++ b/libs/spark/src/Unstable_DropdownContext/Unstable_DropdownContext.ts
@@ -1,0 +1,18 @@
+import { createContext, MouseEvent } from 'react';
+
+export interface Unstable_DropdownContextValue {
+  id: string;
+  anchorEl: null | HTMLElement;
+  open: (event: MouseEvent<HTMLElement>) => void;
+  close: () => void;
+  isOpen: boolean;
+}
+
+const Unstable_DropdownContext =
+  createContext<Unstable_DropdownContextValue | null>(null);
+
+if (process.env.NODE_ENV !== 'production') {
+  Unstable_DropdownContext.displayName = 'DropdownContext';
+}
+
+export default Unstable_DropdownContext;

--- a/libs/spark/src/Unstable_DropdownContext/index.ts
+++ b/libs/spark/src/Unstable_DropdownContext/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_DropdownContext';
+export * from './Unstable_DropdownContext';

--- a/libs/spark/src/Unstable_DropdownMenu/Unstable_DropdownMenu.test.tsx
+++ b/libs/spark/src/Unstable_DropdownMenu/Unstable_DropdownMenu.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import Unstable_Dropdown from '../Unstable_Dropdown';
+import Unstable_DropdownMenu from './Unstable_DropdownMenu';
+
+describe('DropdownMenu', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(
+      <Unstable_Dropdown>
+        <Unstable_DropdownMenu />
+      </Unstable_Dropdown>
+    );
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_DropdownMenu/Unstable_DropdownMenu.tsx
+++ b/libs/spark/src/Unstable_DropdownMenu/Unstable_DropdownMenu.tsx
@@ -1,0 +1,139 @@
+import { PopoverProps } from '@material-ui/core/Popover';
+import React, { ElementType, forwardRef } from 'react';
+import clsx from 'clsx';
+import { OverridableComponent, OverrideProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+import Unstable_Menu, { Unstable_MenuProps } from '../Unstable_Menu';
+import useDropdown_unstable from '../useDropdown_unstable';
+
+type Placement = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
+
+export interface Unstable_DropdownMenuTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends ElementType = typeof Unstable_Menu
+> {
+  props: P & {
+    // possible props of override component that are deconstructed
+    onClose?: PopoverProps['onClose'];
+    PaperProps?: {
+      className?: string;
+    };
+  } & {
+    /**
+     * If `true`, the menu is visible.
+     */
+    open?: boolean | undefined;
+    /**
+     * The placement of the menu `Popover` in relation to its anchor.
+     * This is a shortcut for common combinations of `anchorOrigin` and `transformOrigin`.
+     */
+    placement?: Placement;
+  };
+  defaultComponent: D;
+  classKey: never;
+}
+
+export type Unstable_DropdownMenuProps<
+  D extends ElementType = Unstable_DropdownMenuTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_DropdownMenuTypeMap<P, D>, D>;
+
+type Origins = Pick<Unstable_MenuProps, 'anchorOrigin' | 'transformOrigin'>;
+
+function getOrigins(placement: Placement): Origins {
+  let anchorOrigin;
+  let transformOrigin;
+
+  if (placement === 'bottom-left') {
+    anchorOrigin = { vertical: 'bottom', horizontal: 'left' };
+    transformOrigin = { vertical: 'top', horizontal: 'left' };
+  } else if (placement === 'bottom-right') {
+    anchorOrigin = { vertical: 'bottom', horizontal: 'right' };
+    transformOrigin = { vertical: 'top', horizontal: 'right' };
+  } else if (placement === 'top-left') {
+    anchorOrigin = { vertical: 'top', horizontal: 'left' };
+    transformOrigin = { vertical: 'bottom', horizontal: 'left' };
+  } else if (placement === 'top-right') {
+    anchorOrigin = { vertical: 'top', horizontal: 'right' };
+    transformOrigin = { vertical: 'bottom', horizontal: 'right' };
+  }
+
+  return { anchorOrigin, transformOrigin };
+}
+
+type PrivateClassKey =
+  | 'private-paper-placement-bottom-left'
+  | 'private-paper-placement-bottom-right'
+  | 'private-paper-placement-top-left'
+  | 'private-paper-placement-top-right';
+
+// since the menu is absolutely positioning by top & left, then position adjustments are made through top & left margin changes
+const styles: Styles<PrivateClassKey> = {
+  'private-paper-placement-bottom-left': {
+    marginTop: 8,
+  },
+  'private-paper-placement-bottom-right': {
+    marginTop: 8,
+  },
+  'private-paper-placement-top-left': {
+    marginTop: -8,
+  },
+  'private-paper-placement-top-right': {
+    marginTop: -8,
+  },
+};
+
+const UnstyledUnstable_DropdownMenu: OverridableComponent<Unstable_DropdownMenuTypeMap> =
+  forwardRef(function Unstable_DropdownMenu(props, ref) {
+    const {
+      classes,
+      // @ts-expect-error TS can't recognize component prop
+      component = Unstable_Menu,
+      placement = 'bottom-left',
+      onClose,
+      PaperProps,
+      anchorOrigin,
+      transformOrigin,
+      ...other
+    } = props as Unstable_DropdownMenuProps;
+
+    const Component = component as ElementType;
+
+    const { anchorEl, id, isOpen, close } = useDropdown_unstable();
+
+    const handleClose: Unstable_MenuProps['onClose'] = (event, reason) => {
+      onClose?.(event, reason);
+      close();
+    };
+
+    const origins = getOrigins(placement);
+
+    return (
+      <Component
+        id={id}
+        getContentAnchorEl={null}
+        anchorEl={anchorEl}
+        keepMounted
+        onClose={handleClose}
+        open={isOpen}
+        ref={ref}
+        PaperProps={{
+          ...PaperProps,
+          className: clsx(
+            classes[`private-paper-placement-${placement}`],
+            PaperProps?.className
+          ),
+        }}
+        {...origins}
+        {...other}
+      />
+    );
+  });
+
+const Unstable_DropdownMenu = withStyles(styles, {
+  name: 'MuiSparkUnstable_DropdownMenu',
+})(UnstyledUnstable_DropdownMenu) as typeof UnstyledUnstable_DropdownMenu;
+
+export default Unstable_DropdownMenu;

--- a/libs/spark/src/Unstable_DropdownMenu/index.ts
+++ b/libs/spark/src/Unstable_DropdownMenu/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_DropdownMenu';
+export * from './Unstable_DropdownMenu';

--- a/libs/spark/src/Unstable_DropdownTrigger/Unstable_DropdownTrigger.test.tsx
+++ b/libs/spark/src/Unstable_DropdownTrigger/Unstable_DropdownTrigger.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import Unstable_Dropdown from '../Unstable_Dropdown';
+import Unstable_DropdownTrigger from './Unstable_DropdownTrigger';
+
+describe('Unstable_DropdownTrigger', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(
+      <Unstable_Dropdown>
+        <Unstable_DropdownTrigger />
+      </Unstable_Dropdown>
+    );
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/Unstable_DropdownTrigger/Unstable_DropdownTrigger.tsx
+++ b/libs/spark/src/Unstable_DropdownTrigger/Unstable_DropdownTrigger.tsx
@@ -1,0 +1,103 @@
+import clsx from 'clsx';
+import React, { ElementType, forwardRef } from 'react';
+import Unstable_Button, {
+  Unstable_ButtonProps,
+  Unstable_ButtonTypeMap,
+} from '../Unstable_Button';
+import { Unstable_ChevronDown } from '../internal';
+import useDropdown_unstable from '../useDropdown_unstable/useDropdown_unstable';
+import { OverridableComponent, OverrideProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+
+export interface Unstable_DropdownTriggerTypeMap<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {},
+  D extends ElementType = Unstable_ButtonTypeMap['defaultComponent']
+> {
+  props: P;
+  defaultComponent: D;
+  classKey: Unstable_DropdownTriggerClassKey;
+}
+
+export type Unstable_DropdownTriggerProps<
+  D extends ElementType = Unstable_DropdownTriggerTypeMap['defaultComponent'],
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  P = {}
+> = OverrideProps<Unstable_DropdownTriggerTypeMap<P, D>, D>;
+
+export type Unstable_DropdownTriggerClassKey = 'root';
+
+type PrivateClassKey =
+  | 'private-root-trailingIcon'
+  | 'private-root-trailingIcon-open';
+
+const styles: Styles<Unstable_DropdownTriggerClassKey | PrivateClassKey> = {
+  root: {},
+  'private-root-trailingIcon': {
+    transition: 'transform 250ms ease',
+  },
+  'private-root-trailingIcon-open': {
+    transform: 'rotate(180deg)',
+  },
+};
+
+const UnstyledUnstable_DropdownTrigger: OverridableComponent<Unstable_DropdownTriggerTypeMap> =
+  forwardRef(function Unstable_DropdownTrigger(
+    {
+      classes,
+      className,
+      // @ts-expect-error TS can't recognize component prop
+      component = Unstable_Button,
+      onClick,
+      ...other
+    },
+    ref
+  ) {
+    const { id, isOpen, open } = useDropdown_unstable();
+
+    const Component = component as ElementType;
+
+    const extra = {};
+    // @ts-expect-error property does not exist
+    if (Component._PDS_ID === 'Unstable_Button') {
+      // check if should add default trailing icon and styles
+      if (
+        Object.prototype.hasOwnProperty.call(other, 'trailingIcon') === false
+      ) {
+        (extra as Unstable_ButtonProps).trailingIcon = <Unstable_ChevronDown />;
+        (extra as Unstable_ButtonProps).classes = {
+          ...(other as Unstable_ButtonProps)?.classes,
+          trailingIcon: clsx(
+            classes['private-root-trailingIcon'],
+            {
+              [classes['private-root-trailingIcon-open']]: isOpen,
+            },
+            (other as Unstable_ButtonProps)?.classes?.trailingIcon
+          ),
+        };
+      }
+    }
+
+    const handleClick: Unstable_DropdownTriggerProps['onClick'] = (event) => {
+      onClick?.(event);
+      open(event);
+    };
+
+    return (
+      <Component
+        aria-controls={id}
+        aria-haspopup="true"
+        className={clsx(classes.root, className)}
+        onClick={handleClick}
+        ref={ref}
+        {...extra}
+        {...other}
+      />
+    );
+  });
+
+const Unstable_DropdownTrigger = withStyles(styles, {
+  name: 'MuiSparkUnstable_DropdownTrigger',
+})(UnstyledUnstable_DropdownTrigger) as typeof UnstyledUnstable_DropdownTrigger;
+
+export default Unstable_DropdownTrigger;

--- a/libs/spark/src/Unstable_DropdownTrigger/index.ts
+++ b/libs/spark/src/Unstable_DropdownTrigger/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Unstable_DropdownTrigger';
+export * from './Unstable_DropdownTrigger';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -252,6 +252,17 @@ export { default as Unstable_CssBaseline } from './Unstable_CssBaseline';
 export { default as Unstable_Divider } from './Unstable_Divider';
 export * from './Unstable_Divider';
 
+export { default as Unstable_Dropdown } from './Unstable_Dropdown';
+export * from './Unstable_Dropdown';
+
+export type { Unstable_DropdownContextValue } from './Unstable_DropdownContext';
+
+export { default as Unstable_DropdownMenu } from './Unstable_DropdownMenu';
+export * from './Unstable_DropdownMenu';
+
+export { default as Unstable_DropdownTrigger } from './Unstable_DropdownTrigger';
+export * from './Unstable_DropdownTrigger';
+
 export { default as Unstable_FontFacesBaseline } from './Unstable_FontFacesBaseline';
 
 export { default as Unstable_FormControl } from './Unstable_FormControl';
@@ -389,6 +400,8 @@ export { default as theme } from './theme';
 export * from './theme';
 
 export { default as unstable_createSvgIcon } from './unstable_createSvgIcon';
+
+export { default as useDropdown_unstable } from './useDropdown_unstable';
 
 export { default as useFormControl } from './useFormControl';
 

--- a/libs/spark/src/useDropdown_unstable/index.ts
+++ b/libs/spark/src/useDropdown_unstable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useDropdown_unstable';

--- a/libs/spark/src/useDropdown_unstable/useDropdown_unstable.ts
+++ b/libs/spark/src/useDropdown_unstable/useDropdown_unstable.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import Unstable_DropdownContext, {
+  Unstable_DropdownContextValue,
+} from '../Unstable_DropdownContext';
+
+const useDropdown_unstable = (): Unstable_DropdownContextValue => {
+  return useContext(Unstable_DropdownContext);
+};
+
+export default useDropdown_unstable;


### PR DESCRIPTION
Avoids consumers having to supply the custom components every time. Uses the new, better context-less name patterns and top-level internal-ish components like the Tabs pattern implemented.