### PR TITLE
feat: standardize Form Control API

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -6,14 +6,38 @@ API surface:
 
 - **Unstable_Autocomplete**
   - see **Unstable_Input** for changes affecting default value of `renderInput`
+  - [feat] improve Form Control API-integration
+- **Unstable_CheckboxGroupField**
+  - see **Unstable_FormControl**
+- **Unstable_FormControl**
+  - [feat] improve Form Control API-integration
+  - [BREAKING] change `id` prop to forward to the root, wrapper element (formerly forwarded to the descendant input element)
+    - _migration: use `inputId` prop_
+  - [feat] add `inputId` prop
+  - [feat] add `labelId` prop
+  - [feat] add `helperTextId` prop
 - **Unstable_Input**
   - see **Unstable_InputAdornment** for changes affecting default values of `renderLeadingEl`, `renderTrailingEl`
+  - [feat] improve Form Control API-integration
 - **Unstable_InputAdornment**
   - [style] increase font size when `size="small`
 - **Unstable_Link**
   - [fix] vertical alignment when `component="button"`
+- **Unstable_RadioGroupField**
+  - [fix] not forwarding the `id` prop to the underlying element
+- **Unstable_RadioGroupField**
+  - see **Unstable_FormControl**, **Unstable_RadioGroup**
 - **Unstable_Select**
   - see **Unstable_Input** for changes affecting default value of `input`
+  - [feat] improve Form Control API-integration
+- **Unstable_TextField**
+  - see **Unstable_FormControl**, **Unstable_Input**, **Unstable_Select**
+  - [DEPRECATION] deprecated; compose the Form Control pattern directly
+- **useFormControl_unstable**
+  - [feat] add `filled`, `focused`, `inputId`, `labelId`, `helperTextId` to parameters
+  - [BREAKING] remove `id` from result
+    - _migration: use `inputId` parameter_
+  - [feat] add `inputId` to result
 
 ## [v2.0.0-alpha.10](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.9...v2.0.0-alpha.10) (2023-03-13)
 

--- a/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.tsx
+++ b/libs/spark/src/Unstable_CheckboxGroupField/Unstable_CheckboxGroupField.tsx
@@ -20,14 +20,6 @@ export interface Unstable_CheckboxGroupFieldProps
    */
   children: ReactNode;
   /**
-   * If `true`, the label, control, and helper text will be disabled.
-   */
-  disabled?: boolean;
-  /**
-   * If `true`, the label, control, and helper text will be displayed in an error state.
-   */
-  error?: boolean;
-  /**
    * Props applied to the `FormHelperText` element.
    */
   FormHelperTextProps?: Partial<Unstable_FormHelperTextProps>;
@@ -35,10 +27,6 @@ export interface Unstable_CheckboxGroupFieldProps
    * Props applied to the `FormLabel` element.
    */
   FormLabelProps?: Partial<Unstable_FormLabelProps>;
-  /**
-   * If `true`, the input will take up the full width of its container.
-   */
-  fullWidth?: boolean;
   /**
    * The helper text content.
    */
@@ -56,10 +44,6 @@ export interface Unstable_CheckboxGroupFieldProps
    */
   FormGroupProps?: Partial<Unstable_FormGroupProps>;
   /**
-   * If `true`, the label is displayed as required and the controls will be required.
-   */
-  required?: boolean;
-  /**
    * Display the `FormGroup` in a row.
    */
   row?: boolean;
