### PR TITLE
style(Input): keep background color constant on focus and hover

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -5,8 +5,15 @@
 API surface:
 
 - **Unstable_Autocomplete**
+  - see **Unstable_Input**
   - [style] simplify internal styles for better behavior with multiple value rendering
   - [feat] add `multipleValueWrapper` class key
+- **Unstable_Input**
+  - [style] keep background color constant on focus _and_ hover
+- **Unstable_Select**
+  - see **Unstable_Input**
+- **Unstable_TextField**
+  - see **Unstable_Input**
 
 ## [v2.0.0-alpha.11](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.10...v2.0.0-alpha.11) (2023-03-15)
 

--- a/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.stories.tsx
@@ -86,6 +86,10 @@ export const FocusVisible: Story = Template.bind({});
 FocusVisible.parameters = { pseudo: { focusVisible: true } };
 FocusVisible.storyName = ':focus-visible';
 
+export const FocusVisibleHover: Story = Template.bind({});
+FocusVisibleHover.parameters = { pseudo: { focusVisible: true, hover: true } };
+FocusVisibleHover.storyName = ':focus-visible :hover';
+
 export const Disabled: Story = Template.bind({});
 Disabled.args = { disabled: true };
 Disabled.storyName = 'disabled';
@@ -168,6 +172,13 @@ export const ValueFocusVisible: Story = Template.bind({});
 ValueFocusVisible.args = { value: 'Text' };
 ValueFocusVisible.parameters = { pseudo: { focusVisible: true } };
 ValueFocusVisible.storyName = 'value :focus-visible';
+
+export const ValueFocusVisibleHover: Story = Template.bind({});
+ValueFocusVisible.args = { value: 'Text' };
+ValueFocusVisibleHover.parameters = {
+  pseudo: { focusVisible: true, hover: true },
+};
+ValueFocusVisibleHover.storyName = 'value :focus-visible :hover';
 
 export const ValueDisabled: Story = Template.bind({});
 ValueDisabled.args = { value: 'Text', disabled: true };

--- a/libs/spark/src/Unstable_Input/Unstable_Input.tsx
+++ b/libs/spark/src/Unstable_Input/Unstable_Input.tsx
@@ -112,6 +112,9 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
       border: theme.unstable_borders.focus,
       boxShadow: theme.unstable_shadows.info,
     },
+    '&.Mui-focused:hover, &:focus-visible:hover': {
+      backgroundColor: theme.unstable_palette.neutral[0],
+    },
     /* error -- can get from internal context => can't condition on prop */
     '&.Mui-error': {
       border: theme.unstable_borders.error,
@@ -146,6 +149,9 @@ const styles: Styles<Unstable_InputClassKey | PrivateClassKey> = (theme) => ({
     border: theme.unstable_borders.bold,
     '&:hover': {
       backgroundColor: theme.unstable_palette.neutral[70],
+    },
+    '&.Mui-focused:hover, &:focus-visible:hover': {
+      backgroundColor: theme.unstable_palette.neutral[60],
     },
   },
   'private-root-multiline': {


### PR DESCRIPTION
Design request. Styling felt weird when the user would click into an input (triggering hover and focus visible), start typing (trigger value -> hover), and the input would look kind of disabled at first character because the filled hover is dark.