### PR TITLE
style(Autocomplete): misaligned input value when `size="small"`; changing width from default `renderMultipleValue`

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -6,7 +6,7 @@ API surface:
 
 - **Unstable_Autocomplete**
   - see **Unstable_Input** for changes affecting default value of `renderInput`
-  - [style] prevent width changes during value input when `multiple={true}` and the default value of `renderMultipleValue` is applied
+  - [style] prevent width changes from default `renderMultipleValue`
   - [feat] improve Form Control API-integration
 - **Unstable_CheckboxGroupField**
   - see **Unstable_FormControl**

--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -6,6 +6,7 @@ API surface:
 
 - **Unstable_Autocomplete**
   - see **Unstable_Input** for changes affecting default value of `renderInput`
+  - [style] prevent width changes during value input when `multiple={true}` and the default value of `renderMultipleValue` is applied
   - [feat] improve Form Control API-integration
 - **Unstable_CheckboxGroupField**
   - see **Unstable_FormControl**
@@ -20,9 +21,9 @@ API surface:
   - see **Unstable_InputAdornment** for changes affecting default values of `renderLeadingEl`, `renderTrailingEl`
   - [feat] improve Form Control API-integration
 - **Unstable_InputAdornment**
-  - [style] increase font size when `size="small`
+  - [style] increase font size when `size="small"`
 - **Unstable_Link**
-  - [fix] vertical alignment when `component="button"`
+  - [style] vertically align with inline text when `component="button"`
 - **Unstable_RadioGroupField**
   - [fix] not forwarding the `id` prop to the underlying element
 - **Unstable_RadioGroupField**

--- a/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.stories.tsx
+++ b/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.stories.tsx
@@ -307,6 +307,19 @@ OptionsPrimitiveMultipleValue1.args = {
 };
 OptionsPrimitiveMultipleValue1.storyName = 'multiple value=[..1]';
 
+export const OptionsPrimitiveMultipleValue1SizeSmall: StoryAutocomplete<
+  string,
+  true
+> = Template.bind({});
+OptionsPrimitiveMultipleValue1SizeSmall.args = {
+  options: '[..string]',
+  multiple: true,
+  value: ['value-1'],
+  size: 'small',
+};
+OptionsPrimitiveMultipleValue1SizeSmall.storyName =
+  'multiple value=[..1] size="small"';
+
 export const OptionsPrimitiveMultipleValue1InputPropsLeadingEl: StoryAutocomplete<
   string,
   true
@@ -637,6 +650,20 @@ TagsOptionsPrimitiveMultipleValue1InputPropsLeadingEl.args = {
 TagsOptionsPrimitiveMultipleValue1InputPropsLeadingEl.storyName =
   'tags multiple value=[..1] InputProps.leadingEl';
 
+export const TagsOptionsPrimitiveMultipleValue1SizeSmall: StoryAutocomplete<
+  string,
+  true
+> = Template.bind({});
+TagsOptionsPrimitiveMultipleValue1SizeSmall.args = {
+  options: '[..string]',
+  multiple: true,
+  value: ['value-1'],
+  tags: true,
+  size: 'small',
+};
+TagsOptionsPrimitiveMultipleValue1SizeSmall.storyName =
+  'tags multiple value=[..1] size="small"';
+
 export const TagsOptionsPrimitiveMultipleValue1Disabled: StoryAutocomplete<
   string,
   true
@@ -752,6 +779,18 @@ TagsOptionsPrimitiveMultipleValue2InputValueSizeSmall.args = {
 };
 TagsOptionsPrimitiveMultipleValue2InputValueSizeSmall.storyName =
   'tags multiple value=[..2] inputValue size=small';
+
+export const TagsOptionsPrimitiveMultipleValue3: StoryAutocomplete<
+  string,
+  true
+> = Template.bind({});
+TagsOptionsPrimitiveMultipleValue3.args = {
+  options: '[..string]',
+  multiple: true,
+  value: ['value-1', 'value-2', 'value-3'],
+  tags: true,
+};
+TagsOptionsPrimitiveMultipleValue3.storyName = 'tags multiple value=[..3]';
 
 export const TagsOptionsPrimitiveMultipleValue3Limit1: StoryAutocomplete<
   string,

--- a/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
+++ b/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
@@ -406,15 +406,12 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     alignItems: 'center',
     alignSelf: 'flex-start',
     color: theme.unstable_palette.text.subdued,
-    display: 'flex',
+    display: 'inline-flex',
     flexWrap: 'wrap',
     marginRight: 0,
     marginTop: 0,
     '.Mui-disabled > &': {
       color: theme.unstable_palette.text.disabled,
-    },
-    '& [class*="MuiSparkUnstable_InputAdornment-root"]': {
-      marginTop: 0,
     },
   },
   'private-inputLeadingEl-noWrap': {
@@ -432,6 +429,10 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     '& > *:first-child': {
       marginLeft: 8,
     },
+    '& [class*="MuiSparkUnstable_InputAdornment-root"]': {
+      marginBottom: 0,
+      marginTop: 0,
+    },
   },
   'private-inputLeadingEl-size-medium-tags': {
     marginTop: 8,
@@ -445,6 +446,10 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     marginTop: 10,
     '& > *:first-child': {
       marginLeft: 4,
+    },
+    '& [class*="MuiSparkUnstable_InputAdornment-root"]': {
+      marginBottom: -2,
+      marginTop: -2,
     },
   },
   'private-inputLeadingEl-size-small-tags': {

--- a/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
+++ b/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
@@ -315,6 +315,16 @@ type PrivateClassKey =
   | 'private-listbox-loadingOptions'
   | 'private-listbox-noOptions';
 
+const inputLeadingElSizeSmallTypography = buildVariant(
+  400,
+  14,
+  16,
+  undefined,
+  'none',
+  '"Inter", sans-serif',
+  "'cv05' 1, 'ss03' 1"
+);
+
 export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
   theme
 ) => ({
@@ -430,15 +440,7 @@ export const styles: Styles<Unstable_AutocompleteClassKey | PrivateClassKey> = (
     },
   },
   'private-inputLeadingEl-size-small': {
-    ...buildVariant(
-      400,
-      14,
-      16,
-      undefined,
-      'none',
-      '"Inter", sans-serif',
-      "'cv05' 1, 'ss03' 1"
-    ),
+    ...inputLeadingElSizeSmallTypography,
     gap: 2,
     marginTop: 10,
     '& > *:first-child': {

--- a/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
+++ b/libs/spark/src/Unstable_Autocomplete/Unstable_Autocomplete.tsx
@@ -719,7 +719,12 @@ const defaultRenderMultipleValue: Unstable_AutocompleteRenderMultipleValue<
     return (
       <span {...other}>
         {state.getOptionLabel(option)}
-        {state.inputValue || index < value.length - 1 ? ',' : ''}
+        {index < value.length - 1 ? ',' : null}
+        {index === value.length - 1 ? (
+          <span style={{ display: 'inline-block', width: '.25em' }}>
+            {state.inputValue ? ',' : null}
+          </span>
+        ) : null}
       </span>
     );
   });


### PR DESCRIPTION
Fix misalignment of input value when default value of `renderMultipleValue` is applied -- unreleased bug from #676, so not noted in changelog.

Fix changing width that can trigger cursor shift, or even overflow, when initially typing.