### PR TITLE
style: change form control related width behaviors

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -23,8 +23,8 @@ API surface:
 - **Unstable_InputAdornment**
   - [style] increase font size when `size="small"`
 - **Unstable_Link**
-  - [style] vertically align with inline text when `component="button"`
-- **Unstable_RadioGroupField**
+  - [style] change to vertically align with inline text when `component="button"`
+- **Unstable_RadioGroup**
   - [fix] not forwarding the `id` prop to the underlying element
 - **Unstable_RadioGroupField**
   - see **Unstable_FormControl**, **Unstable_RadioGroup**
@@ -33,7 +33,8 @@ API surface:
   - [feat] improve Form Control API-integration
 - **Unstable_TextField**
   - see **Unstable_FormControl**, **Unstable_Input**, **Unstable_Select**
-  - [DEPRECATION] deprecated; compose the Form Control pattern directly
+  - [DEPRECATION] deprecated
+    - _migration: compose the Form Control pattern directly_
 - **useFormControl_unstable**
   - [feat] add `filled`, `focused`, `inputId`, `labelId`, `helperTextId` to parameters
   - [BREAKING] remove `id` from result

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -12,6 +12,7 @@ API surface:
   - see **Unstable_FormControl**
 - **Unstable_FormControl**
   - [feat] improve Form Control API-integration
+  - [style] remove default width
   - [BREAKING] change `id` prop to forward to the root, wrapper element (formerly forwarded to the descendant input element)
     - _migration: use `inputId` prop_
   - [feat] add `inputId` prop

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -20,6 +20,7 @@ API surface:
   - [feat] add `inputId` prop
   - [feat] add `labelId` prop
   - [feat] add `helperTextId` prop
+  - [style] change to be block-level element
 - **Unstable_Input**
   - see **Unstable_InputAdornment** for changes affecting default values of `renderLeadingEl`, `renderTrailingEl`
   - [feat] improve Form Control API-integration

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -7,6 +7,8 @@ API surface:
 - **Unstable_Autocomplete**
   - see **Unstable_Input** for changes affecting default value of `renderInput`
   - [style] prevent width changes from default `renderMultipleValue`
+  - [style] change to be inline-level element
+  - [style] change to vertically align with inline text
   - [feat] improve Form Control API-integration
 - **Unstable_CheckboxGroupField**
   - see **Unstable_FormControl**

