### PR TITLE
fix(CheckboxListItem): underlying `onClick` type preventing custom signature

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -14,6 +14,7 @@ API surface:
   - [style] reduce padding on mobile
 - **Unstable_CheckboxListItem**
   - see **Unstable_ListItem**
+  - [fix] underlying `onClick` type preventing custom signature
 - **Unstable_CheckboxMenuItem**
   - see **Unstable_MenuItem**
 - **Unstable_Dropdown**

--- a/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.test.tsx
+++ b/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.test.tsx
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react';
-import Unstable_CheckboxListItem from './Unstable_CheckboxListItem';
+import Unstable_CheckboxListItem, {
+  Unstable_CheckboxListItemProps,
+} from './Unstable_CheckboxListItem';
 
 describe('Unstable_CheckboxListItem', () => {
   it('Can render without ThemeProvider', () => {
@@ -10,5 +12,24 @@ describe('Unstable_CheckboxListItem', () => {
     );
 
     expect(baseElement).toBeTruthy();
+  });
+
+  // This is a type test, not runtime
+  it.skip('Has replaced `onClick` prop', () => {
+    const handleClick: Unstable_CheckboxListItemProps['onClick'] = (
+      _e,
+      value,
+      checked
+    ) => {
+      return;
+    };
+
+    <Unstable_CheckboxListItem
+      onClick={handleClick}
+      checked={false}
+      value="value"
+    >
+      Label
+    </Unstable_CheckboxListItem>;
   });
 });

--- a/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.tsx
+++ b/libs/spark/src/Unstable_CheckboxListItem/Unstable_CheckboxListItem.tsx
@@ -1,4 +1,10 @@
-import React, { ElementType, forwardRef, MouseEvent, Ref } from 'react';
+import React, {
+  ElementType,
+  forwardRef,
+  MouseEvent,
+  MouseEventHandler,
+  Ref,
+} from 'react';
 import clsx from 'clsx';
 import Unstable_Checkbox, {
   Unstable_CheckboxProps,
@@ -15,7 +21,9 @@ export type Unstable_CheckboxListItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
   D extends ElementType = 'li'
-> = Omit<Unstable_ListItemTypeMap<P, D>, 'classKey'> & {
+> = Omit<Unstable_ListItemTypeMap<P, D>, 'props' | 'classKey'> & {
+  props: Omit<Unstable_ListItemTypeMap<P, D>['props'], 'onClick'>;
+} & {
   classKey: Unstable_CheckboxListItemClassKey;
   props: P & {
     /**
@@ -62,7 +70,8 @@ export type Unstable_CheckboxListItemProps<
   D extends ElementType = Unstable_CheckboxListItemTypeMap['defaultComponent'],
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {}
-> = OverrideProps<Unstable_CheckboxListItemTypeMap<P, D>, D>;
+> = Omit<OverrideProps<Unstable_CheckboxListItemTypeMap<P, D>, D>, 'onClick'> &
+  Pick<Unstable_CheckboxListItemTypeMap<P, D>['props'], 'onClick'>;
 
 export type Unstable_CheckboxListItemClassKey = 'root' | 'label';
 
@@ -124,8 +133,7 @@ const Unstable_CheckboxListItem: OverridableComponent<
 
   const checked = checkedProp === undefined ? selected : checkedProp;
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  const handleClick = (event) => {
+  const handleClick: MouseEventHandler<HTMLLIElement> = (event) => {
     if (onClick) {
       onClick(event, value, checked);
     }


### PR DESCRIPTION
Pretty hacky, but this prevents the following type error when trying to create a click handler function that satisfies the custom signature:

```
const handleClick: React.MouseEventHandler<HTMLLIElement> & ((event: React.MouseEvent<{}, MouseEvent>, value: string, checked: boolean) => void)
Type '(_e: MouseEvent<{}, MouseEvent>, value: string, checked: boolean) => void' is not assignable to type 'MouseEventHandler<HTMLLIElement> & ((event: MouseEvent<{}, MouseEvent>, value: string, checked: boolean) => void)'.
  Type '(_e: MouseEvent<{}, MouseEvent>, value: string, checked: boolean) => void' is not assignable to type 'MouseEventHandler<HTMLLIElement>'.ts(2322)
```

The problem lies with the fact that the utility types, Overridable Component and Overridable Props, do not allow for removals or replacements of the underlying "Base Props", HTML Element props.