### PR TITLE
feat(LinearProgress): initial implementation (unstable)

### DIFF
--- a/libs/spark/CHANGELOG.md
+++ b/libs/spark/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.13...vNext) (YYYY-MM-DD)
 
-No changes.
+The naming scheme of v2 replacement components will change from "Unstable\_\<Component\>" to "\<Component\>\_unstable". The intention is to ease developer emotions about the "unstable" prefix by changing it to a suffix and to increase find-ability of components.
+
+API surface:
+
+- **LinearProgress_unstable**
+  - [feat] initial implementation
 
 ## [vNext](https://github.com/prenda-school/prenda-spark/compare/v2.0.0-alpha.12...v2.0.0-alpha.13) (2023-03-21)
 

--- a/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.stories.tsx
+++ b/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.stories.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import {
+  LinearProgress_unstable,
+  LinearProgressProps_unstable,
+  Unstable_Typography,
+} from '..';
+
+export const _retyped =
+  LinearProgress_unstable as typeof LinearProgress_unstable;
+
+export default {
+  title: '@ps/LinearProgress',
+  component: _retyped,
+  excludeStories: ['_retyped'],
+} as Meta;
+
+const Template = (args) => <LinearProgress_unstable {...args} />;
+
+type Story = DefaultStory<LinearProgressProps_unstable>;
+
+export const Default: Story = Template.bind({});
+Default.storyName = '(default)';
+
+export const Value0: Story = Template.bind({});
+Value0.args = { value: 0 };
+Value0.storyName = 'value=0';
+
+export const Value50: Story = Template.bind({});
+Value50.args = { value: 50 };
+Value50.storyName = 'value=50';
+
+export const Value100: Story = Template.bind({});
+Value100.args = { value: 100 };
+Value100.storyName = 'value=100';
+
+export const VariantDeterminateValueColorBlue: Story = Template.bind({});
+VariantDeterminateValueColorBlue.args = {
+  color: 'blue',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorBlue.storyName =
+  'variant=determinate value=50 color=blue';
+
+export const VariantDeterminateValueColorGreen: Story = Template.bind({});
+VariantDeterminateValueColorGreen.args = {
+  color: 'green',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorGreen.storyName =
+  'variant=determinate value=50 color=green';
+
+export const VariantDeterminateValueColorNeutral: Story = Template.bind({});
+VariantDeterminateValueColorNeutral.args = {
+  color: 'neutral',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorNeutral.storyName =
+  'variant=determinate value=50 color=neutral';
+
+export const VariantDeterminateValueColorPurple: Story = Template.bind({});
+VariantDeterminateValueColorPurple.args = {
+  color: 'purple',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorPurple.storyName =
+  'variant=determinate value=50 color=purple';
+
+export const VariantDeterminateValueColorRed: Story = Template.bind({});
+VariantDeterminateValueColorRed.args = {
+  color: 'red',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorRed.storyName =
+  'variant=determinate value=50 color=red';
+
+export const VariantDeterminateValueColorTeal: Story = Template.bind({});
+VariantDeterminateValueColorTeal.args = {
+  color: 'teal',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorTeal.storyName =
+  'variant=determinate value=50 color=teal';
+
+export const VariantDeterminateValueColorYellow: Story = Template.bind({});
+VariantDeterminateValueColorYellow.args = {
+  color: 'yellow',
+  value: 50,
+  variant: 'determinate',
+};
+VariantDeterminateValueColorYellow.storyName =
+  'variant=determinate value=50 color=yellow';
+
+export const VariantIndeterminate: Story = Template.bind({});
+VariantIndeterminate.args = { variant: 'indeterminate' };
+VariantIndeterminate.storyName = 'variant=indeterminate';
+
+export const VariantQuery: Story = Template.bind({});
+VariantQuery.args = { variant: 'query' };
+VariantQuery.storyName = 'variant=query';
+
+const labelElement = (
+  <Unstable_Typography component="span" variant="T14">
+    50%
+  </Unstable_Typography>
+);
+
+export const Value50Children: Story = Template.bind({});
+Value50Children.args = {
+  children: labelElement,
+  value: 50,
+};
+Value50Children.storyName = 'children value=50';
+
+export const Value50ChildrenLabelPlacementStart: Story = Template.bind({});
+Value50ChildrenLabelPlacementStart.args = {
+  children: labelElement,
+  value: 50,
+  labelPlacement: 'start',
+};
+Value50ChildrenLabelPlacementStart.storyName =
+  'children value=50 labelPlacement=start';
+
+export const Value50ChildrenLabelPlacementEnd: Story = Template.bind({});
+Value50ChildrenLabelPlacementEnd.args = {
+  children: labelElement,
+  value: 50,
+  labelPlacement: 'end',
+};
+Value50ChildrenLabelPlacementEnd.storyName =
+  'children value=50 labelPlacement=end';

--- a/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.test.tsx
+++ b/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import LinearProgress_unstable from './LinearProgress_unstable';
+
+describe('LinearProgress_unstable', () => {
+  it('Can render without ThemeProvider', () => {
+    const { baseElement } = render(<LinearProgress_unstable />);
+
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.tsx
+++ b/libs/spark/src/LinearProgress_unstable/LinearProgress_unstable.tsx
@@ -1,0 +1,194 @@
+import {
+  default as MuiLinearProgress,
+  LinearProgressProps as MuiLinearProgressProps,
+} from '@material-ui/core/LinearProgress';
+import clsx from 'clsx';
+import React, { forwardRef, isValidElement, ReactNode } from 'react';
+import { StandardProps } from '../utils';
+import withStyles, { Styles } from '../withStyles';
+
+export interface LinearProgressProps_unstable
+  extends StandardProps<
+    MuiLinearProgressProps,
+    LinearProgressClassKey_unstable,
+    'classes' | 'color' | 'variant'
+  > {
+  /**
+   * The color of the bar.
+   */
+  color?: 'neutral' | 'red' | 'yellow' | 'teal' | 'green' | 'blue' | 'purple';
+  /**
+   * The variant of the component
+   */
+  variant?: Exclude<MuiLinearProgressProps['variant'], 'buffer'>;
+  children?: ReactNode;
+  labelPlacement?: 'start' | 'end';
+}
+
+export type LinearProgressClassKey_unstable =
+  | 'root'
+  | 'bar'
+  | 'dashed'
+  | 'container'
+  | 'label';
+
+type PrivateClassKey =
+  | 'private-root-with-label'
+  | 'private-bar-color-neutral'
+  | 'private-bar-color-red'
+  | 'private-bar-color-yellow'
+  | 'private-bar-color-teal'
+  | 'private-bar-color-green'
+  | 'private-bar-color-blue'
+  | 'private-bar-color-purple'
+  | 'private-label-color-neutral'
+  | 'private-label-color-red'
+  | 'private-label-color-yellow'
+  | 'private-label-color-teal'
+  | 'private-label-color-green'
+  | 'private-label-color-blue'
+  | 'private-label-color-purple';
+
+const styles: Styles<LinearProgressClassKey_unstable | PrivateClassKey> = (
+  theme
+) => ({
+  /* Styles applied to the root element. */
+  root: {
+    backgroundColor: theme.unstable_palette.neutral[80],
+    borderRadius: 4,
+    height: 8,
+  },
+  bar: {
+    backgroundColor: theme.unstable_palette.blue[500],
+    borderRadius: 4,
+  },
+  dashed: {},
+  container: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: 8,
+  },
+  label: {},
+  'private-root-with-label': {
+    width: '100%',
+  },
+  'private-bar-color-neutral': {
+    backgroundColor: theme.unstable_palette.neutral[300],
+  },
+  'private-bar-color-red': {
+    backgroundColor: theme.unstable_palette.red[600],
+  },
+  'private-bar-color-yellow': {
+    backgroundColor: theme.unstable_palette.yellow[500],
+  },
+  'private-bar-color-teal': {
+    backgroundColor: theme.unstable_palette.teal[500],
+  },
+  'private-bar-color-green': {
+    backgroundColor: theme.unstable_palette.green[600],
+  },
+  'private-bar-color-blue': {
+    backgroundColor: theme.unstable_palette.blue[600],
+  },
+  'private-bar-color-purple': {
+    backgroundColor: theme.unstable_palette.purple[500],
+  },
+  'private-label-color-neutral': {
+    color: theme.unstable_palette.neutral[300],
+  },
+  'private-label-color-red': {
+    color: theme.unstable_palette.red[600],
+  },
+  'private-label-color-yellow': {
+    color: theme.unstable_palette.yellow[500],
+  },
+  'private-label-color-teal': {
+    color: theme.unstable_palette.teal[500],
+  },
+  'private-label-color-green': {
+    color: theme.unstable_palette.green[600],
+  },
+  'private-label-color-blue': {
+    color: theme.unstable_palette.blue[600],
+  },
+  'private-label-color-purple': {
+    color: theme.unstable_palette.purple[500],
+  },
+});
+
+const UnstyledLinearProgress = forwardRef<
+  HTMLDivElement,
+  LinearProgressProps_unstable
+>(function LinearProgress(props, ref) {
+  const {
+    children,
+    classes,
+    color = 'neutral',
+    labelPlacement = 'end',
+    variant = 'determinate',
+    value = 0,
+    ...other
+  } = props;
+
+  const hasChildren = isValidElement(children);
+
+  const progressElement = (
+    <MuiLinearProgress
+      classes={{
+        root: clsx(classes.root, {
+          [classes['private-root-with-label']]: hasChildren,
+        }),
+        bar: clsx(classes.bar, {
+          [classes['private-bar-color-neutral']]: color === 'neutral',
+          [classes['private-bar-color-red']]: color === 'red',
+          [classes['private-bar-color-yellow']]: color === 'yellow',
+          [classes['private-bar-color-teal']]: color === 'teal',
+          [classes['private-bar-color-green']]: color === 'green',
+          [classes['private-bar-color-blue']]: color === 'blue',
+          [classes['private-bar-color-purple']]: color === 'purple',
+        }),
+        dashed: classes.dashed,
+      }}
+      ref={ref}
+      value={value}
+      variant={variant}
+      {...other}
+    />
+  );
+
+  if (!hasChildren) {
+    return progressElement;
+  }
+
+  const labelElement = (
+    <span
+      className={clsx(classes.label, {
+        [classes['private-label-color-neutral']]: color === 'neutral',
+        [classes['private-label-color-red']]: color === 'red',
+        [classes['private-label-color-yellow']]: color === 'yellow',
+        [classes['private-label-color-teal']]: color === 'teal',
+        [classes['private-label-color-green']]: color === 'green',
+        [classes['private-label-color-blue']]: color === 'blue',
+        [classes['private-label-color-purple']]: color === 'purple',
+      })}
+    >
+      {children}
+    </span>
+  );
+
+  return (
+    <div className={classes.container}>
+      {labelPlacement === 'start' ? labelElement : null}
+
+      {progressElement}
+
+      {labelPlacement === 'end' ? labelElement : null}
+    </div>
+  );
+});
+
+const LinearProgress_unstable = withStyles(styles, {
+  name: 'MuiSparkLinearProgress_unstable',
+})(UnstyledLinearProgress) as typeof UnstyledLinearProgress;
+
+export default LinearProgress_unstable;

--- a/libs/spark/src/LinearProgress_unstable/index.ts
+++ b/libs/spark/src/LinearProgress_unstable/index.ts
@@ -1,0 +1,2 @@
+export { default } from './LinearProgress_unstable';
+export * from './LinearProgress_unstable';

--- a/libs/spark/src/index.ts
+++ b/libs/spark/src/index.ts
@@ -86,6 +86,9 @@ export * from './InputBase';
 export { default as InputLabel } from './InputLabel';
 export * from './InputLabel';
 
+export { default as LinearProgress_unstable } from './LinearProgress_unstable';
+export * from './LinearProgress_unstable';
+
 export { default as Link } from './Link';
 export * from './Link';
 


### PR DESCRIPTION
Initial implementation of a [Linear Progress component](https://v4.mui.com/components/progress/#linear). Removed "buffer" variant because support is complex and we don't seem to need it -- can revisit if we ever do want it. Circular progress will come in follow-up. Supports labels as children. Supports colors (subject to change since there's no spec).

With this component, the migration to a new "unstable" naming scheme is beginning where it appears as a lowercase suffix instead of prefix. This pattern already exists for the unstable hooks.