--- a/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
+++ b/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
@@ -330,9 +330,11 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
 ) => ({
   /* Styles applied to the root element. */
   root: {
-    display: 'flex',
+    display: 'inline-flex',
+
     maxWidth: theme.unstable_typography.pxToRem(320),
     width: '100%',
+    verticalAlign: 'bottom',
     '&$focused $private-clearIndicator-dirty': {
       visibility: 'visible',
     },
@@ -356,6 +358,10 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
   /* Styles applied to the Input element. */
   inputRoot: {
     flexWrap: 'wrap',
+    '& $input': {
+      width: 0,
+      minWidth: '5ch',
+    },
   },
   'private-inputRoot-noWrap': {
     flexWrap: 'nowrap',
@@ -368,10 +374,6 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     '$private-root-hasPopupIndicator$private-root-hasClearIndicator &': {
       paddingRight: 4 + 32 + 4 + 32 + 12,
     },
-    '& $input': {
-      width: 0,
-      minWidth: '5ch',
-    },
   },
   'private-inputRoot-size-small': {
     paddingLeft: 4,
@@ -380,10 +382,6 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     },
     '$private-root-hasPopupIndicator$private-root-hasClearIndicator &': {
       paddingRight: 2 + 28 + 2 + 28 + 8, // spacing + popup-indicator + gap + popup-indicator + padding
-    },
-    '& $input': {
-      width: 0,
-      minWidth: 30,
     },
   },
   /* Styles applied to the input element. */

--- a/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.stories.tsx
+++ b/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.stories.tsx
@@ -179,10 +179,10 @@ Children2LabelHelperText.storyName =
   'children=(CheckboxFields helperText) label helperText';
 
 const SideBySideTemplate = (args) => (
-  <>
+  <div style={{ display: 'flex' }}>
     <Unstable_CheckboxGroupField {...args} />
     <Unstable_CheckboxGroupField {...args} />
-  </>
+  </div>
 );
 
 export const SideBySide: Story = SideBySideTemplate.bind({});

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -68,7 +68,9 @@ type PrivateClassKey =
 
 const styles: Styles<Unstable_FormControlClassKey | PrivateClassKey> = {
   /** Styles applied to the root element. */
-  root: {},
+  root: {
+    display: 'flex',
+  },
   /* Private */
   'private-root-fullWidth': {
     width: '100%',

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -66,17 +66,12 @@ type PrivateClassKey =
   | 'private-root-size-medium'
   | 'private-root-size-small';
 
-const styles: Styles<Unstable_FormControlClassKey | PrivateClassKey> = (
-  theme
-) => ({
+const styles: Styles<Unstable_FormControlClassKey | PrivateClassKey> = {
   /** Styles applied to the root element. */
-  root: {
-    maxWidth: theme.unstable_typography.pxToRem(320),
-    width: '100%',
-  },
+  root: {},
   /* Private */
   'private-root-fullWidth': {
-    maxWidth: '100%',
+    width: '100%',
   },
   'private-root-size-medium': {
     gap: 8,
@@ -84,7 +79,7 @@ const styles: Styles<Unstable_FormControlClassKey | PrivateClassKey> = (
   'private-root-size-small': {
     gap: 4,
   },
-});
+};
 
 const Unstable_FormControl: OverridableComponent<Unstable_FormControlTypeMap> =
   forwardRef(function Unstable_FormControl(props, ref) {

--- a/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.stories.tsx
+++ b/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.stories.tsx
@@ -136,13 +136,13 @@ LabelHelperTextErrorDisabled.storyName =
   'children=(RadioFields) label helperText error disabled';
 
 export const LabelHelperTextFullWidth: Story = Template.bind({});
-LabelHelperTextErrorDisabled.args = {
+LabelHelperTextFullWidth.args = {
   children: '(RadioFields)',
   label: 'Label',
   helperText: 'Helper text',
   fullWidth: true,
 };
-LabelHelperTextErrorDisabled.storyName =
+LabelHelperTextFullWidth.storyName =
   'children=(RadioFields) label helperText fullWidth';
 
 export const LabelHelperTextRequired: Story = Template.bind({});

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -93,6 +93,7 @@ export type Unstable_SelectClassKey =
   | 'menuPaper';
 
 type PrivateClassKey =
+  | 'private-root-fullWidth'
   | 'private-root-renderValueAsTag'
   | 'private-root-renderValueAsTag-preventMultipleOverflow'
   | 'private-icon-size-medium'
@@ -111,7 +112,7 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
       ...styles.select,
       ...styles.selectMenu,
       '&&': {
-        paddingRight: 24 + 14 + 4, // override MUI (icon width + right margin + left margin) (requires increased specificity)
+        paddingRight: 4 + 24 + 16, // spacing + icon + padding; override MUI
       },
       '.MuiSparkUnstable_InputAdornment-root ~ &': {
         paddingLeft: 14 + 24 + 8,
@@ -138,6 +139,9 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
       marginTop: 4,
     },
     /* Private */
+    'private-root-fullWidth': {
+      width: '100%',
+    },
     'private-root-renderValueAsTag': {
       paddingBottom: 8,
       paddingTop: 8,
@@ -233,7 +237,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
     const {
       bgcolor: bgcolorMenuPaperProp = 'default',
       border: borderMenuPaperProp = 'none',
-      className: classMameMenuPaperProp,
+      className: classNameMenuPaperProp,
       radius: radiusMenuPaperProp = 'sm',
       shadow: shadowMenuPaperProp = 'E400',
       ...otherMenuPaperProps
@@ -315,7 +319,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
                     paperClasses_unstable[
                       `private-root-shadow-${shadowMenuPaperProp}`
                     ],
-                    classMameMenuPaperProp
+                    classNameMenuPaperProp
                   ),
                 },
               },
@@ -333,6 +337,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
           root: clsx(
             classes.root,
             {
+              [classes['private-root-fullWidth']]: formControl.fullWidth,
               [classes['private-root-renderValueAsTag']]: renderValueAsTag,
               [classes[
                 'private-root-renderValueAsTag-preventMultipleOverflow'


### PR DESCRIPTION
- amend some changelog entries
- [Select] fix an internal typo
- [Select] slightly increase the spacing between the input and icon
- [Select] fix child not increasing to 100% width when full width
    - didn't affect styles at-large
- [RadioGroupField] fix a story
- [FormControl] remove default width
- [FormControl] make block-level element
    - if kept inline-level element without a default width, it would shrink with a child input like Select
- [CheckboxGroupField] change side-by-side story to be in flex
    - consequence of Form Control being block-level 