@@ -71,17 +55,13 @@ const Unstable_CheckboxGroupField = forwardRef<
 >(function Unstable_CheckboxGroupField(props, ref) {
   const {
     children,
-    disabled = false,
-    error = false,
     FormHelperTextProps,
     FormLabelProps,
-    fullWidth = false,
     helperText,
     id: idProp,
     label,
     name,
     FormGroupProps,
-    required = false,
     row,
     ...other
   } = props;
@@ -93,17 +73,16 @@ const Unstable_CheckboxGroupField = forwardRef<
 
   return (
     <Unstable_FormControl
-      aria-describedby={helperTextId}
-      aria-labelledby={labelId}
       component="fieldset"
-      disabled={disabled}
-      error={error}
-      fullWidth={fullWidth}
       id={id}
+      inputId={id}
+      labelId={labelId}
+      helperTextId={helperTextId}
+      role="group"
       // @ts-expect-error not identical types
       ref={ref as unknown as RefObject<HTMLFieldSetElement>}
-      required={required}
-      role="group"
+      {...(helperTextId && { 'aria-describedby': helperTextId })}
+      {...(labelId && { 'aria-labelledby': labelId })}
       {...other}
     >
       {label ? (
@@ -111,7 +90,6 @@ const Unstable_CheckboxGroupField = forwardRef<
         <span>
           <Unstable_FormLabel
             component="legend"
-            id={labelId}
             // @ts-expect-error not identical types
             ref={FormLabelProps?.ref as unknown as RefObject<HTMLLegendElement>}
             {...FormLabelProps}
@@ -126,7 +104,7 @@ const Unstable_CheckboxGroupField = forwardRef<
       </Unstable_FormGroup>
 
       {helperText ? (
-        <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
+        <Unstable_FormHelperText {...FormHelperTextProps}>
           {helperText}
         </Unstable_FormHelperText>
       ) : null}

--- a/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
+++ b/libs/spark/src/Unstable_FormControl/Unstable_FormControl.tsx
@@ -6,6 +6,7 @@ import { OverridableComponent, OverrideProps, useId } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import clsx from 'clsx';
 import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
+import { FormControlProperties_Unstable } from '../useFormControl_unstable';
 
 export interface Unstable_FormControlTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -15,16 +16,38 @@ export interface Unstable_FormControlTypeMap<
   props: P &
     Omit<
       MuiFormControlProps,
-      'classes' | 'color' | 'hiddenLabel' | 'margin' | 'size' | 'variant'
+      | 'classes'
+      | 'color'
+      | 'hiddenLabel'
+      | 'margin'
+      | 'variant'
+      // form control
+      | 'disabled'
+      | 'error'
+      | 'focused'
+      | 'fullWidth'
+      | 'required'
+      | 'size'
+    > &
+    Partial<
+      Pick<
+        FormControlProperties_Unstable,
+        | 'inputId'
+        | 'labelId'
+        | 'helperTextId'
+        | 'disabled'
+        | 'error'
+        | 'focused'
+        | 'fullWidth'
+        | 'required'
+        | 'size'
+        | 'success'
+      >
     > & {
       /**
-       * If `true`, the descendant components should be displayed in an success state.
+       * The id of the root, wrapper element.
        */
-      success?: boolean;
-      /**
-       * The size of the descendant components.
-       */
-      size?: 'medium' | 'small';
+      id?: string;
     };
   defaultComponent: D;
   classKey: Unstable_FormControlClassKey;
@@ -69,19 +92,25 @@ const Unstable_FormControl: OverridableComponent<Unstable_FormControlTypeMap> =
       classes,
       color: _color,
       fullWidth,
-      id: idProp,
+      inputId: inputIdProp,
+      labelId: labelIdProp,
+      helperTextId: helperTextIdProp,
       size = 'medium',
       success = false,
       ...other
     } = props;
 
-    const id = useId(idProp);
-    const labelId = `${id}-label`;
-    const helperTextId = `${id}-helper-text`;
+    const inputId = useId(inputIdProp);
 
     return (
       <Unstable_FormControlExtraContext.Provider
-        value={{ helperTextId, id, labelId, success, size }}
+        value={{
+          inputId,
+          labelId: labelIdProp,
+          helperTextId: helperTextIdProp,
+          success,
+          size,
+        }}
       >
         <MuiFormControl
           classes={{

--- a/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
+++ b/libs/spark/src/Unstable_FormControlExtraContext/Unstable_FormControlExtraContext.ts
@@ -1,33 +1,19 @@
 import { createContext } from 'react';
+import { FormControlProperties_Unstable } from '../useFormControl_unstable';
 
-export interface Unstable_FormControlExtraContextValue {
-  /**
-   * The id of the descendent input.
-   */
-  id?: string;
-  /**
-   * The id of the descendent label.
-   */
-  labelId?: string;
-  /**
-   * The id of the descendent helper text.
-   */
-  helperTextId?: string;
-  /**
-   * The size of the descendant components
-   */
-  size?: 'medium' | 'small';
-  /**
-   * If `true`, then descendant components will be displayed in a success state.
-   */
-  success?: boolean;
-}
+/** internal */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unstable_FormControlExtraContextValue
+  extends Partial<
+    Pick<
+      FormControlProperties_Unstable,
+      'inputId' | 'labelId' | 'helperTextId' | 'size' | 'success'
+    >
+  > {}
 
+/** internal */
 const Unstable_FormControlExtraContext =
-  createContext<Unstable_FormControlExtraContextValue>({
-    size: 'medium',
-    success: false,
-  });
+  createContext<Unstable_FormControlExtraContextValue | null>(null);
 
 if (process.env.NODE_ENV !== 'production') {
   Unstable_FormControlExtraContext.displayName = 'FormControlExtraContext';

--- a/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
+++ b/libs/spark/src/Unstable_FormHelperText/Unstable_FormHelperText.tsx
@@ -3,51 +3,35 @@ import clsx from 'clsx';
 import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import { buildVariant } from '../theme/typography';
-import useFormControl_unstable from '../useFormControl_unstable';
+import useFormControl_unstable, {
+  FormControlProperties_Unstable,
+} from '../useFormControl_unstable';
 
 export interface Unstable_FormHelperTextTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
   P = {},
   D extends ElementType = 'p'
 > {
-  props: P & {
-    /**
-     * The content of the component.
-     */
-    children?: React.ReactNode;
-    /**
-     * If `true`, the helper text should be displayed in a disabled state.
-     */
-    disabled?: boolean;
-    /**
-     * If `true`, helper text should be displayed in an error state.
-     */
-    error?: boolean;
-    /**
-     * If `true`, the helper text should use filled classes key.
-     */
-    filled?: boolean;
-    /**
-     * If `true`, the helper text should use focused classes key.
-     */
-    focused?: boolean;
-    /**
-     * Icon placed before the children.
-     */
-    leadingIcon?: ReactNode;
-    /**
-     * If `true`, the component reserves one line height for displaying a future message.
-     */
-    reserveLineHeight?: boolean;
-    /**
-     * If `true`, the helper text should use required classes key.
-     */
-    required?: boolean;
-    /**
-     * The size of the component.
-     */
-    size?: 'medium' | 'small';
-  };
+  props: P &
+    Partial<
+      Pick<
+        FormControlProperties_Unstable,
+        'disabled' | 'error' | 'filled' | 'focused' | 'required' | 'size'
+      >
+    > & {
+      /**
+       * The content of the component.
+       */
+      children?: React.ReactNode;
+      /**
+       * Icon placed before the children.
+       */
+      leadingIcon?: ReactNode;
+      /**
+       * If `true`, the component reserves one line height for displaying a future message.
+       */
+      reserveLineHeight?: boolean;
+    };
   defaultComponent: D;
   classKey: Unstable_FormHelperTextClassKey;
 }
@@ -135,19 +119,28 @@ const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeM
       className,
       // @ts-expect-error not picked up as a prop from `OverridableComponent`
       component: Component = 'p',
-      disabled: _disabled,
-      error: _error,
-      filled: _filled,
-      focused: _focused,
-      id: idProp,
       leadingIcon,
       reserveLineHeight,
-      required: _required,
-      size: _size,
+      // form control
+      disabled: disabledProp,
+      error: errorProp,
+      filled: filledProp,
+      focused: focusedProp,
+      id: idProp,
+      required: requiredProp,
+      size: sizeProp,
       ...other
     } = props;
 
-    const formControl = useFormControl_unstable(props);
+    const formControl = useFormControl_unstable({
+      disabled: disabledProp,
+      error: errorProp,
+      filled: filledProp,
+      focused: focusedProp,
+      helperTextId: idProp,
+      required: requiredProp,
+      size: sizeProp,
+    });
 
     return (
       <Component
@@ -162,7 +155,7 @@ const Unstable_FormHelperText: OverridableComponent<Unstable_FormHelperTextTypeM
           },
           className
         )}
-        id={idProp || formControl.helperTextId}
+        id={formControl.helperTextId}
         ref={ref}
         {...other}
       >

--- a/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
+++ b/libs/spark/src/Unstable_FormLabel/Unstable_FormLabel.tsx
@@ -6,7 +6,9 @@ import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 import clsx from 'clsx';
 import { buildVariant } from '../theme/typography';
-import useFormControl_unstable from '../useFormControl_unstable';
+import useFormControl_unstable, {
+  FormControlProperties_Unstable,
+} from '../useFormControl_unstable';
 
 export interface Unstable_FormLabelTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -14,12 +16,22 @@ export interface Unstable_FormLabelTypeMap<
   D extends ElementType = 'label'
 > {
   props: P &
-    Omit<MuiFormLabelProps, 'classes' | 'color' | 'filled'> & {
-      /**
-       * The size of the label.
-       */
-      size?: 'medium' | 'small';
-    };
+    Omit<
+      MuiFormLabelProps,
+      | 'classes'
+      | 'color'
+      | 'disabled'
+      | 'error'
+      | 'filled'
+      | 'focused'
+      | 'required'
+    > &
+    Partial<
+      Pick<
+        FormControlProperties_Unstable,
+        'disabled' | 'error' | 'filled' | 'focused' | 'required' | 'size'
+      >
+    >;
   defaultComponent: D;
   classKey: Unstable_FormLabelClassKey;
 }
@@ -89,13 +101,28 @@ const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> =
     const {
       classes,
       color: _color,
+      // form control
+      disabled: disabledProp,
+      error: errorProp,
+      filled: filledProp,
+      focused: focusedProp,
       htmlFor: htmlForProp,
       id: idProp,
-      size: _size,
+      required: requiredProp,
+      size: sizeProp,
       ...other
     } = props;
 
-    const formControl = useFormControl_unstable(props);
+    const formControl = useFormControl_unstable({
+      disabled: disabledProp,
+      error: errorProp,
+      filled: filledProp,
+      focused: focusedProp,
+      inputId: htmlForProp,
+      labelId: idProp,
+      required: requiredProp,
+      size: sizeProp,
+    });
 
     return (
       <MuiFormLabel
@@ -106,8 +133,13 @@ const Unstable_FormLabel: OverridableComponent<Unstable_FormLabelTypeMap> =
           ),
           asterisk: classes.asterisk,
         }}
-        htmlFor={htmlForProp || formControl.id}
-        id={idProp || formControl.labelId}
+        disabled={formControl.disabled}
+        error={formControl.error}
+        filled={formControl.filled}
+        focused={formControl.focused}
+        htmlFor={formControl.inputId}
+        id={formControl.labelId}
+        required={formControl.required}
         ref={ref}
         {...other}
       />

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -7,7 +7,9 @@ import {
 import Unstable_InputAdornment from '../Unstable_InputAdornment';
 import withStyles, { StyledComponentProps, Styles } from '../withStyles';
 import { buildVariant } from '../theme/typography';
-import useFormControl_unstable from '../useFormControl_unstable';
+import useFormControl_unstable, {
+  FormControlProperties_Unstable,
+} from '../useFormControl_unstable';
 
 export interface Unstable_InputProps
   extends Omit<
@@ -20,8 +22,19 @@ export interface Unstable_InputProps
       | 'rowsMax'
       | 'rowsMin'
       | 'startAdornment'
+      // form control
+      | 'disabled'
+      | 'error'
+      | 'fullWidth'
+      | 'required'
     >,
-    StyledComponentProps<Unstable_InputClassKey> {
+    StyledComponentProps<Unstable_InputClassKey>,
+    Partial<
+      Pick<
+        FormControlProperties_Unstable,
+        'disabled' | 'error' | 'fullWidth' | 'required' | 'size' | 'success'
+      >
+    > {
   /**
    * The content of the `startAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
    */
@@ -31,27 +44,19 @@ export interface Unstable_InputProps
    */
   renderLeadingEl?: (
     props: { children: ReactNode; className?: string },
-    state: { size: 'medium' | 'small' }
+    state: Pick<FormControlProperties_Unstable, 'size'>
   ) => ReactNode;
   /**
    * Render the trailing element.
    */
   renderTrailingEl?: (
     props: { children: ReactNode; className?: string },
-    state: { size: 'medium' | 'small' }
+    state: Pick<FormControlProperties_Unstable, 'size'>
   ) => ReactNode;
   /**
    * The content of the `endAdornment` (an InputAdornment), usually an Icon, IconButton, or string.
    */
   trailingEl?: ReactNode;
-  /**
-   * If `true`, the input will indicate a success.
-   */
-  success?: boolean;
-  /**
-   * The size of the input.
-   */
-  size?: 'medium' | 'small';
 }
 
 export type Unstable_InputClassKey =
@@ -193,7 +198,7 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
 
 const defaultRenderLeadingEl: Unstable_InputProps['renderLeadingEl'] = (
   props: { children: ReactNode; className?: string },
-  state: { size: 'medium' | 'small' }
+  state: Pick<FormControlProperties_Unstable, 'size'>
 ) => {
   return (
     <Unstable_InputAdornment position="start" size={state.size} {...props} />
@@ -202,7 +207,7 @@ const defaultRenderLeadingEl: Unstable_InputProps['renderLeadingEl'] = (
 
 const defaultRenderTrailingEl: Unstable_InputProps['renderTrailingEl'] = (
   props: { children: ReactNode; className?: string },
-  state: { size: 'medium' | 'small' }
+  state: Pick<FormControlProperties_Unstable, 'size'>
 ) => {
   return (
     <Unstable_InputAdornment position="end" size={state.size} {...props} />
@@ -212,33 +217,46 @@ const defaultRenderTrailingEl: Unstable_InputProps['renderTrailingEl'] = (
 const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
   function Unstable_Input(props, ref) {
     const {
-      'aria-describedby': ariaDescribedByProp,
       classes,
-      id: idProp,
-      fullWidth,
       leadingEl,
       multiline,
       placeholder,
       renderLeadingEl = defaultRenderLeadingEl,
       renderTrailingEl = defaultRenderTrailingEl,
-      size: _size,
-      success: _success,
       trailingEl,
       value,
+      // form control
+      'aria-describedby': ariaDescribedByProp,
+      disabled: disabledProp,
+      error: errorProp,
+      fullWidth: fullWidthProp,
+      id: idProp,
+      required: requiredProp,
+      size: sizeProp,
+      success: successProp,
       ...other
     } = props;
 
-    const formControl = useFormControl_unstable(props);
+    const formControl = useFormControl_unstable({
+      disabled: disabledProp,
+      error: errorProp,
+      fullWidth: fullWidthProp,
+      helperTextId: ariaDescribedByProp,
+      inputId: idProp,
+      required: requiredProp,
+      size: sizeProp,
+      success: successProp,
+    });
 
     return (
       <MuiInputBase
-        aria-describedby={ariaDescribedByProp || formControl.helperTextId}
+        aria-describedby={formControl.helperTextId}
         classes={{
           root: clsx(
             classes.root,
             classes[`private-root-size-${formControl.size}`],
             {
-              [classes['private-root-fullWidth']]: fullWidth,
+              [classes['private-root-fullWidth']]: formControl.fullWidth,
               [classes['private-root-value']]: value,
               [classes['private-root-multiline']]: multiline,
               [classes[`private-root-size-${formControl.size}-leadingEl`]]:
@@ -258,6 +276,7 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
             }
           ),
         }}
+        disabled={formControl.disabled}
         endAdornment={
           trailingEl
             ? renderTrailingEl(
@@ -269,9 +288,12 @@ const Unstable_Input = forwardRef<unknown, Unstable_InputProps>(
               )
             : undefined
         }
-        id={idProp || formControl.id}
+        error={formControl.error}
+        fullWidth={formControl.fullWidth}
+        id={formControl.inputId}
         multiline={multiline}
         placeholder={placeholder}
+        required={formControl.required}
         startAdornment={
           leadingEl
             ? renderLeadingEl(

--- a/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
+++ b/libs/spark/src/Unstable_InputAdornment/Unstable_InputAdornment.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
 import React, { ElementType, forwardRef } from 'react';
 import { buildVariant } from '../theme/typography';
-import useFormControl_unstable from '../useFormControl_unstable';
+import useFormControl_unstable, {
+  FormControlProperties_Unstable,
+} from '../useFormControl_unstable';
 import { OverridableComponent, OverrideProps } from '../utils';
 import withStyles, { Styles } from '../withStyles';
 
@@ -10,16 +12,13 @@ export interface Unstable_InputAdornmentTypeMap<
   P = {},
   D extends ElementType = 'div'
 > {
-  props: P & {
-    /**
-     * The position of the adornment in the Input element.
-     */
-    position: 'start' | 'end';
-    /**
-     * The size of the adornment.
-     */
-    size?: 'medium' | 'small';
-  };
+  props: P &
+    Partial<Pick<FormControlProperties_Unstable, 'size'>> & {
+      /**
+       * The position of the adornment in the Input element.
+       */
+      position: 'start' | 'end';
+    };
   defaultComponent: D;
   classKey: Unstable_InputAdornmentClassKey;
 }
@@ -95,11 +94,12 @@ const Unstable_InputAdornment: OverridableComponent<Unstable_InputAdornmentTypeM
       // @ts-expect-error prop does not exist :/
       component: Component = 'div',
       position,
-      size: _size,
+      // form control
+      size: sizeProp,
       ...other
     } = props;
 
-    const formControl = useFormControl_unstable(props);
+    const formControl = useFormControl_unstable({ size: sizeProp });
 
     return (
       <Component

--- a/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
+++ b/libs/spark/src/Unstable_RadioGroup/Unstable_RadioGroup.tsx
@@ -30,7 +30,6 @@ const Unstable_RadioGroup = forwardRef<unknown, Unstable_RadioGroupProps>(
   function Unstable_RadioGroup(props, ref) {
     const {
       classes,
-      id: idProp,
       // underscored props will be processed directly from `props` by `formControlState` below
       required: _required,
       ...other

--- a/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.tsx
+++ b/libs/spark/src/Unstable_RadioGroupField/Unstable_RadioGroupField.tsx
@@ -24,14 +24,6 @@ export interface Unstable_RadioGroupFieldProps
    */
   defaultValue?: Unstable_RadioGroupProps['defaultValue'];
   /**
-   * If `true`, the label, control, and helper text will be disabled.
-   */
-  disabled?: boolean;
-  /**
-   * If `true`, the label, control, and helper text will be displayed in an error state.
-   */
-  error?: boolean;
-  /**
    * Props applied to the `FormHelperText` element.
    */
   FormHelperTextProps?: Partial<Unstable_FormHelperTextProps>;
@@ -40,17 +32,9 @@ export interface Unstable_RadioGroupFieldProps
    */
   FormLabelProps?: Partial<Unstable_FormLabelProps>;
   /**
-   * If `true`, the label, control, and helper text will take up the full width of its container.
-   */
-  fullWidth?: boolean;
-  /**
    * The helper text content.
    */
   helperText?: ReactNode;
-  /**
-   * The `id` attribute of the `RadioGroup` element.
-   */
-  id?: string;
   /**
    * The label content.
    */
@@ -71,10 +55,6 @@ export interface Unstable_RadioGroupFieldProps
    */
   RadioGroupProps?: Partial<Unstable_RadioGroupProps>;
   /**
-   * If `true`, the label is displayed as required and the controls will be required.
-   */
-  required?: boolean;
-  /**
    * Display the `RadioGroup` in a row.
    */
   row?: boolean;
@@ -91,18 +71,14 @@ const Unstable_RadioGroupField = forwardRef<
   const {
     children,
     defaultValue,
-    disabled = false,
-    error = false,
     FormHelperTextProps,
     FormLabelProps,
-    fullWidth = false,
     helperText,
     id: idProp,
     label,
     name,
     onChange,
     RadioGroupProps,
-    required = false,
     row,
     value,
     ...other
@@ -115,25 +91,26 @@ const Unstable_RadioGroupField = forwardRef<
 
   return (
     <Unstable_FormControl
-      disabled={disabled}
-      error={error}
-      fullWidth={fullWidth}
-      ref={ref as unknown as RefObject<HTMLDivElement>}
-      required={required}
+      component="fieldset"
+      id={id}
+      inputId={id}
+      labelId={labelId}
+      helperTextId={helperTextId}
+      role="radiogroup"
+      // @ts-expect-error not identical types
+      ref={ref as unknown as RefObject<HTMLFieldSetElement>}
+      {...(helperTextId && { 'aria-describedby': helperTextId })}
+      {...(labelId && { 'aria-labelledby': labelId })}
       {...other}
     >
       {label ? (
-        <Unstable_FormLabel htmlFor={id} id={labelId} {...FormLabelProps}>
-          {label}
-        </Unstable_FormLabel>
+        <Unstable_FormLabel {...FormLabelProps}>{label}</Unstable_FormLabel>
       ) : null}
 
       <Unstable_RadioGroup
-        aria-describedby={helperTextId}
-        aria-labelledby={labelId}
         defaultValue={defaultValue}
-        id={id}
         onChange={onChange}
+        role={undefined}
         row={row}
         value={value}
         {...RadioGroupProps}
@@ -142,7 +119,7 @@ const Unstable_RadioGroupField = forwardRef<
       </Unstable_RadioGroup>
 
       {helperText ? (
-        <Unstable_FormHelperText id={helperTextId} {...FormHelperTextProps}>
+        <Unstable_FormHelperText {...FormHelperTextProps}>
           {helperText}
         </Unstable_FormHelperText>
       ) : null}

--- a/libs/spark/src/Unstable_Select/Unstable_Select.tsx
+++ b/libs/spark/src/Unstable_Select/Unstable_Select.tsx
@@ -174,15 +174,12 @@ const styles: Styles<Unstable_SelectClassKey | PrivateClassKey> = (theme) => {
 const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
   function Unstable_Select(props, ref) {
     const {
-      'aria-describedby': ariaDescribedByProp,
       autoWidth = false,
       children,
       classes,
-      disabled,
       displayEmpty = true,
       getTagProps,
       IconComponent = Unstable_ChevronDown,
-      id: idProp,
       input,
       inputProps,
       labelId: labelIdProp,
@@ -195,13 +192,29 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
       preventMultipleOverflow = false,
       renderValue: renderValueProp,
       renderValueAsTag = false,
-      size: _size,
       SelectDisplayProps,
       value,
+      // form control
+      'aria-describedby': ariaDescribedByProp,
+      disabled: disabledProp,
+      error: errorProp,
+      fullWidth: fullWidthProp,
+      id: idProp,
+      required: requiredProp,
+      size: sizeProp,
+      success: successProp,
       ...other
     } = props;
 
-    const formControl = useFormControl_unstable(props);
+    const formControl = useFormControl_unstable({
+      disabled: disabledProp,
+      error: errorProp,
+      fullWidth: fullWidthProp,
+      inputId: idProp,
+      required: requiredProp,
+      size: sizeProp,
+      success: successProp,
+    });
 
     const {
       getContentAnchorEl: getContentAnchorElMenuProp = null,
@@ -245,7 +258,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
                 <Unstable_Tag
                   key={value}
                   label={value}
-                  disabled={disabled}
+                  disabled={formControl.disabled}
                   {...(getTagProps && getTagProps({ value, index }))}
                 />
               ))}
@@ -264,8 +277,10 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
     }
 
     return cloneElement(InputComponent, {
-      'aria-describedby': ariaDescribedByProp || formControl.helperTextId,
-      disabled,
+      'aria-describedby': formControl.helperTextId,
+      disabled: formControl.disabled,
+      error: formControl.error,
+      fullWidth: formControl.fullWidth,
       inputComponent,
       inputProps: {
         children,
@@ -273,11 +288,11 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
         type: undefined, // We render a select. We can ignore the type provided by the `Input`.
         multiple,
         ...(native
-          ? { id: idProp || formControl.id }
+          ? { id: formControl.inputId }
           : {
               autoWidth,
               displayEmpty,
-              labelId: labelIdProp || formControl.labelId,
+              labelId: formControl.labelId,
               MenuProps: {
                 ...MenuProps,
                 anchorOrigin: anchorOriginMenuProp,
@@ -309,7 +324,7 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
               open,
               renderValue,
               SelectDisplayProps: {
-                id: idProp || formControl.id,
+                id: formControl.inputId,
                 ...SelectDisplayProps,
               },
             }),
@@ -338,7 +353,9 @@ const Unstable_Select = forwardRef<unknown, Unstable_SelectProps>(
         },
         ...(input ? input.props.inputProps : {}),
       },
+      required: formControl.required,
       size: formControl.size,
+      success: formControl.success,
       value,
       ref,
       ...other,

--- a/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
+++ b/libs/spark/src/Unstable_TextField/Unstable_TextField.tsx
@@ -42,14 +42,6 @@ export interface Unstable_TextFieldProps
    */
   defaultValue?: unknown;
   /**
-   * If `true`, the `input` element will be disabled.
-   */
-  disabled?: boolean;
-  /**
-   * If `true`, the label will be displayed in an error state.
-   */
-  error?: boolean;
-  /**
    * Props applied to the `FormHelperText` element.
    */
   FormHelperTextProps?: Partial<Unstable_FormHelperTextProps>;
@@ -57,10 +49,6 @@ export interface Unstable_TextFieldProps
    * Props applied to the `FormLabel` element.
    */
   FormLabelProps?: Partial<Unstable_FormLabelProps>;
-  /**
-   * If `true`, the input will take up the full width of its container.
-   */
-  fullWidth?: boolean;
   /**
    * The helper text content.
    */
@@ -113,10 +101,6 @@ export interface Unstable_TextFieldProps
    */
   placeholder?: string;
   /**
-   * If `true`, the label is displayed as required and the `input` element` will be required.
-   */
-  required?: boolean;
-  /**
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows?: string | number;
@@ -147,6 +131,9 @@ export interface Unstable_TextFieldProps
   value?: unknown;
 }
 
+/**
+ * @deprecated Compose the Form Control pattern directly.
+ */
 const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
   function Unstable_TextField(props, ref) {
     const {
@@ -154,10 +141,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       autoFocus = false,
       children,
       defaultValue,
-      disabled = false,
-      error = false,
       FormHelperTextProps,
-      fullWidth = false,
       helperText,
       FormLabelProps,
       inputProps,
@@ -171,13 +155,10 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       onChange,
       onFocus,
       placeholder,
-      required = false,
       maxRows,
       minRows,
       select = false,
       SelectProps,
-      size,
-      success,
       trailingEl,
       type,
       value,
@@ -206,9 +187,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
       <Unstable_Input
         autoComplete={autoComplete}
         autoFocus={autoFocus}
-        disabled={disabled}
         defaultValue={defaultValue}
-        fullWidth={fullWidth}
         leadingEl={leadingEl}
         multiline={multiline}
         name={name}
@@ -230,13 +209,7 @@ const Unstable_TextField = forwardRef<unknown, Unstable_TextFieldProps>(
 
     return (
       <Unstable_FormControl
-        disabled={disabled}
-        error={error}
-        fullWidth={fullWidth}
         ref={ref as unknown as RefObject<HTMLDivElement>}
-        required={required}
-        size={size}
-        success={success}
         {...other}
       >
         {label ? (

--- a/libs/spark/src/useFormControlExtra_unstable/index.ts
+++ b/libs/spark/src/useFormControlExtra_unstable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useFormControlExtra_unstable';

--- a/libs/spark/src/useFormControlExtra_unstable/useFormControlExtra_unstable.ts
+++ b/libs/spark/src/useFormControlExtra_unstable/useFormControlExtra_unstable.ts
@@ -1,0 +1,78 @@
+import { useContext } from 'react';
+import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
+import {
+  DEFAULT_FORM_CONTROL_API_VALUES,
+  FormControlProperties_Unstable,
+} from '../useFormControl_unstable';
+
+/** internal */
+export type UseFormControlExtra_UnstableParams = Partial<
+  Pick<
+    FormControlProperties_Unstable,
+    'inputId' | 'labelId' | 'helperTextId' | 'size' | 'success'
+  >
+>;
+
+/** internal */
+export type UseFormControlExtra_UnstableResult = Pick<
+  FormControlProperties_Unstable,
+  'inputId' | 'labelId' | 'helperTextId' | 'size' | 'success'
+>;
+
+/** internal */
+const useFormControlExtra_unstable = (
+  params: UseFormControlExtra_UnstableParams
+): UseFormControlExtra_UnstableResult => {
+  const formControlExtra = useContext(Unstable_FormControlExtraContext);
+
+  // always let consumer override => prefer passed parameters
+
+  let inputId: FormControlProperties_Unstable['inputId'];
+  if (typeof params.inputId !== 'undefined') {
+    inputId = params.inputId;
+  } else if (formControlExtra) {
+    inputId = formControlExtra.inputId;
+  }
+
+  let labelId: FormControlProperties_Unstable['labelId'];
+  if (typeof params.labelId !== 'undefined') {
+    labelId = params.labelId;
+  } else if (inputId) {
+    labelId = `${inputId}-label`;
+  }
+
+  let helperTextId: FormControlProperties_Unstable['helperTextId'];
+  if (typeof params.helperTextId !== 'undefined') {
+    helperTextId = params.helperTextId;
+  } else if (inputId) {
+    helperTextId = `${inputId}-helper-text`;
+  }
+
+  let size: FormControlProperties_Unstable['size'];
+  if (typeof params.size !== 'undefined') {
+    size = params.size;
+  } else if (formControlExtra) {
+    size = formControlExtra.size;
+  } else {
+    size = DEFAULT_FORM_CONTROL_API_VALUES.size;
+  }
+
+  let success: FormControlProperties_Unstable['success'];
+  if (typeof params.success !== 'undefined') {
+    success = params.success;
+  } else if (formControlExtra) {
+    success = formControlExtra.success;
+  } else {
+    success = DEFAULT_FORM_CONTROL_API_VALUES.success;
+  }
+
+  return {
+    inputId,
+    labelId,
+    helperTextId,
+    size,
+    success,
+  };
+};
+
+export default useFormControlExtra_unstable;

--- a/libs/spark/src/useFormControl_unstable/index.ts
+++ b/libs/spark/src/useFormControl_unstable/index.ts
@@ -1,1 +1,2 @@
 export { default } from './useFormControl_unstable';
+export * from './useFormControl_unstable';

--- a/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
+++ b/libs/spark/src/useFormControl_unstable/useFormControl_unstable.ts
@@ -1,27 +1,59 @@
 import { useFormControl } from '@material-ui/core/FormControl';
-import { useContext } from 'react';
-import Unstable_FormControlExtraContext from '../Unstable_FormControlExtraContext';
+import useFormControlExtra_unstable from '../useFormControlExtra_unstable/useFormControlExtra_unstable';
 
-export type UseFormControl_UnstableParams = {
-  disabled?: boolean;
-  error?: boolean;
-  fullWidth?: boolean;
-  required?: boolean;
-  size?: 'medium' | 'small';
-  success?: boolean;
-};
+export type UseFormControl_UnstableParams = Partial<
+  Omit<
+    FormControlProperties_Unstable,
+    'onBlur' | 'onEmpty' | 'onFilled' | 'onFocus'
+  >
+>;
 
-export type UseFormControl_UnstableResult = {
+export type UseFormControl_UnstableResult = FormControlProperties_Unstable;
+
+export type FormControlProperties_Unstable = {
+  /**
+   * Whether the components display in a disabled state.
+   */
   disabled: boolean;
+  /**
+   * Whether the components display in an error state.
+   */
   error: boolean;
+  /**
+   * Whether the components take up the full width of the container.
+   */
   fullWidth: boolean;
+  /**
+   * Whether the components display as required.
+   */
   required: boolean;
+  /**
+   * The size of the components.
+   */
   size: 'medium' | 'small';
+  /**
+   * Whether the components display in a success state.
+   */
   success: boolean;
-  id?: string;
+  /**
+   * The id of the input element.
+   */
+  inputId?: string;
+  /**
+   * The id of the label element.
+   */
   labelId?: string;
+  /**
+   * The id of the helper text element.
+   */
   helperTextId?: string;
+  /**
+   * Whether the components display as filled.
+   */
   filled?: boolean;
+  /**
+   * Whether the components display as focused.
+   */
   focused?: boolean;
   onBlur?: () => void;
   onEmpty?: () => void;
@@ -29,52 +61,73 @@ export type UseFormControl_UnstableResult = {
   onFocus?: () => void;
 };
 
+export const DEFAULT_FORM_CONTROL_API_VALUES: Readonly<FormControlProperties_Unstable> =
+  {
+    disabled: false,
+    error: false,
+    fullWidth: false,
+    required: false,
+    row: false,
+    size: 'medium',
+    success: false,
+  };
+
 const useFormControl_unstable = (
   params: UseFormControl_UnstableParams
 ): UseFormControl_UnstableResult => {
   const muiFormControl = useFormControl();
-  const formControlExtra = useContext(Unstable_FormControlExtraContext);
+  const formControlExtra = useFormControlExtra_unstable(params);
 
-  let disabled = false;
-  if (typeof params.disabled === 'undefined' && muiFormControl) {
+  // always let consumer override => prefer passed parameters -- note, the consumer can't override mui form control internals given that their api doesn't accept parameters, so consumer overrides of those attributes are isolated to the single, calling component
+
+  let disabled: FormControlProperties_Unstable['disabled'];
+  if (typeof params.disabled !== 'undefined') {
+    disabled = params.disabled;
+  } else if (muiFormControl) {
     disabled = muiFormControl.disabled;
   } else {
-    disabled = params.disabled;
+    disabled = DEFAULT_FORM_CONTROL_API_VALUES.disabled;
   }
 
-  let error = false;
-  if (typeof params.error === 'undefined' && muiFormControl) {
+  let error: FormControlProperties_Unstable['error'];
+  if (typeof params.error !== 'undefined') {
+    error = params.error;
+  } else if (muiFormControl) {
     error = muiFormControl.error;
   } else {
-    error = params.error;
+    error = DEFAULT_FORM_CONTROL_API_VALUES.error;
   }
 
-  let fullWidth = false;
-  if (typeof params.fullWidth === 'undefined' && muiFormControl) {
+  let fullWidth: FormControlProperties_Unstable['fullWidth'];
+  if (typeof params.fullWidth !== 'undefined') {
+    fullWidth = params.fullWidth;
+  } else if (muiFormControl) {
     fullWidth = muiFormControl.fullWidth;
   } else {
-    fullWidth = params.fullWidth;
+    fullWidth = DEFAULT_FORM_CONTROL_API_VALUES.fullWidth;
   }
 
-  let required = false;
-  if (typeof params.required === 'undefined' && muiFormControl) {
+  let required: FormControlProperties_Unstable['required'];
+  if (typeof params.required !== 'undefined') {
+    required = params.required;
+  } else if (muiFormControl) {
     required = muiFormControl.required;
   } else {
-    required = params.required;
+    required = DEFAULT_FORM_CONTROL_API_VALUES.required;
   }
 
-  let size: 'medium' | 'small' = 'medium';
-  if (typeof params.size === 'undefined' && formControlExtra) {
-    size = formControlExtra.size;
-  } else {
-    size = params.size;
+  let filled: FormControlProperties_Unstable['filled'];
+  if (typeof params.filled !== 'undefined') {
+    filled = params.filled;
+  } else if (muiFormControl) {
+    filled = muiFormControl.filled;
   }
 
-  let success = false;
-  if (typeof params.success === 'undefined' && formControlExtra) {
-    success = formControlExtra.success;
-  } else {
-    success = params.success;
+  let focused: FormControlProperties_Unstable['focused'];
+  if (typeof params.focused !== 'undefined') {
+    focused = params.focused;
+  } else if (muiFormControl) {
+    focused = muiFormControl.focused;
   }
 
   return {
@@ -82,19 +135,18 @@ const useFormControl_unstable = (
     error,
     fullWidth,
     required,
-    size,
-    success,
-    // PDS : not prop-controlled
-    id: formControlExtra.id,
+    size: formControlExtra.size,
+    success: formControlExtra.success,
+    inputId: formControlExtra.inputId,
     labelId: formControlExtra.labelId,
     helperTextId: formControlExtra.helperTextId,
-    // MUI : internal-determined
-    filled: muiFormControl?.filled,
-    focused: muiFormControl?.focused,
-    onBlur: muiFormControl?.onBlur,
-    onEmpty: muiFormControl?.onEmpty,
-    onFilled: muiFormControl?.onFilled,
-    onFocus: muiFormControl?.onFocus,
+    ...(filled && { filled }),
+    ...(focused && { focused }),
+    // determined completely by mui-internals
+    ...(muiFormControl?.onBlur && { onBlur: muiFormControl?.onBlur }),
+    ...(muiFormControl?.onEmpty && { onEmpty: muiFormControl?.onEmpty }),
+    ...(muiFormControl?.onFilled && { onFilled: muiFormControl?.onFilled }),
+    ...(muiFormControl?.onFocus && { onBlur: muiFormControl?.onFocus }),
   };
 };
 


### PR DESCRIPTION
Create a central source of truth for values integrated into the Form Control paradigm / api. Will help to standardize prop values, descriptions, and handling. There are some possible edge cases of mishandling prop values that this PR solves, but they are not detailed here.