### PR TITLE
fix: esm build exports removed types

### DIFF
--- a/libs/spark-icons/.eslintrc.json
+++ b/libs/spark-icons/.eslintrc.json
@@ -8,6 +8,7 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "excludedFiles": ["*.stories.*"],
       "parserOptions": {
         "project": ["libs/spark/tsconfig.*?.json"]
       },
@@ -18,6 +19,10 @@
     },
     {
       "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.stories.*"],
       "rules": {}
     }
   ]

--- a/libs/spark-icons/.eslintrc.json
+++ b/libs/spark-icons/.eslintrc.json
@@ -8,7 +8,13 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "parserOptions": {
+        "project": ["libs/spark/tsconfig.*?.json"]
+      },
+      "rules": {
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/consistent-type-exports": "error"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/libs/spark/.eslintrc.json
+++ b/libs/spark/.eslintrc.json
@@ -12,7 +12,13 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "parserOptions": {
+        "project": ["libs/spark/tsconfig.*?.json"]
+      },
+      "rules": {
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/consistent-type-exports": "error"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/libs/spark/.eslintrc.json
+++ b/libs/spark/.eslintrc.json
@@ -12,6 +12,7 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "excludedFiles": ["*.stories.*"],
       "parserOptions": {
         "project": ["libs/spark/tsconfig.*?.json"]
       },
@@ -22,6 +23,10 @@
     },
     {
       "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.stories.*"],
       "rules": {}
     }
   ]

--- a/libs/spark/src/Alert/Alert.tsx
+++ b/libs/spark/src/Alert/Alert.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/lab/Alert';
-export {
+export type {
   /** @deprecated */
   AlertClassKey,
   /** @deprecated */

--- a/libs/spark/src/AlertTitle/AlertTitle.ts
+++ b/libs/spark/src/AlertTitle/AlertTitle.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/lab/AlertTitle';
-export {
+export type {
   /** @deprecated */
   AlertTitleClassKey,
   /** @deprecated */

--- a/libs/spark/src/Autocomplete/Autocomplete.tsx
+++ b/libs/spark/src/Autocomplete/Autocomplete.tsx
@@ -5,6 +5,8 @@ export {
 export {
   /** @deprecated */
   createFilterOptions,
+} from '@material-ui/lab/Autocomplete';
+export type {
   /** @deprecated */
   AutocompleteChangeDetails,
   /** @deprecated */

--- a/libs/spark/src/Avatar/Avatar.tsx
+++ b/libs/spark/src/Avatar/Avatar.tsx
@@ -1,14 +1,17 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import {
-  default as MuiAvatar,
+import type {
   AvatarClassKey as MuiAvatarClassKey,
-  AvatarProps as MuiAvatarProps,
+  AvatarProps as MuiAvatarProps} from '@material-ui/core/Avatar';
+import {
+  default as MuiAvatar
 } from '@material-ui/core/Avatar';
 import makeStyles from '../makeStyles';
-import {
+import type {
   OverridableComponent,
-  OverrideProps,
+  OverrideProps} from '../utils';
+import {
   capitalize,
   useClassesCapture,
 } from '../utils';

--- a/libs/spark/src/Avatar/Avatar.tsx
+++ b/libs/spark/src/Avatar/Avatar.tsx
@@ -1,20 +1,14 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type {
   AvatarClassKey as MuiAvatarClassKey,
-  AvatarProps as MuiAvatarProps} from '@material-ui/core/Avatar';
-import {
-  default as MuiAvatar
+  AvatarProps as MuiAvatarProps,
 } from '@material-ui/core/Avatar';
+import { default as MuiAvatar } from '@material-ui/core/Avatar';
 import makeStyles from '../makeStyles';
-import type {
-  OverridableComponent,
-  OverrideProps} from '../utils';
-import {
-  capitalize,
-  useClassesCapture,
-} from '../utils';
+import type { OverridableComponent, OverrideProps } from '../utils';
+import { capitalize, useClassesCapture } from '../utils';
 
 /** @deprecated */
 export type AvatarClassKey = MuiAvatarClassKey | CustomClassKey;

--- a/libs/spark/src/Banner/Banner.tsx
+++ b/libs/spark/src/Banner/Banner.tsx
@@ -1,5 +1,7 @@
-import React, { CSSProperties, SyntheticEvent } from 'react';
-import { default as Alert, AlertProps, AlertClassKey } from '../Alert';
+import type { CSSProperties, SyntheticEvent } from 'react';
+import React from 'react';
+import type { AlertProps, AlertClassKey } from '../Alert';
+import { default as Alert } from '../Alert';
 import Button from '../Button';
 import IconButton from '../IconButton';
 import { ArrowRight, Cross } from '../internal';

--- a/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,14 @@
 import React, { forwardRef } from 'react';
-import {
-  default as MuiBreadcrumbs,
+import type {
   BreadcrumbsClassKey,
   BreadcrumbsProps,
-  BreadcrumbsTypeMap,
+  BreadcrumbsTypeMap} from '@material-ui/core/Breadcrumbs';
+import {
+  default as MuiBreadcrumbs
 } from '@material-ui/core/Breadcrumbs';
 import makeStyles from '../makeStyles';
-import { OverridableComponent, useMergeClasses } from '../utils';
+import type { OverridableComponent} from '../utils';
+import { useMergeClasses } from '../utils';
 import { ChevronRight } from '../internal';
 
 export type {

--- a/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/libs/spark/src/Breadcrumbs/Breadcrumbs.tsx
@@ -2,12 +2,11 @@ import React, { forwardRef } from 'react';
 import type {
   BreadcrumbsClassKey,
   BreadcrumbsProps,
-  BreadcrumbsTypeMap} from '@material-ui/core/Breadcrumbs';
-import {
-  default as MuiBreadcrumbs
+  BreadcrumbsTypeMap,
 } from '@material-ui/core/Breadcrumbs';
+import { default as MuiBreadcrumbs } from '@material-ui/core/Breadcrumbs';
 import makeStyles from '../makeStyles';
-import type { OverridableComponent} from '../utils';
+import type { OverridableComponent } from '../utils';
 import { useMergeClasses } from '../utils';
 import { ChevronRight } from '../internal';
 

--- a/libs/spark/src/Button/Button.ts
+++ b/libs/spark/src/Button/Button.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Button';
-export {
+export type {
   /** @deprecated */
   ButtonClassKey,
   /** @deprecated */

--- a/libs/spark/src/ButtonBase/defaults.ts
+++ b/libs/spark/src/ButtonBase/defaults.ts
@@ -1,4 +1,4 @@
-import { ButtonBaseProps } from './ButtonBase';
+import type { ButtonBaseProps } from './ButtonBase';
 
 export const MuiButtonBaseDefaultProps: Partial<ButtonBaseProps> = {
   disableRipple: true,

--- a/libs/spark/src/Card/Card.tsx
+++ b/libs/spark/src/Card/Card.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Card';
-export {
+export type {
   /** @deprecated */
   CardClassKey,
   /** @deprecated */

--- a/libs/spark/src/Card/defaults.ts
+++ b/libs/spark/src/Card/defaults.ts
@@ -1,5 +1,5 @@
-import { CardClassKey, CardProps } from './Card';
-import { StyleRules } from '../withStyles';
+import type { CardClassKey, CardProps } from './Card';
+import type { StyleRules } from '../withStyles';
 
 export const MuiCardDefaultProps: Partial<CardProps> = {
   elevation: 2, // E200

--- a/libs/spark/src/Checkbox/Checkbox.tsx
+++ b/libs/spark/src/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Checkbox';
-export {
+export type {
   /** @deprecated */
   CheckboxClassKey,
   /** @deprecated */

--- a/libs/spark/src/CircularProgress_unstable/index.ts
+++ b/libs/spark/src/CircularProgress_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `/alpha/CircularProgress` */
   default,
 } from '../alpha/CircularProgress';
-export {
+export type {
   /** @deprecated */
   CircularProgressClassKey as CircularProgressClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/Divider/Divider.ts
+++ b/libs/spark/src/Divider/Divider.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Divider';
-export {
+export type {
   /** @deprecated */
   DividerClassKey,
   /** @deprecated */

--- a/libs/spark/src/Drawer_unstable/index.ts
+++ b/libs/spark/src/Drawer_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Drawer` */
   default,
 } from '../alpha/Drawer';
-export {
+export type {
   /** @deprecated */
   DrawerClassKey as DrawerClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
+++ b/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
@@ -1,8 +1,11 @@
-import React, { ElementType, forwardRef } from 'react';
-import { default as Button, ButtonTypeMap } from '../Button';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type { ButtonTypeMap } from '../Button';
+import { default as Button } from '../Button';
 import { useDropdownContext } from '../DropdownContext';
-import { OverridableComponent, OverrideProps } from '../utils';
-import withStyles, { Styles } from '../withStyles';
+import type { OverridableComponent, OverrideProps } from '../utils';
+import type { Styles } from '../withStyles';
+import withStyles from '../withStyles';
 
 /** @deprecated */
 export type DropdownAnchorProps<

--- a/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
+++ b/libs/spark/src/DropdownAnchor/DropdownAnchor.tsx
@@ -1,4 +1,4 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type { ButtonTypeMap } from '../Button';
 import { default as Button } from '../Button';

--- a/libs/spark/src/DropdownContext/DropdownContext.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.tsx
@@ -1,12 +1,5 @@
-import type {
-  MouseEvent,
-  ReactNode} from 'react';
-import React, {
-  createContext,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import type { MouseEvent, ReactNode } from 'react';
+import React, { createContext, useContext, useMemo, useState } from 'react';
 import { useUniqueId } from '../utils';
 
 // This file is an adaption of Mui's TabContext.

--- a/libs/spark/src/DropdownContext/DropdownContext.tsx
+++ b/libs/spark/src/DropdownContext/DropdownContext.tsx
@@ -1,7 +1,8 @@
+import type {
+  MouseEvent,
+  ReactNode} from 'react';
 import React, {
   createContext,
-  MouseEvent,
-  ReactNode,
   useContext,
   useMemo,
   useState,

--- a/libs/spark/src/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import type { PopoverProps } from '@material-ui/core/Popover';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import { useDropdownContext } from '../DropdownContext';

--- a/libs/spark/src/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/DropdownMenu/DropdownMenu.tsx
@@ -1,11 +1,13 @@
-import { PopoverProps } from '@material-ui/core/Popover';
-import React, { ElementType, forwardRef } from 'react';
+import type { PopoverProps } from '@material-ui/core/Popover';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import { useDropdownContext } from '../DropdownContext';
 import type { MenuProps } from '../Menu';
 import Menu from '../Menu';
-import { OverridableComponent, OverrideProps } from '../utils';
-import withStyles, { Styles } from '../withStyles';
+import type { OverridableComponent, OverrideProps } from '../utils';
+import type { Styles } from '../withStyles';
+import withStyles from '../withStyles';
 
 type Placement = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
 

--- a/libs/spark/src/FontFacesBaseline/FontFacesBaseline.ts
+++ b/libs/spark/src/FontFacesBaseline/FontFacesBaseline.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import fontFaces from '../theme/fontFaces';
 import withStyles from '../withStyles';
 

--- a/libs/spark/src/FormControlLabel/FormControlLabel.ts
+++ b/libs/spark/src/FormControlLabel/FormControlLabel.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/FormControlLabel';
-export {
+export type {
   /** @deprecated */
   FormControlLabelClassKey,
   /** @deprecated */

--- a/libs/spark/src/FormGroup/FormGroup.ts
+++ b/libs/spark/src/FormGroup/FormGroup.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/FormGroup';
-export {
+export type {
   /** @deprecated */
   FormGroupClassKey,
   /** @deprecated */

--- a/libs/spark/src/FormHelperText/FormHelperText.ts
+++ b/libs/spark/src/FormHelperText/FormHelperText.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/FormHelperText';
-export {
+export type {
   /** @deprecated */
   FormHelperTextClassKey,
   /** @deprecated */

--- a/libs/spark/src/FormLabel/FormLabel.ts
+++ b/libs/spark/src/FormLabel/FormLabel.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/FormLabel';
-export {
+export type {
   /** @deprecated */
   FormLabelBaseProps,
   /** @deprecated */

--- a/libs/spark/src/IconButton/IconButton.tsx
+++ b/libs/spark/src/IconButton/IconButton.tsx
@@ -1,12 +1,15 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import {
-  default as MuiIconButton,
+import type {
   IconButtonClassKey as MuiIconButtonClassKey,
-  IconButtonProps as MuiIconButtonProps,
+  IconButtonProps as MuiIconButtonProps} from '@material-ui/core/IconButton';
+import {
+  default as MuiIconButton
 } from '@material-ui/core/IconButton';
 import makeStyles from '../makeStyles';
-import { OverridableComponent, capitalize, useClassesCapture } from '../utils';
+import type { OverridableComponent} from '../utils';
+import { capitalize, useClassesCapture } from '../utils';
 
 /** @deprecated */
 export interface IconButtonTypeMap<

--- a/libs/spark/src/IconButton/IconButton.tsx
+++ b/libs/spark/src/IconButton/IconButton.tsx
@@ -1,14 +1,13 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type {
   IconButtonClassKey as MuiIconButtonClassKey,
-  IconButtonProps as MuiIconButtonProps} from '@material-ui/core/IconButton';
-import {
-  default as MuiIconButton
+  IconButtonProps as MuiIconButtonProps,
 } from '@material-ui/core/IconButton';
+import { default as MuiIconButton } from '@material-ui/core/IconButton';
 import makeStyles from '../makeStyles';
-import type { OverridableComponent} from '../utils';
+import type { OverridableComponent } from '../utils';
 import { capitalize, useClassesCapture } from '../utils';
 
 /** @deprecated */

--- a/libs/spark/src/Input/Input.tsx
+++ b/libs/spark/src/Input/Input.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Input';
-export {
+export type {
   /** @deprecated */
   InputClassKey,
   /** @deprecated */

--- a/libs/spark/src/InputAdornment/index.ts
+++ b/libs/spark/src/InputAdornment/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from './InputAdornment';
-export {
+export type {
   /** @deprecated */
   InputAdornmentClassKey,
   /** @deprecated */

--- a/libs/spark/src/InputBase/InputBase.tsx
+++ b/libs/spark/src/InputBase/InputBase.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/InputBase';
-export {
+export type {
   /** @deprecated */
   InputBaseClassKey,
   /** @deprecated */

--- a/libs/spark/src/InputLabel/InputLabel.ts
+++ b/libs/spark/src/InputLabel/InputLabel.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/InputLabel';
-export {
+export type {
   /** @deprecated */
   InputLabelClassKey,
   /** @deprecated */

--- a/libs/spark/src/LinearProgress_unstable/index.ts
+++ b/libs/spark/src/LinearProgress_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/LinearProgress` */
   default,
 } from '../alpha/LinearProgress';
-export {
+export type {
   /** @deprecated */
   LinearProgressClassKey as LinearProgressClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/Link/Link.tsx
+++ b/libs/spark/src/Link/Link.tsx
@@ -1,11 +1,14 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  LinkProps as MuiLinkProps} from '@material-ui/core/Link';
 import {
-  default as MuiLink,
-  LinkProps as MuiLinkProps,
+  default as MuiLink
 } from '@material-ui/core/Link';
 import makeStyles from '../makeStyles';
-import { OverridableComponent, OverrideProps, useMergeClasses } from '../utils';
+import type { OverridableComponent, OverrideProps} from '../utils';
+import { useMergeClasses } from '../utils';
 
 /** @deprecated */
 export interface LinkTypeMap<

--- a/libs/spark/src/Link/Link.tsx
+++ b/libs/spark/src/Link/Link.tsx
@@ -1,13 +1,10 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  LinkProps as MuiLinkProps} from '@material-ui/core/Link';
-import {
-  default as MuiLink
-} from '@material-ui/core/Link';
+import type { LinkProps as MuiLinkProps } from '@material-ui/core/Link';
+import { default as MuiLink } from '@material-ui/core/Link';
 import makeStyles from '../makeStyles';
-import type { OverridableComponent, OverrideProps} from '../utils';
+import type { OverridableComponent, OverrideProps } from '../utils';
 import { useMergeClasses } from '../utils';
 
 /** @deprecated */

--- a/libs/spark/src/List/List.ts
+++ b/libs/spark/src/List/List.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/List';
-export {
+export type {
   /** @deprecated */
   ListClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListItem/ListItem.ts
+++ b/libs/spark/src/ListItem/ListItem.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/ListItem';
-export {
+export type {
   /** @deprecated */
   ListItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListItemAvatar/ListItemAvatar.ts
+++ b/libs/spark/src/ListItemAvatar/ListItemAvatar.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/ListItemAvatar';
-export {
+export type {
   /** @deprecated */
   ListItemAvatarClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListItemIcon/index.ts
+++ b/libs/spark/src/ListItemIcon/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from './ListItemIcon';
-export {
+export type {
   /** @deprecated */
   ListItemIconClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListItemSecondaryAction/ListItemSecondaryAction.ts
+++ b/libs/spark/src/ListItemSecondaryAction/ListItemSecondaryAction.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/ListItemSecondaryAction';
-export {
+export type {
   /** @deprecated */
   ListItemSecondaryActionClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListItemText/ListItemText.ts
+++ b/libs/spark/src/ListItemText/ListItemText.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/ListItemText';
-export {
+export type {
   /** @deprecated */
   ListItemTextClassKey,
   /** @deprecated */

--- a/libs/spark/src/ListSubheader/ListSubheader.ts
+++ b/libs/spark/src/ListSubheader/ListSubheader.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/ListSubheader';
-export {
+export type {
   /** @deprecated */
   ListSubheaderClassKey,
   /** @deprecated */

--- a/libs/spark/src/Menu/Menu.ts
+++ b/libs/spark/src/Menu/Menu.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Menu';
-export {
+export type {
   /** @deprecated */
   MenuClassKey,
   /** @deprecated */

--- a/libs/spark/src/MenuItem/MenuItem.ts
+++ b/libs/spark/src/MenuItem/MenuItem.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/MenuItem';
-export {
+export type {
   /** @deprecated */
   MenuItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/MenuList/MenuList.ts
+++ b/libs/spark/src/MenuList/MenuList.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/MenuList';
-export {
+export type {
   /** @deprecated */
   MenuListClassKey,
   /** @deprecated */

--- a/libs/spark/src/NavBar/NavBar.tsx
+++ b/libs/spark/src/NavBar/NavBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { default as AppBar, AppBarProps } from '@material-ui/core/AppBar';
+import type { AppBarProps } from '@material-ui/core/AppBar';
+import { default as AppBar } from '@material-ui/core/AppBar';
 import withStyles from '../withStyles';
 
 /** @deprecated */

--- a/libs/spark/src/NavBarButton/NavBarButton.tsx
+++ b/libs/spark/src/NavBarButton/NavBarButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { default as Button, ButtonProps } from '@material-ui/core/Button';
+import type { ButtonProps } from '@material-ui/core/Button';
+import { default as Button } from '@material-ui/core/Button';
 import withStyles from '../withStyles';
 
 export type NavBarButtonProps = Omit<ButtonProps, 'variant' | 'color'>;

--- a/libs/spark/src/Paper/Paper.ts
+++ b/libs/spark/src/Paper/Paper.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Paper';
-export {
+export type {
   /** @deprecated */
   PaperClassKey,
   /** @deprecated */

--- a/libs/spark/src/Radio/Radio.tsx
+++ b/libs/spark/src/Radio/Radio.tsx
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Radio';
-export {
+export type {
   /** @deprecated */
   RadioClassKey,
   /** @deprecated */

--- a/libs/spark/src/RadioGroup/RadioGroup.ts
+++ b/libs/spark/src/RadioGroup/RadioGroup.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/RadioGroup';
-export {
+export type {
   /** @deprecated */
   RadioGroupClassKey,
   /** @deprecated */

--- a/libs/spark/src/SectionMessage/SectionMessage.tsx
+++ b/libs/spark/src/SectionMessage/SectionMessage.tsx
@@ -1,5 +1,7 @@
-import React, { CSSProperties } from 'react';
-import { default as Alert, AlertProps, AlertClassKey } from '../Alert';
+import type { CSSProperties } from 'react';
+import React from 'react';
+import type { AlertProps, AlertClassKey } from '../Alert';
+import { default as Alert } from '../Alert';
 import IconButton from '../IconButton';
 import { Cross } from '../internal';
 import withStyles from '../withStyles';

--- a/libs/spark/src/SectionMessageTitle/SectionMessageTitle.ts
+++ b/libs/spark/src/SectionMessageTitle/SectionMessageTitle.ts
@@ -1,10 +1,6 @@
 import type { CSSProperties } from 'react';
-import type {
-  AlertTitleProps,
-  AlertTitleClassKey} from '../AlertTitle';
-import {
-  default as AlertTitle
-} from '../AlertTitle';
+import type { AlertTitleProps, AlertTitleClassKey } from '../AlertTitle';
+import { default as AlertTitle } from '../AlertTitle';
 import withStyles from '../withStyles';
 
 /** @deprecated */

--- a/libs/spark/src/SectionMessageTitle/SectionMessageTitle.ts
+++ b/libs/spark/src/SectionMessageTitle/SectionMessageTitle.ts
@@ -1,8 +1,9 @@
 import type { CSSProperties } from 'react';
-import {
-  default as AlertTitle,
+import type {
   AlertTitleProps,
-  AlertTitleClassKey,
+  AlertTitleClassKey} from '../AlertTitle';
+import {
+  default as AlertTitle
 } from '../AlertTitle';
 import withStyles from '../withStyles';
 

--- a/libs/spark/src/Select/Select.ts
+++ b/libs/spark/src/Select/Select.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Select';
-export {
+export type {
   /** @deprecated */
   SelectClassKey,
   /** @deprecated */

--- a/libs/spark/src/SideBarContext_unstable/index.ts
+++ b/libs/spark/src/SideBarContext_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarContext` */
   default,
 } from '../alpha/SideBarContext';
-export {
+export type {
   /** @deprecated */
   SideBarContextValue as SideBarContextValue_unstable,
 } from '../alpha/SideBarContext';

--- a/libs/spark/src/SideBarDrawer_unstable/index.ts
+++ b/libs/spark/src/SideBarDrawer_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarDrawer` */
   default,
 } from '../alpha/SideBarDrawer';
-export {
+export type {
   /** @deprecated */
   SideBarDrawerClassKey as SideBarDrawerClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/SideBarListItem_unstable/index.ts
+++ b/libs/spark/src/SideBarListItem_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarListItem` */
   default,
 } from '../alpha/SideBarListItem';
-export {
+export type {
   /** @deprecated */
   SideBarListItemClassKey as SideBarListItemClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/SideBarListSubheader_unstable/index.ts
+++ b/libs/spark/src/SideBarListSubheader_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarListSubheader` */
   default,
 } from '../alpha/SideBarListSubheader';
-export {
+export type {
   /** @deprecated */
   SideBarListSubheaderClassKey as SideBarListSubheaderClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/SideBarList_unstable/index.ts
+++ b/libs/spark/src/SideBarList_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarList` */
   default,
 } from '../alpha/SideBarList';
-export {
+export type {
   /** @deprecated */
   SideBarListClassKey as SideBarListClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/SideBarProvider_unstable/index.ts
+++ b/libs/spark/src/SideBarProvider_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SideBarProvider` */
   default,
 } from '../alpha/SideBarProvider';
-export {
+export type {
   /** @deprecated */
   SideBarProviderClassKey as SideBarProviderClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/Skeleton/index.ts
+++ b/libs/spark/src/Skeleton/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from './Skeleton';
-export {
+export type {
   /** @deprecated */
   SkeletonClassKey,
   /** @deprecated */

--- a/libs/spark/src/Step/Step.tsx
+++ b/libs/spark/src/Step/Step.tsx
@@ -1,11 +1,10 @@
-import type { ReactElement} from 'react';
+import type { ReactElement } from 'react';
 import React, { forwardRef } from 'react';
 import type {
   StepClasskey as MuiStepClassKey,
-  StepProps as MuiStepProps} from '@material-ui/core/Step';
-import {
-  default as MuiStep
+  StepProps as MuiStepProps,
 } from '@material-ui/core/Step';
+import { default as MuiStep } from '@material-ui/core/Step';
 import StepConnector from '../StepConnector';
 import type { Orientation } from '../Stepper';
 import makeStyles from '../makeStyles';

--- a/libs/spark/src/Step/Step.tsx
+++ b/libs/spark/src/Step/Step.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement, forwardRef } from 'react';
-import {
-  default as MuiStep,
+import type { ReactElement} from 'react';
+import React, { forwardRef } from 'react';
+import type {
   StepClasskey as MuiStepClassKey,
-  StepProps as MuiStepProps,
+  StepProps as MuiStepProps} from '@material-ui/core/Step';
+import {
+  default as MuiStep
 } from '@material-ui/core/Step';
 import StepConnector from '../StepConnector';
 import type { Orientation } from '../Stepper';

--- a/libs/spark/src/StepButton/StepButton.tsx
+++ b/libs/spark/src/StepButton/StepButton.tsx
@@ -1,17 +1,19 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepButton/StepButton.js
+import type {
+  ElementType,
+  ReactNode} from 'react';
 import React, {
   cloneElement,
-  ElementType,
   forwardRef,
-  isValidElement,
-  ReactNode,
+  isValidElement
 } from 'react';
 import clsx from 'clsx';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
 import type { Orientation } from '../Stepper';
 import makeStyles from '../makeStyles';
-import { OverridableComponent, useMergeClasses } from '../utils';
+import type { OverridableComponent} from '../utils';
+import { useMergeClasses } from '../utils';
 
 export type StepButtonClassKey = 'root' | 'horizontal' | 'vertical';
 

--- a/libs/spark/src/StepButton/StepButton.tsx
+++ b/libs/spark/src/StepButton/StepButton.tsx
@@ -1,18 +1,12 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepButton/StepButton.js
-import type {
-  ElementType,
-  ReactNode} from 'react';
-import React, {
-  cloneElement,
-  forwardRef,
-  isValidElement
-} from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { cloneElement, forwardRef, isValidElement } from 'react';
 import clsx from 'clsx';
 import ButtonBase from '../ButtonBase';
 import StepLabel from '../StepLabel';
 import type { Orientation } from '../Stepper';
 import makeStyles from '../makeStyles';
-import type { OverridableComponent} from '../utils';
+import type { OverridableComponent } from '../utils';
 import { useMergeClasses } from '../utils';
 
 export type StepButtonClassKey = 'root' | 'horizontal' | 'vertical';

--- a/libs/spark/src/StepConnector/StepConnector.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.tsx
@@ -1,8 +1,10 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepConnector/StepConnector.js
-import React, { forwardRef, HTMLAttributes, Ref } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
-import { StandardProps, useMergeClasses } from '../utils';
+import type { StandardProps} from '../utils';
+import { useMergeClasses } from '../utils';
 import type { Orientation } from '../Stepper';
 
 export type StepConnectorClassKey =

--- a/libs/spark/src/StepConnector/StepConnector.tsx
+++ b/libs/spark/src/StepConnector/StepConnector.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, Ref } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import makeStyles from '../makeStyles';
-import type { StandardProps} from '../utils';
+import type { StandardProps } from '../utils';
 import { useMergeClasses } from '../utils';
 import type { Orientation } from '../Stepper';
 

--- a/libs/spark/src/StepContent/StepContent.tsx
+++ b/libs/spark/src/StepContent/StepContent.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react';
-import {
-  default as MuiStepContent,
+import type {
   StepContentClasskey as StepContentClassKey,
-  StepContentProps,
+  StepContentProps} from '@material-ui/core/StepContent';
+import {
+  default as MuiStepContent
 } from '@material-ui/core/StepContent';
 import makeStyles from '../makeStyles';
 import { useMergeClasses } from '../utils';

--- a/libs/spark/src/StepContent/StepContent.tsx
+++ b/libs/spark/src/StepContent/StepContent.tsx
@@ -1,10 +1,9 @@
 import React, { forwardRef } from 'react';
 import type {
   StepContentClasskey as StepContentClassKey,
-  StepContentProps} from '@material-ui/core/StepContent';
-import {
-  default as MuiStepContent
+  StepContentProps,
 } from '@material-ui/core/StepContent';
+import { default as MuiStepContent } from '@material-ui/core/StepContent';
 import makeStyles from '../makeStyles';
 import { useMergeClasses } from '../utils';
 

--- a/libs/spark/src/StepIcon/StepIcon.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.tsx
@@ -1,12 +1,12 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepIcon/StepIcon.js
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { SvgIconProps } from '../SvgIcon';
 import { default as SvgIcon } from '../SvgIcon';
 import { AlertThick, CheckThick } from '../internal';
 import makeStyles from '../makeStyles';
-import type { StandardProps} from '../utils';
+import type { StandardProps } from '../utils';
 import { useMergeClasses } from '../utils';
 
 export type StepIconClassKey =

--- a/libs/spark/src/StepIcon/StepIcon.tsx
+++ b/libs/spark/src/StepIcon/StepIcon.tsx
@@ -1,10 +1,13 @@
 // Original credit to MUI. https://github.com/mui-org/material-ui/blob/c545ccab7edfdf4a44d4ec2f4bf10ebc7fd00259/packages/material-ui/src/StepIcon/StepIcon.js
-import React, { ReactNode, forwardRef } from 'react';
+import type { ReactNode} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { default as SvgIcon, SvgIconProps } from '../SvgIcon';
+import type { SvgIconProps } from '../SvgIcon';
+import { default as SvgIcon } from '../SvgIcon';
 import { AlertThick, CheckThick } from '../internal';
 import makeStyles from '../makeStyles';
-import { StandardProps, useMergeClasses } from '../utils';
+import type { StandardProps} from '../utils';
+import { useMergeClasses } from '../utils';
 
 export type StepIconClassKey =
   | 'root'

--- a/libs/spark/src/StepLabel/StepLabel.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.tsx
@@ -1,10 +1,12 @@
 import React, { forwardRef } from 'react';
-import {
-  default as MuiStepLabel,
+import type {
   StepLabelClasskey as StepLabelClassKey,
-  StepLabelProps as MuiStepLabelProps,
+  StepLabelProps as MuiStepLabelProps} from '@material-ui/core/StepLabel';
+import {
+  default as MuiStepLabel
 } from '@material-ui/core/StepLabel';
-import { default as StepIcon, StepIconProps } from '../StepIcon';
+import type { StepIconProps } from '../StepIcon';
+import { default as StepIcon } from '../StepIcon';
 import makeStyles from '../makeStyles';
 import { useMergeClasses } from '../utils';
 

--- a/libs/spark/src/StepLabel/StepLabel.tsx
+++ b/libs/spark/src/StepLabel/StepLabel.tsx
@@ -1,10 +1,9 @@
 import React, { forwardRef } from 'react';
 import type {
   StepLabelClasskey as StepLabelClassKey,
-  StepLabelProps as MuiStepLabelProps} from '@material-ui/core/StepLabel';
-import {
-  default as MuiStepLabel
+  StepLabelProps as MuiStepLabelProps,
 } from '@material-ui/core/StepLabel';
+import { default as MuiStepLabel } from '@material-ui/core/StepLabel';
 import type { StepIconProps } from '../StepIcon';
 import { default as StepIcon } from '../StepIcon';
 import makeStyles from '../makeStyles';

--- a/libs/spark/src/Stepper/Stepper.tsx
+++ b/libs/spark/src/Stepper/Stepper.tsx
@@ -2,10 +2,9 @@ import React, { forwardRef } from 'react';
 import type {
   Orientation,
   StepperClasskey as StepperClassKey,
-  StepperProps} from '@material-ui/core/Stepper';
-import {
-  default as MuiStepper
+  StepperProps,
 } from '@material-ui/core/Stepper';
+import { default as MuiStepper } from '@material-ui/core/Stepper';
 import StepConnector from '../StepConnector';
 import makeStyles from '../makeStyles';
 import { useMergeClasses } from '../utils';

--- a/libs/spark/src/Stepper/Stepper.tsx
+++ b/libs/spark/src/Stepper/Stepper.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react';
-import {
-  default as MuiStepper,
+import type {
   Orientation,
   StepperClasskey as StepperClassKey,
-  StepperProps,
+  StepperProps} from '@material-ui/core/Stepper';
+import {
+  default as MuiStepper
 } from '@material-ui/core/Stepper';
 import StepConnector from '../StepConnector';
 import makeStyles from '../makeStyles';

--- a/libs/spark/src/SvgIcon/SvgIcon.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.tsx
@@ -1,14 +1,17 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  SvgIconProps as MuiSvgIconProps} from '@material-ui/core/SvgIcon';
 import {
-  default as MuiSvgIcon,
-  SvgIconProps as MuiSvgIconProps,
+  default as MuiSvgIcon
 } from '@material-ui/core/SvgIcon';
 import makeStyles from '../makeStyles';
+import type {
+  OverridableComponent,
+  OverrideProps} from '../utils';
 import {
   capitalize,
-  OverridableComponent,
-  OverrideProps,
   useMergeClasses,
 } from '../utils';
 

--- a/libs/spark/src/SvgIcon/SvgIcon.tsx
+++ b/libs/spark/src/SvgIcon/SvgIcon.tsx
@@ -1,19 +1,11 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  SvgIconProps as MuiSvgIconProps} from '@material-ui/core/SvgIcon';
-import {
-  default as MuiSvgIcon
-} from '@material-ui/core/SvgIcon';
+import type { SvgIconProps as MuiSvgIconProps } from '@material-ui/core/SvgIcon';
+import { default as MuiSvgIcon } from '@material-ui/core/SvgIcon';
 import makeStyles from '../makeStyles';
-import type {
-  OverridableComponent,
-  OverrideProps} from '../utils';
-import {
-  capitalize,
-  useMergeClasses,
-} from '../utils';
+import type { OverridableComponent, OverrideProps } from '../utils';
+import { capitalize, useMergeClasses } from '../utils';
 
 /** @deprecated */
 export type SvgIconClassKey =

--- a/libs/spark/src/Switch/Switch.tsx
+++ b/libs/spark/src/Switch/Switch.tsx
@@ -1,11 +1,10 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type {
   SwitchClassKey as MuiSwitchClassKey,
-  SwitchProps as MuiSwitchProps} from '@material-ui/core/Switch';
-import {
-  default as MuiSwitch
+  SwitchProps as MuiSwitchProps,
 } from '@material-ui/core/Switch';
+import { default as MuiSwitch } from '@material-ui/core/Switch';
 import type { OverridableComponent, OverrideProps } from '../utils';
 
 /** @deprecated */

--- a/libs/spark/src/Switch/Switch.tsx
+++ b/libs/spark/src/Switch/Switch.tsx
@@ -1,10 +1,12 @@
-import React, { ElementType, forwardRef } from 'react';
-import {
-  default as MuiSwitch,
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
   SwitchClassKey as MuiSwitchClassKey,
-  SwitchProps as MuiSwitchProps,
+  SwitchProps as MuiSwitchProps} from '@material-ui/core/Switch';
+import {
+  default as MuiSwitch
 } from '@material-ui/core/Switch';
-import { OverridableComponent, OverrideProps } from '../utils';
+import type { OverridableComponent, OverrideProps } from '../utils';
 
 /** @deprecated */
 // Add keys missing from Mui

--- a/libs/spark/src/Tab/Tab.ts
+++ b/libs/spark/src/Tab/Tab.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Tab';
-export {
+export type {
   /** @deprecated */
   TabClassKey,
   /** @deprecated */

--- a/libs/spark/src/TabContext/TabContext.ts
+++ b/libs/spark/src/TabContext/TabContext.ts
@@ -8,9 +8,11 @@ export {
   /** @deprecated */
   getTabId,
   /** @deprecated */
+  useTabContext,
+} from '@material-ui/lab/TabContext';
+export type {
+  /** @deprecated */
   TabContextProps,
   /** @deprecated */
   TabContextValue,
-  /** @deprecated */
-  useTabContext,
 } from '@material-ui/lab/TabContext';

--- a/libs/spark/src/TabList/TabList.ts
+++ b/libs/spark/src/TabList/TabList.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/lab/TabList';
-export {
+export type {
   /** @deprecated */
   TabListClassKey,
   /** @deprecated */

--- a/libs/spark/src/TabPanel/TabPanel.ts
+++ b/libs/spark/src/TabPanel/TabPanel.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/lab/TabPanel';
-export {
+export type {
   /** @deprecated */
   TabPanelClassKey,
   /** @deprecated */

--- a/libs/spark/src/Tabs/Tabs.ts
+++ b/libs/spark/src/Tabs/Tabs.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/Tabs';
-export {
+export type {
   /** @deprecated */
   TabsActions,
   /** @deprecated */

--- a/libs/spark/src/Tag/Tag.tsx
+++ b/libs/spark/src/Tag/Tag.tsx
@@ -1,21 +1,15 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type {
   ChipClassKey as MuiChipClassKey,
-  ChipProps as MuiChipProps} from '@material-ui/core/Chip';
-import {
-  default as MuiChip
+  ChipProps as MuiChipProps,
 } from '@material-ui/core/Chip';
+import { default as MuiChip } from '@material-ui/core/Chip';
 import { CrossSmall } from '../internal';
 import makeStyles from '../makeStyles';
-import type {
-  OverridableComponent,
-  OverrideProps} from '../utils';
-import {
-  capitalize,
-  useClassesCapture,
-} from '../utils';
+import type { OverridableComponent, OverrideProps } from '../utils';
+import { capitalize, useClassesCapture } from '../utils';
 
 /** @deprecated */
 export type TagClassKey = MuiChipClassKey | CustomClassKey;

--- a/libs/spark/src/Tag/Tag.tsx
+++ b/libs/spark/src/Tag/Tag.tsx
@@ -1,15 +1,18 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import {
-  default as MuiChip,
+import type {
   ChipClassKey as MuiChipClassKey,
-  ChipProps as MuiChipProps,
+  ChipProps as MuiChipProps} from '@material-ui/core/Chip';
+import {
+  default as MuiChip
 } from '@material-ui/core/Chip';
 import { CrossSmall } from '../internal';
 import makeStyles from '../makeStyles';
-import {
+import type {
   OverridableComponent,
-  OverrideProps,
+  OverrideProps} from '../utils';
+import {
   capitalize,
   useClassesCapture,
 } from '../utils';

--- a/libs/spark/src/TextField/TextField.ts
+++ b/libs/spark/src/TextField/TextField.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '@material-ui/core/TextField';
-export {
+export type {
   /** @deprecated */
   BaseTextFieldProps,
   /** @deprecated */

--- a/libs/spark/src/TopBar_unstable/index.ts
+++ b/libs/spark/src/TopBar_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/TopBar` */
   default,
 } from '../alpha/TopBar';
-export {
+export type {
   /** @deprecated */
   TopBarClassKey as TopBarClassKey_unstable,
   /** @deprecated */

--- a/libs/spark/src/Typography/Typography.tsx
+++ b/libs/spark/src/Typography/Typography.tsx
@@ -1,15 +1,14 @@
-import type { ElementType, ForwardedRef} from 'react';
+import type { ElementType, ForwardedRef } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type {
   TypographyClassKey as MuiTypographyClassKey,
-  TypographyProps as MuiTypographyProps} from '@material-ui/core/Typography';
-import {
-  default as MuiTypography
+  TypographyProps as MuiTypographyProps,
 } from '@material-ui/core/Typography';
+import { default as MuiTypography } from '@material-ui/core/Typography';
 import makeStyles from '../makeStyles';
 import type { SparkVariant } from '../theme/typography';
-import type { OverrideProps} from '../utils';
+import type { OverrideProps } from '../utils';
 import { capitalize, useClassesCapture } from '../utils';
 
 export interface TypographyTypeMap<

--- a/libs/spark/src/Typography/Typography.tsx
+++ b/libs/spark/src/Typography/Typography.tsx
@@ -1,13 +1,16 @@
-import React, { ElementType, ForwardedRef, forwardRef } from 'react';
+import type { ElementType, ForwardedRef} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import {
-  default as MuiTypography,
+import type {
   TypographyClassKey as MuiTypographyClassKey,
-  TypographyProps as MuiTypographyProps,
+  TypographyProps as MuiTypographyProps} from '@material-ui/core/Typography';
+import {
+  default as MuiTypography
 } from '@material-ui/core/Typography';
 import makeStyles from '../makeStyles';
 import type { SparkVariant } from '../theme/typography';
-import { OverrideProps, capitalize, useClassesCapture } from '../utils';
+import type { OverrideProps} from '../utils';
+import { capitalize, useClassesCapture } from '../utils';
 
 export interface TypographyTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/Typography/index.ts
+++ b/libs/spark/src/Typography/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from './Typography';
-export {
+export type {
   /** @deprecated */
   TypographyClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Autocomplete/index.ts
+++ b/libs/spark/src/Unstable_Autocomplete/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated `alpha/Autocomplete` */
   default,
 } from '../alpha/Autocomplete';
-export {
+export type {
   /** @deprecated */
   AutocompleteClassKey as Unstable_AutocompleteClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Avatar/index.ts
+++ b/libs/spark/src/Unstable_Avatar/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Avatar` */
   default,
 } from '../alpha/Avatar';
-export {
+export type {
   /** @deprecated */
   AvatarClassKey as Unstable_AvatarClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_AvatarButton/index.ts
+++ b/libs/spark/src/Unstable_AvatarButton/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/AvatarButton` */
   default,
 } from '../alpha/AvatarButton';
-export {
+export type {
   /** @deprecated */
   AvatarButtonClassKey as Unstable_AvatarButtonClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Banner/index.ts
+++ b/libs/spark/src/Unstable_Banner/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Banner` */
   default,
 } from '../alpha/Banner';
-export {
+export type {
   /** @deprecated */
   BannerClassKey as Unstable_BannerClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Button/index.ts
+++ b/libs/spark/src/Unstable_Button/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Button` */
   default,
 } from '../alpha/Button';
-export {
+export type {
   /** @deprecated */
   ButtonClassKey as Unstable_ButtonClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Card/index.ts
+++ b/libs/spark/src/Unstable_Card/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Card` */
   default,
 } from '../alpha/Card';
-export {
+export type {
   /** @deprecated */
   CardClassKey as Unstable_CardClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Checkbox/index.ts
+++ b/libs/spark/src/Unstable_Checkbox/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Checkbox` */
   default,
 } from '../alpha/Checkbox';
-export {
+export type {
   /** @deprecated */
   CheckboxClassKey as Unstable_CheckboxClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_CheckboxField/index.ts
+++ b/libs/spark/src/Unstable_CheckboxField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/CheckboxField` */
   default,
 } from '../alpha/CheckboxField';
-export {
+export type {
   /** @deprecated */
   CheckboxFieldClassKey as Unstable_CheckboxFieldClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_CheckboxGroupField/index.ts
+++ b/libs/spark/src/Unstable_CheckboxGroupField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/CheckboxGroupField` */
   default,
 } from '../alpha/CheckboxGroupField';
-export {
+export type {
   /** @deprecated */
   CheckboxGroupFieldProps as Unstable_CheckboxGroupFieldProps,
 } from '../alpha/CheckboxGroupField';

--- a/libs/spark/src/Unstable_CheckboxListItem/index.ts
+++ b/libs/spark/src/Unstable_CheckboxListItem/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/CheckboxListItem` */
   default,
 } from '../alpha/CheckboxListItem';
-export {
+export type {
   /** @deprecated */
   CheckboxListItemClassKey as Unstable_CheckboxListItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_CheckboxMenuItem/index.ts
+++ b/libs/spark/src/Unstable_CheckboxMenuItem/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/CheckboxMenuItem` */
   default,
 } from '../alpha/CheckboxMenuItem';
-export {
+export type {
   /** @deprecated */
   CheckboxMenuItemClassKey as Unstable_CheckboxMenuItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ContentGroup/index.ts
+++ b/libs/spark/src/Unstable_ContentGroup/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ContentGroup` */
   default,
 } from '../alpha/ContentGroup';
-export {
+export type {
   /** @deprecated */
   ContentGroupClassKey as Unstable_ContentGroupClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Divider/index.ts
+++ b/libs/spark/src/Unstable_Divider/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Divider` */
   default,
 } from '../alpha/Divider';
-export {
+export type {
   /** @deprecated */
   DividerClassKey as Unstable_DividerClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Dropdown/index.ts
+++ b/libs/spark/src/Unstable_Dropdown/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Dropdown` */
   default,
 } from '../alpha/Dropdown';
-export {
+export type {
   /** @deprecated */
   DropdownProps as Unstable_DropdownProps,
 } from '../alpha/Dropdown';

--- a/libs/spark/src/Unstable_DropdownContext/index.ts
+++ b/libs/spark/src/Unstable_DropdownContext/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated */
   default,
 } from '../alpha/DropdownContext';
-export {
+export type {
   /** @deprecated */
   DropdownContextValue as Unstable_DropdownContextValue,
 } from '../alpha/DropdownContext';

--- a/libs/spark/src/Unstable_DropdownMenu/index.ts
+++ b/libs/spark/src/Unstable_DropdownMenu/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/DropdownMenu` */
   default,
 } from '../alpha/DropdownMenu';
-export {
+export type {
   /** @deprecated */
   DropdownMenuProps as Unstable_DropdownMenuProps,
   /** @deprecated */

--- a/libs/spark/src/Unstable_DropdownTrigger/index.ts
+++ b/libs/spark/src/Unstable_DropdownTrigger/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/DropdownTrigger` */
   default,
 } from '../alpha/DropdownTrigger';
-export {
+export type {
   /** @deprecated */
   DropdownTriggerClassKey as Unstable_DropdownTriggerClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_FormControl/index.ts
+++ b/libs/spark/src/Unstable_FormControl/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormControl` */
   default,
 } from '../alpha/FormControl';
-export {
+export type {
   /** @deprecated */
   FormControlClassKey as Unstable_FormControlClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_FormControlExtraContext/index.ts
+++ b/libs/spark/src/Unstable_FormControlExtraContext/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormControlExtraContext` */
   default,
 } from '../alpha/FormControlExtraContext';
-export {
+export type {
   /** @deprecated */
   FormControlExtraContextValue as Unstable_FormControlExtraContextValue,
 } from '../alpha/FormControlExtraContext';

--- a/libs/spark/src/Unstable_FormControlLabel/index.ts
+++ b/libs/spark/src/Unstable_FormControlLabel/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormControlLabel` */
   default,
 } from '../alpha/FormControlLabel';
-export {
+export type {
   /** @deprecated */
   FormControlLabelClassKey as Unstable_FormControlLabelClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_FormGroup/index.ts
+++ b/libs/spark/src/Unstable_FormGroup/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormGroup` */
   default,
 } from '../alpha/FormGroup';
-export {
+export type {
   /** @deprecated */
   FormGroupClassKey as Unstable_FormGroupClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_FormHelperText/index.ts
+++ b/libs/spark/src/Unstable_FormHelperText/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormHelperText` */
   default,
 } from '../alpha/FormHelperText';
-export {
+export type {
   /** @deprecated */
   FormHelperTextClassKey as Unstable_FormHelperTextClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_FormLabel/index.ts
+++ b/libs/spark/src/Unstable_FormLabel/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/FormLabel` */
   default,
 } from '../alpha/FormLabel';
-export {
+export type {
   /** @deprecated */
   FormLabelClassKey as Unstable_FormLabelClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_IconButton/index.ts
+++ b/libs/spark/src/Unstable_IconButton/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/IconButton` */
   default,
 } from '../alpha/IconButton';
-export {
+export type {
   /** @deprecated */
   IconButtonClassKey as Unstable_IconButtonClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Input/index.ts
+++ b/libs/spark/src/Unstable_Input/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Input` */
   default,
 } from '../alpha/Input';
-export {
+export type {
   /** @deprecated */
   InputClassKey as Unstable_InputClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_InputAdornment/index.ts
+++ b/libs/spark/src/Unstable_InputAdornment/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/InputAdornment` */
   default,
 } from '../alpha/InputAdornment';
-export {
+export type {
   /** @deprecated */
   InputAdornmentClassKey as Unstable_InputAdornmentClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Link/index.ts
+++ b/libs/spark/src/Unstable_Link/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Link` */
   default,
 } from '../alpha/Link';
-export {
+export type {
   /** @deprecated */
   LinkClassKey as Unstable_LinkClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_List/index.ts
+++ b/libs/spark/src/Unstable_List/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/List` */
   default,
 } from '../alpha/List';
-export {
+export type {
   /** @deprecated */
   ListClassKey as Unstable_ListClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ListItem/index.ts
+++ b/libs/spark/src/Unstable_ListItem/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ListItem` */
   default,
 } from '../alpha/ListItem';
-export {
+export type {
   /** @deprecated */
   ListItemClassKey as Unstable_ListItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ListSubheader/index.ts
+++ b/libs/spark/src/Unstable_ListSubheader/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ListSubheader` */
   default,
 } from '../alpha/ListSubheader';
-export {
+export type {
   /** @deprecated */
   ListSubheaderClassKey as Unstable_ListSubheaderClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Menu/index.ts
+++ b/libs/spark/src/Unstable_Menu/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Menu` */
   default,
 } from '../alpha/Menu';
-export {
+export type {
   /** @deprecated */
   MenuClassKey as Unstable_MenuClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_MenuItem/index.ts
+++ b/libs/spark/src/Unstable_MenuItem/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/MenuItem` */
   default,
 } from '../alpha/MenuItem';
-export {
+export type {
   /** @deprecated */
   MenuItemClassKey as Unstable_MenuItemClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_MenuList/index.ts
+++ b/libs/spark/src/Unstable_MenuList/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/MenuList` */
   default,
 } from '../alpha/MenuList';
-export {
+export type {
   /** @deprecated */
   MenuListClassKey as Unstable_MenuListClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Modal/index.ts
+++ b/libs/spark/src/Unstable_Modal/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   /** @deprecated */
   ModalProps as Unstable_ModalProps,
 } from '../alpha/Modal';

--- a/libs/spark/src/Unstable_ModalDialog/index.ts
+++ b/libs/spark/src/Unstable_ModalDialog/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ModalDialog` */
   default,
 } from '../alpha/ModalDialog';
-export {
+export type {
   /** @deprecated */
   ModalDialogClassKey as Unstable_ModalDialogClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ModalDialogActions/index.ts
+++ b/libs/spark/src/Unstable_ModalDialogActions/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ModalDialogActions` */
   default,
 } from '../alpha/ModalDialogActions';
-export {
+export type {
   /** @deprecated */
   ModalDialogActionsClassKey as Unstable_ModalDialogActionsClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ModalDialogContent/index.ts
+++ b/libs/spark/src/Unstable_ModalDialogContent/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ModalDialogContent` */
   default,
 } from '../alpha/ModalDialogContent';
-export {
+export type {
   /** @deprecated */
   ModalDialogContentClassKey as Unstable_ModalDialogContentClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ModalDialogContentText/index.ts
+++ b/libs/spark/src/Unstable_ModalDialogContentText/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ModalDialogContentText` */
   default,
 } from '../alpha/ModalDialogContentText';
-export {
+export type {
   /** @deprecated */
   ModalDialogContentTextClassKey as Unstable_ModalDialogContentTextClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ModalDialogTitle/index.ts
+++ b/libs/spark/src/Unstable_ModalDialogTitle/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ModalDialogTitle` */
   default,
 } from '../alpha/ModalDialogTitle';
-export {
+export type {
   /** @deprecated */
   ModalDialogTitleClassKey as Unstable_ModalDialogTitleClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Paper/index.ts
+++ b/libs/spark/src/Unstable_Paper/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Paper` */
   default,
 } from '../alpha/Paper';
-export {
+export type {
   /** @deprecated */
   PaperClassKey as Unstable_PaperClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Radio/index.ts
+++ b/libs/spark/src/Unstable_Radio/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Radio` */
   default,
 } from '../alpha/Radio';
-export {
+export type {
   /** @deprecated */
   RadioClassKey as Unstable_RadioClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_RadioField/index.ts
+++ b/libs/spark/src/Unstable_RadioField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/RadioField` */
   default,
 } from '../alpha/RadioField';
-export {
+export type {
   /** @deprecated */
   RadioFieldProps as Unstable_RadioFieldProps,
 } from '../alpha/RadioField';

--- a/libs/spark/src/Unstable_RadioGroup/index.ts
+++ b/libs/spark/src/Unstable_RadioGroup/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/RadioGroup` */
   default,
 } from '../alpha/RadioGroup';
-export {
+export type {
   /** @deprecated */
   RadioGroupClassKey as Unstable_RadioGroupClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_RadioGroupExtraContext/index.ts
+++ b/libs/spark/src/Unstable_RadioGroupExtraContext/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/RadioGroupExtraContext` */
   default,
 } from '../alpha/RadioGroupExtraContext';
-export {
+export type {
   /** @deprecated */
   RadioGroupExtraContextValue as Unstable_RadioGroupExtraContextValue,
 } from '../alpha/RadioGroupExtraContext';

--- a/libs/spark/src/Unstable_RadioGroupField/index.ts
+++ b/libs/spark/src/Unstable_RadioGroupField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/RadioGroupField` */
   default,
 } from '../alpha/RadioGroupField';
-export {
+export type {
   /** @deprecated */
   RadioGroupFieldProps as Unstable_RadioGroupFieldProps,
 } from '../alpha/RadioGroupField';

--- a/libs/spark/src/Unstable_SectionMessage/index.ts
+++ b/libs/spark/src/Unstable_SectionMessage/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SectionMessage` */
   default,
 } from '../alpha/SectionMessage';
-export {
+export type {
   /** @deprecated */
   SectionMessageClassKey as Unstable_SectionMessageClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Select/index.ts
+++ b/libs/spark/src/Unstable_Select/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Select` */
   default,
 } from '../alpha/Select';
-export {
+export type {
   /** @deprecated */
   SelectClassKey as Unstable_SelectClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_SvgIcon/index.ts
+++ b/libs/spark/src/Unstable_SvgIcon/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SvgIcon` */
   default,
 } from '../alpha/SvgIcon';
-export {
+export type {
   /** @deprecated */
   SvgIconClassKey as Unstable_SvgIconClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Switch/index.ts
+++ b/libs/spark/src/Unstable_Switch/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Switch` */
   default,
 } from '../alpha/Switch';
-export {
+export type {
   /** @deprecated */
   SwitchClassKey as Unstable_SwitchClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_SwitchField/index.ts
+++ b/libs/spark/src/Unstable_SwitchField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/SwitchField` */
   default,
 } from '../alpha/SwitchField';
-export {
+export type {
   /** @deprecated */
   SwitchFieldProps as Unstable_SwitchFieldProps,
 } from '../alpha/SwitchField';

--- a/libs/spark/src/Unstable_Tab/index.ts
+++ b/libs/spark/src/Unstable_Tab/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Tab` */
   default,
 } from '../alpha/Tab';
-export {
+export type {
   /** @deprecated */
   TabClassKey as Unstable_TabClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_TabPanel/index.ts
+++ b/libs/spark/src/Unstable_TabPanel/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/TabPanel` */
   default,
 } from '../alpha/TabPanel';
-export {
+export type {
   /** @deprecated */
   TabPanelClassKey as Unstable_TabPanelClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Tabs/index.ts
+++ b/libs/spark/src/Unstable_Tabs/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Tabs` */
   default,
 } from '../alpha/Tabs';
-export {
+export type {
   /** @deprecated */
   TabsClassKey as Unstable_TabsClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_TabsContext/index.ts
+++ b/libs/spark/src/Unstable_TabsContext/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/TabsContext` */
   default,
 } from '../alpha/TabsContext';
-export {
+export type {
   /** @deprecated */
   TabsContextValue as Unstable_TabsContextValue,
 } from '../alpha/TabsContext';

--- a/libs/spark/src/Unstable_TabsList/index.ts
+++ b/libs/spark/src/Unstable_TabsList/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/TabsList` */
   default,
 } from '../alpha/TabsList';
-export {
+export type {
   /** @deprecated */
   TabsListClassKey as Unstable_TabsListClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Tag/index.ts
+++ b/libs/spark/src/Unstable_Tag/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Tag` */
   default,
 } from '../alpha/Tag';
-export {
+export type {
   /** @deprecated */
   TagClassKey as Unstable_TagClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_TextField/index.ts
+++ b/libs/spark/src/Unstable_TextField/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/TextField` */
   default,
 } from '../alpha/TextField';
-export {
+export type {
   /** @deprecated */
   TextFieldProps as Unstable_TextFieldProps,
 } from '../alpha/TextField';

--- a/libs/spark/src/Unstable_Toast/index.ts
+++ b/libs/spark/src/Unstable_Toast/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Toast` */
   default,
 } from '../alpha/Toast';
-export {
+export type {
   /** @deprecated */
   ToastClassKey as Unstable_ToastClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ToastsContext/index.ts
+++ b/libs/spark/src/Unstable_ToastsContext/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   /** @deprecated */
   ToastsContextEnqueueOptions as Unstable_ToastsContextEnqueueOptions,
   /** @deprecated */

--- a/libs/spark/src/Unstable_ToastsProvider/index.ts
+++ b/libs/spark/src/Unstable_ToastsProvider/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/ToastsProvider` */
   default,
 } from '../alpha/ToastsProvider';
-export {
+export type {
   /** @deprecated */
   ToastsProviderProps as Unstable_ToastsProviderProps,
 } from '../alpha/ToastsProvider';

--- a/libs/spark/src/Unstable_Tooltip/index.ts
+++ b/libs/spark/src/Unstable_Tooltip/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Tooltip` */
   default,
 } from '../alpha/Tooltip';
-export {
+export type {
   /** @deprecated */
   TooltipClassKey as Unstable_TooltipClassKey,
   /** @deprecated */

--- a/libs/spark/src/Unstable_Typography/index.ts
+++ b/libs/spark/src/Unstable_Typography/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/Typography` */
   default,
 } from '../alpha/Typography';
-export {
+export type {
   /** @deprecated */
   TypographyClassKey as Unstable_TypographyClassKey,
   /** @deprecated */

--- a/libs/spark/src/alpha/Autocomplete/Autocomplete.stories.tsx
+++ b/libs/spark/src/alpha/Autocomplete/Autocomplete.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Autocomplete, AutocompleteProps } from '..';
+import type { AutocompleteProps } from '..';
+import { Autocomplete } from '..';
 import {
   containBoxShadow,
   enableHooks,

--- a/libs/spark/src/alpha/Autocomplete/Autocomplete.tsx
+++ b/libs/spark/src/alpha/Autocomplete/Autocomplete.tsx
@@ -5,14 +5,8 @@ import type {
   AutocompleteRenderGroupParams as MuiAutocompleteRenderGroupParams,
 } from '@material-ui/lab/Autocomplete';
 import clsx from 'clsx';
-import type {
-  ComponentType,
-  HTMLAttributes,
-  Key,
-  ReactNode} from 'react';
-import React, {
-  forwardRef,
-} from 'react';
+import type { ComponentType, HTMLAttributes, Key, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import Skeleton from '../Skeleton';
 import CheckboxMenuItem from '../CheckboxMenuItem';
 import type { IconButtonProps } from '../IconButton';
@@ -28,9 +22,7 @@ import type { TagProps } from '../Tag';
 import Tag from '../Tag';
 import { ChevronDown, Cross } from '../../internal';
 import { buildVariant } from '../theme/typography';
-import type {
-  UseAutocompleteResultGetOptionProps,
-} from '../useAutocomplete';
+import type { UseAutocompleteResultGetOptionProps } from '../useAutocomplete';
 import useAutocomplete from '../useAutocomplete';
 import type { FormControlProperties } from '../useFormControl';
 import useFormControl from '../useFormControl';

--- a/libs/spark/src/alpha/Autocomplete/Autocomplete.tsx
+++ b/libs/spark/src/alpha/Autocomplete/Autocomplete.tsx
@@ -1,33 +1,42 @@
-import Popper, { PopperProps } from '@material-ui/core/Popper';
-import {
+import type { PopperProps } from '@material-ui/core/Popper';
+import Popper from '@material-ui/core/Popper';
+import type {
   AutocompleteProps as MuiAutocompleteProps,
   AutocompleteRenderGroupParams as MuiAutocompleteRenderGroupParams,
 } from '@material-ui/lab/Autocomplete';
 import clsx from 'clsx';
-import React, {
+import type {
   ComponentType,
   HTMLAttributes,
   Key,
-  ReactNode,
+  ReactNode} from 'react';
+import React, {
   forwardRef,
 } from 'react';
 import Skeleton from '../Skeleton';
 import CheckboxMenuItem from '../CheckboxMenuItem';
-import IconButton, { IconButtonProps } from '../IconButton';
-import Input, { InputProps } from '../Input';
+import type { IconButtonProps } from '../IconButton';
+import IconButton from '../IconButton';
+import type { InputProps } from '../Input';
+import Input from '../Input';
 import InputAdornment from '../InputAdornment';
 import ListSubheader from '../ListSubheader';
 import MenuItem from '../MenuItem';
-import Paper, { PaperProps } from '../Paper';
-import Tag, { TagProps } from '../Tag';
+import type { PaperProps } from '../Paper';
+import Paper from '../Paper';
+import type { TagProps } from '../Tag';
+import Tag from '../Tag';
 import { ChevronDown, Cross } from '../../internal';
 import { buildVariant } from '../theme/typography';
-import useAutocomplete, {
+import type {
   UseAutocompleteResultGetOptionProps,
 } from '../useAutocomplete';
-import useFormControl, { FormControlProperties } from '../useFormControl';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import useAutocomplete from '../useAutocomplete';
+import type { FormControlProperties } from '../useFormControl';
+import useFormControl from '../useFormControl';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface AutocompleteProps<
   T,

--- a/libs/spark/src/alpha/Avatar/Avatar.stories.tsx
+++ b/libs/spark/src/alpha/Avatar/Avatar.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Avatar, AvatarProps } from '..';
+import type { AvatarProps } from '..';
+import { Avatar } from '..';
 import { sparkThemeProvider, User } from '../../../stories';
 
 export default {

--- a/libs/spark/src/alpha/Avatar/Avatar.tsx
+++ b/libs/spark/src/alpha/Avatar/Avatar.tsx
@@ -1,12 +1,15 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  AvatarProps as MuiAvatarProps} from '@material-ui/core/Avatar';
 import {
-  default as MuiAvatar,
-  AvatarProps as MuiAvatarProps,
+  default as MuiAvatar
 } from '@material-ui/core/Avatar';
 import { buildVariant } from '../theme/typography';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface AvatarTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Avatar/Avatar.tsx
+++ b/libs/spark/src/alpha/Avatar/Avatar.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  AvatarProps as MuiAvatarProps} from '@material-ui/core/Avatar';
-import {
-  default as MuiAvatar
-} from '@material-ui/core/Avatar';
+import type { AvatarProps as MuiAvatarProps } from '@material-ui/core/Avatar';
+import { default as MuiAvatar } from '@material-ui/core/Avatar';
 import { buildVariant } from '../theme/typography';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/AvatarButton/AvatarButton.stories.tsx
+++ b/libs/spark/src/alpha/AvatarButton/AvatarButton.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { AvatarButton, AvatarButtonProps } from '..';
+import type { AvatarButtonProps } from '..';
+import { AvatarButton } from '..';
 import {
   containBoxShadowInline,
   inverseBackground,

--- a/libs/spark/src/alpha/AvatarButton/AvatarButton.tsx
+++ b/libs/spark/src/alpha/AvatarButton/AvatarButton.tsx
@@ -1,10 +1,7 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
-import type {
-  ExtendButtonBaseTypeMap} from '@material-ui/core/ButtonBase';
-import {
-  default as ButtonBase
-} from '@material-ui/core/ButtonBase';
+import type { ExtendButtonBaseTypeMap } from '@material-ui/core/ButtonBase';
+import { default as ButtonBase } from '@material-ui/core/ButtonBase';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { AvatarProps } from '../Avatar';
 import Avatar from '../Avatar';

--- a/libs/spark/src/alpha/AvatarButton/AvatarButton.tsx
+++ b/libs/spark/src/alpha/AvatarButton/AvatarButton.tsx
@@ -1,11 +1,15 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
+  ExtendButtonBaseTypeMap} from '@material-ui/core/ButtonBase';
 import {
-  default as ButtonBase,
-  ExtendButtonBaseTypeMap,
+  default as ButtonBase
 } from '@material-ui/core/ButtonBase';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import Avatar, { AvatarProps } from '../Avatar';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { AvatarProps } from '../Avatar';
+import Avatar from '../Avatar';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 type _AvatarButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Banner/Banner.stories.tsx
+++ b/libs/spark/src/alpha/Banner/Banner.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Banner, BannerProps } from '..';
+import type { BannerProps } from '..';
+import { Banner } from '..';
 
 export default {
   title: '@ps/Banner',

--- a/libs/spark/src/alpha/Banner/Banner.tsx
+++ b/libs/spark/src/alpha/Banner/Banner.tsx
@@ -1,7 +1,9 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import Alert, { AlertClassKey, AlertProps } from '../internal/Alert';
-import withStyles, { Styles } from '../../withStyles';
+import type { AlertClassKey, AlertProps } from '../internal/Alert';
+import Alert from '../internal/Alert';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface BannerProps extends AlertProps {}

--- a/libs/spark/src/alpha/Breadcrumb/Breadcrumb.tsx
+++ b/libs/spark/src/alpha/Breadcrumb/Breadcrumb.tsx
@@ -1,8 +1,11 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
-import Link, { LinkClassKey, LinkProps, LinkTypeMap } from '../Link';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
+import type { LinkClassKey, LinkProps, LinkTypeMap } from '../Link';
+import Link from '../Link';
 
 export interface BreadcrumbTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Breadcrumbs/Breadcrumbs.tsx
+++ b/libs/spark/src/alpha/Breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,14 @@
-import React, { ElementType, forwardRef } from 'react';
-import {
-  default as MuiBreadcrumbs,
+import type { ElementType } from 'react';
+import React, { forwardRef } from 'react';
+import type {
   BreadcrumbsClassKey as MuiBreadcrumbsClassKey,
   BreadcrumbsProps as MuiBreadcrumbsProps,
   BreadcrumbsTypeMap as MuiBreadcrumbsTypeMap,
 } from '@material-ui/core/Breadcrumbs';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import { default as MuiBreadcrumbs } from '@material-ui/core/Breadcrumbs';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import createSvgIcon from '../createSvgIcon/createSvgIcon';
 
 export interface BreadcrumbsTypeMap<

--- a/libs/spark/src/alpha/Button/Button.stories.tsx
+++ b/libs/spark/src/alpha/Button/Button.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme } from '../..';
-import { Avatar, Button, ButtonProps } from '..';
+import type { ButtonProps } from '..';
+import { Avatar, Button } from '..';
 import {
   ChevronDown,
   containBoxShadowInline,

--- a/libs/spark/src/alpha/Button/Button.tsx
+++ b/libs/spark/src/alpha/Button/Button.tsx
@@ -1,14 +1,17 @@
-import React, { cloneElement, ElementType, forwardRef, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { cloneElement, forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  ButtonProps as MuiButtonProps} from '@material-ui/core/Button';
 import {
-  default as MuiButton,
-  ButtonProps as MuiButtonProps,
+  default as MuiButton
 } from '@material-ui/core/Button';
-import { OverridableComponent, OverrideProps } from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { buildVariant } from '../theme/typography';
 import { lighten, darken, alpha } from '@material-ui/core/styles';
-import { AvatarProps } from '../Avatar';
-import withStyles, { Styles } from '../../withStyles';
+import type { AvatarProps } from '../Avatar';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Button/Button.tsx
+++ b/libs/spark/src/alpha/Button/Button.tsx
@@ -1,11 +1,8 @@
 import type { ElementType, ReactNode } from 'react';
 import React, { cloneElement, forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  ButtonProps as MuiButtonProps} from '@material-ui/core/Button';
-import {
-  default as MuiButton
-} from '@material-ui/core/Button';
+import type { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
+import { default as MuiButton } from '@material-ui/core/Button';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import { buildVariant } from '../theme/typography';
 import { lighten, darken, alpha } from '@material-ui/core/styles';

--- a/libs/spark/src/alpha/Card/Card.stories.tsx
+++ b/libs/spark/src/alpha/Card/Card.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Card, CardProps, Typography } from '..';
+import type { CardProps} from '..';
+import { Card, Typography } from '..';
 
 export const _retyped = (props: CardProps) => <Card {...props} />;
 

--- a/libs/spark/src/alpha/Card/Card.stories.tsx
+++ b/libs/spark/src/alpha/Card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type { CardProps} from '..';
+import type { CardProps } from '..';
 import { Card, Typography } from '..';
 
 export const _retyped = (props: CardProps) => <Card {...props} />;

--- a/libs/spark/src/alpha/Card/Card.tsx
+++ b/libs/spark/src/alpha/Card/Card.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type { PaperProps } from '../Paper';
 import Paper from '../Paper';

--- a/libs/spark/src/alpha/Card/Card.tsx
+++ b/libs/spark/src/alpha/Card/Card.tsx
@@ -1,8 +1,11 @@
 import clsx from 'clsx';
-import React, { ElementType, forwardRef } from 'react';
-import Paper, { PaperProps } from '../Paper';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type { PaperProps } from '../Paper';
+import Paper from '../Paper';
 import type { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface CardTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Checkbox/Checkbox.stories.tsx
+++ b/libs/spark/src/alpha/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Checkbox, CheckboxProps } from '..';
+import type { CheckboxProps } from '..';
+import { Checkbox } from '..';
 import {
   containBoxShadowInline,
   enableHooks,

--- a/libs/spark/src/alpha/Checkbox/Checkbox.tsx
+++ b/libs/spark/src/alpha/Checkbox/Checkbox.tsx
@@ -1,11 +1,14 @@
-import React, { forwardRef, Ref } from 'react';
+import type { Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  CheckboxProps as MuiCheckboxProps} from '@material-ui/core/Checkbox';
 import {
-  default as MuiCheckbox,
-  CheckboxProps as MuiCheckboxProps,
+  default as MuiCheckbox
 } from '@material-ui/core/Checkbox';
 import CheckboxIcon from './CheckboxIcon';
-import withStyles, { StyledComponentProps } from '../../withStyles';
+import type { StyledComponentProps } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface CheckboxProps
   extends Omit<

--- a/libs/spark/src/alpha/Checkbox/Checkbox.tsx
+++ b/libs/spark/src/alpha/Checkbox/Checkbox.tsx
@@ -1,11 +1,8 @@
 import type { Ref } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  CheckboxProps as MuiCheckboxProps} from '@material-ui/core/Checkbox';
-import {
-  default as MuiCheckbox
-} from '@material-ui/core/Checkbox';
+import type { CheckboxProps as MuiCheckboxProps } from '@material-ui/core/Checkbox';
+import { default as MuiCheckbox } from '@material-ui/core/Checkbox';
 import CheckboxIcon from './CheckboxIcon';
 import type { StyledComponentProps } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/CheckboxField/CheckboxField.stories.tsx
+++ b/libs/spark/src/alpha/CheckboxField/CheckboxField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { CheckboxField, CheckboxFieldProps } from '..';
+import type { CheckboxFieldProps } from '..';
+import { CheckboxField } from '..';
 import { containBoxShadowInline } from '../../../stories';
 
 export const _retyped = CheckboxField as typeof CheckboxField;

--- a/libs/spark/src/alpha/CheckboxField/CheckboxField.tsx
+++ b/libs/spark/src/alpha/CheckboxField/CheckboxField.tsx
@@ -1,10 +1,14 @@
-import React, { forwardRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import FormControlLabel, { FormControlLabelProps } from '../FormControlLabel';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
+import type { FormControlLabelProps } from '../FormControlLabel';
+import FormControlLabel from '../FormControlLabel';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
 import Checkbox from '../Checkbox';
 import { useId } from '../../utils';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface CheckboxFieldProps
   extends Omit<FormControlLabelProps, 'classes' | 'control'>,

--- a/libs/spark/src/alpha/CheckboxGroupField/CheckboxGroupField.stories.tsx
+++ b/libs/spark/src/alpha/CheckboxGroupField/CheckboxGroupField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { CheckboxField, CheckboxGroupField, CheckboxGroupFieldProps } from '..';
+import type { CheckboxGroupFieldProps } from '..';
+import { CheckboxField, CheckboxGroupField } from '..';
 import { containBoxShadow, Info } from '../../../stories';
 
 export const _retyped = CheckboxGroupField as typeof CheckboxGroupField;

--- a/libs/spark/src/alpha/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/libs/spark/src/alpha/CheckboxGroupField/CheckboxGroupField.tsx
@@ -1,8 +1,13 @@
-import React, { forwardRef, ReactNode, RefObject } from 'react';
-import FormControl, { FormControlProps } from '../FormControl';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
-import FormLabel, { FormLabelProps } from '../FormLabel';
-import FormGroup, { FormGroupProps } from '../FormGroup';
+import type { ReactNode, RefObject } from 'react';
+import React, { forwardRef } from 'react';
+import type { FormControlProps } from '../FormControl';
+import FormControl from '../FormControl';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
+import type { FormLabelProps } from '../FormLabel';
+import FormLabel from '../FormLabel';
+import type { FormGroupProps } from '../FormGroup';
+import FormGroup from '../FormGroup';
 import { useId } from '../../utils';
 
 export interface CheckboxGroupFieldProps

--- a/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.stories.tsx
+++ b/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Avatar, CheckboxListItem, CheckboxListItemProps } from '..';
+import type { CheckboxListItemProps } from '..';
+import { Avatar, CheckboxListItem } from '..';
 import { containBoxShadow, enableHooks, statefulValue } from '../../../stories';
 import { default as ListItemMeta } from '../ListItem/ListItem.stories';
 

--- a/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.test.tsx
+++ b/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
-import CheckboxListItem, { CheckboxListItemProps } from './CheckboxListItem';
+import type { CheckboxListItemProps } from './CheckboxListItem';
+import CheckboxListItem from './CheckboxListItem';
 
 describe('CheckboxListItem', () => {
   it('Can render without ThemeProvider', () => {

--- a/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.tsx
+++ b/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.tsx
@@ -1,16 +1,21 @@
-import React, {
+import type {
   ElementType,
-  forwardRef,
   MouseEvent,
   MouseEventHandler,
-  Ref,
+  Ref} from 'react';
+import React, {
+  forwardRef
 } from 'react';
 import clsx from 'clsx';
-import Checkbox, { CheckboxProps } from '../Checkbox';
-import ListItem, { ListItemTypeMap, ListItemProps } from '../ListItem';
-import { OverridableComponent, OverrideProps, useId } from '../../utils';
-import { ExtendButtonBase } from '../../ButtonBase';
-import withStyles, { Styles } from '../../withStyles';
+import type { CheckboxProps } from '../Checkbox';
+import Checkbox from '../Checkbox';
+import type { ListItemTypeMap, ListItemProps } from '../ListItem';
+import ListItem from '../ListItem';
+import type { OverridableComponent, OverrideProps} from '../../utils';
+import { useId } from '../../utils';
+import type { ExtendButtonBase } from '../../ButtonBase';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export type CheckboxListItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.tsx
+++ b/libs/spark/src/alpha/CheckboxListItem/CheckboxListItem.tsx
@@ -1,17 +1,11 @@
-import type {
-  ElementType,
-  MouseEvent,
-  MouseEventHandler,
-  Ref} from 'react';
-import React, {
-  forwardRef
-} from 'react';
+import type { ElementType, MouseEvent, MouseEventHandler, Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { CheckboxProps } from '../Checkbox';
 import Checkbox from '../Checkbox';
 import type { ListItemTypeMap, ListItemProps } from '../ListItem';
 import ListItem from '../ListItem';
-import type { OverridableComponent, OverrideProps} from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { useId } from '../../utils';
 import type { ExtendButtonBase } from '../../ButtonBase';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/CheckboxMenuItem/CheckboxMenuItem.stories.tsx
+++ b/libs/spark/src/alpha/CheckboxMenuItem/CheckboxMenuItem.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { CheckboxMenuItem, CheckboxMenuItemProps } from '..';
+import type { CheckboxMenuItemProps } from '..';
+import { CheckboxMenuItem } from '..';
 import { containBoxShadow, enableHooks, statefulValue } from '../../../stories';
 import { default as CheckboxListItemMeta } from '../CheckboxListItem/CheckboxListItem.stories';
 

--- a/libs/spark/src/alpha/CheckboxMenuItem/CheckboxMenuItem.tsx
+++ b/libs/spark/src/alpha/CheckboxMenuItem/CheckboxMenuItem.tsx
@@ -1,13 +1,16 @@
-import React, { ElementType, forwardRef, Ref } from 'react';
+import type { ElementType, Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import CheckboxListItem, {
+import type {
   CheckboxListItemProps,
   CheckboxListItemTypeMap,
 } from '../CheckboxListItem';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import { ExtendButtonBase } from '../../ButtonBase';
+import CheckboxListItem from '../CheckboxListItem';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { ExtendButtonBase } from '../../ButtonBase';
 import { alpha } from '@material-ui/core/styles';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export type CheckboxMenuItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/CircularProgress/CircularProgress.stories.tsx
+++ b/libs/spark/src/alpha/CircularProgress/CircularProgress.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { CircularProgress, CircularProgressProps } from '..';
+import type { CircularProgressProps } from '..';
+import { CircularProgress } from '..';
 
 export const _retyped = CircularProgress as typeof CircularProgress;
 

--- a/libs/spark/src/alpha/CircularProgress/CircularProgress.tsx
+++ b/libs/spark/src/alpha/CircularProgress/CircularProgress.tsx
@@ -1,10 +1,7 @@
-import type {
-  CircularProgressProps as MuiCircularProgressProps} from '@material-ui/core/CircularProgress';
-import {
-  default as MuiCircularProgress
-} from '@material-ui/core/CircularProgress';
+import type { CircularProgressProps as MuiCircularProgressProps } from '@material-ui/core/CircularProgress';
+import { default as MuiCircularProgress } from '@material-ui/core/CircularProgress';
 import clsx from 'clsx';
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import type { StandardProps } from '../../utils';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/CircularProgress/CircularProgress.tsx
+++ b/libs/spark/src/alpha/CircularProgress/CircularProgress.tsx
@@ -1,11 +1,14 @@
+import type {
+  CircularProgressProps as MuiCircularProgressProps} from '@material-ui/core/CircularProgress';
 import {
-  default as MuiCircularProgress,
-  CircularProgressProps as MuiCircularProgressProps,
+  default as MuiCircularProgress
 } from '@material-ui/core/CircularProgress';
 import clsx from 'clsx';
-import React, { ReactNode, forwardRef } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { ReactNode} from 'react';
+import React, { forwardRef } from 'react';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface CircularProgressProps
   extends StandardProps<

--- a/libs/spark/src/alpha/ContentGroup/ContentGroup.stories.tsx
+++ b/libs/spark/src/alpha/ContentGroup/ContentGroup.stories.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { makeStyles } from '../..';
+import type {
+  AvatarProps,
+  ContentGroupProps} from '..';
 import {
   Avatar,
-  AvatarProps,
   Checkbox,
   IconButton,
   Link,
   ContentGroup,
-  ContentGroupProps,
   useMediaQuery,
 } from '..';
 import {

--- a/libs/spark/src/alpha/ContentGroup/ContentGroup.stories.tsx
+++ b/libs/spark/src/alpha/ContentGroup/ContentGroup.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { makeStyles } from '../..';
-import type {
-  AvatarProps,
-  ContentGroupProps} from '..';
+import type { AvatarProps, ContentGroupProps } from '..';
 import {
   Avatar,
   Checkbox,

--- a/libs/spark/src/alpha/ContentGroup/ContentGroup.tsx
+++ b/libs/spark/src/alpha/ContentGroup/ContentGroup.tsx
@@ -1,8 +1,12 @@
-import React, { ElementType, forwardRef, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import Typography, { TypographyProps } from '../Typography';
-import { OverridableComponent, OverrideProps, useId } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { TypographyProps } from '../Typography';
+import Typography from '../Typography';
+import type { OverridableComponent, OverrideProps} from '../../utils';
+import { useId } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ContentGroupTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/ContentGroup/ContentGroup.tsx
+++ b/libs/spark/src/alpha/ContentGroup/ContentGroup.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { TypographyProps } from '../Typography';
 import Typography from '../Typography';
-import type { OverridableComponent, OverrideProps} from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { useId } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/Divider/Divider.stories.tsx
+++ b/libs/spark/src/alpha/Divider/Divider.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { DecoratorFn } from '@storybook/react';
-import { Divider, DividerProps } from '..';
+import type { DecoratorFn } from '@storybook/react';
+import type { DividerProps } from '..';
+import { Divider } from '..';
 
 export const _retyped = Divider as typeof Divider;
 

--- a/libs/spark/src/alpha/Divider/Divider.tsx
+++ b/libs/spark/src/alpha/Divider/Divider.tsx
@@ -1,10 +1,7 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
-import type {
-  DividerProps as MuiDividerProps} from '@material-ui/core/Divider';
-import {
-  default as MuiDivider
-} from '@material-ui/core/Divider';
+import type { DividerProps as MuiDividerProps } from '@material-ui/core/Divider';
+import { default as MuiDivider } from '@material-ui/core/Divider';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/Divider/Divider.tsx
+++ b/libs/spark/src/alpha/Divider/Divider.tsx
@@ -1,10 +1,13 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
+  DividerProps as MuiDividerProps} from '@material-ui/core/Divider';
 import {
-  default as MuiDivider,
-  DividerProps as MuiDividerProps,
+  default as MuiDivider
 } from '@material-ui/core/Divider';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import clsx from 'clsx';
 
 export interface DividerTypeMap<

--- a/libs/spark/src/alpha/Drawer/Drawer.tsx
+++ b/libs/spark/src/alpha/Drawer/Drawer.tsx
@@ -1,11 +1,14 @@
+import type {
+  DrawerProps as MuiDrawerProps} from '@material-ui/core/Drawer';
 import {
-  default as MuiDrawer,
-  DrawerProps as MuiDrawerProps,
+  default as MuiDrawer
 } from '@material-ui/core/Drawer';
 import clsx from 'clsx';
-import React, { CSSProperties } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { CSSProperties } from 'react';
+import React from 'react';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface DrawerProps
   extends StandardProps<

--- a/libs/spark/src/alpha/Drawer/Drawer.tsx
+++ b/libs/spark/src/alpha/Drawer/Drawer.tsx
@@ -1,8 +1,5 @@
-import type {
-  DrawerProps as MuiDrawerProps} from '@material-ui/core/Drawer';
-import {
-  default as MuiDrawer
-} from '@material-ui/core/Drawer';
+import type { DrawerProps as MuiDrawerProps } from '@material-ui/core/Drawer';
+import { default as MuiDrawer } from '@material-ui/core/Drawer';
 import clsx from 'clsx';
 import type { CSSProperties } from 'react';
 import React from 'react';

--- a/libs/spark/src/alpha/Dropdown/Dropdown.stories.tsx
+++ b/libs/spark/src/alpha/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,6 @@
-import React, { CSSProperties } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { CSSProperties } from 'react';
+import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import {
   AvatarButton,
   Button,

--- a/libs/spark/src/alpha/Dropdown/Dropdown.tsx
+++ b/libs/spark/src/alpha/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
-import React, {
+import type {
   MouseEvent,
-  ReactNode,
+  ReactNode} from 'react';
+import React, {
   useCallback,
   useMemo,
   useState,

--- a/libs/spark/src/alpha/Dropdown/Dropdown.tsx
+++ b/libs/spark/src/alpha/Dropdown/Dropdown.tsx
@@ -1,11 +1,5 @@
-import type {
-  MouseEvent,
-  ReactNode} from 'react';
-import React, {
-  useCallback,
-  useMemo,
-  useState,
-} from 'react';
+import type { MouseEvent, ReactNode } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DropdownContext from '../DropdownContext/DropdownContext';
 import { useUniqueId } from '../../utils';
 

--- a/libs/spark/src/alpha/DropdownContext/DropdownContext.ts
+++ b/libs/spark/src/alpha/DropdownContext/DropdownContext.ts
@@ -1,4 +1,5 @@
-import { createContext, MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
+import { createContext } from 'react';
 
 export interface DropdownContextValue {
   id: string;

--- a/libs/spark/src/alpha/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/alpha/DropdownMenu/DropdownMenu.tsx
@@ -1,9 +1,12 @@
-import { PopoverProps } from '@material-ui/core/Popover';
-import React, { ElementType, forwardRef } from 'react';
+import type { PopoverProps } from '@material-ui/core/Popover';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
-import Menu, { MenuProps } from '../Menu';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
+import type { MenuProps } from '../Menu';
+import Menu from '../Menu';
 import useDropdown from '../useDropdown';
 
 type Placement = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';

--- a/libs/spark/src/alpha/DropdownMenu/DropdownMenu.tsx
+++ b/libs/spark/src/alpha/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import type { PopoverProps } from '@material-ui/core/Popover';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { OverridableComponent, OverrideProps } from '../../utils';

--- a/libs/spark/src/alpha/DropdownTrigger/DropdownTrigger.tsx
+++ b/libs/spark/src/alpha/DropdownTrigger/DropdownTrigger.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type { ButtonProps, ButtonTypeMap } from '../Button';
 import Button from '../Button';

--- a/libs/spark/src/alpha/DropdownTrigger/DropdownTrigger.tsx
+++ b/libs/spark/src/alpha/DropdownTrigger/DropdownTrigger.tsx
@@ -1,10 +1,13 @@
 import clsx from 'clsx';
-import React, { ElementType, forwardRef } from 'react';
-import Button, { ButtonProps, ButtonTypeMap } from '../Button';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type { ButtonProps, ButtonTypeMap } from '../Button';
+import Button from '../Button';
 import { ChevronDown } from '../../internal';
 import useDropdown from '../useDropdown/useDropdown';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface DropdownTriggerTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/FontFacesBaseline/FontFacesBaseline.ts
+++ b/libs/spark/src/alpha/FontFacesBaseline/FontFacesBaseline.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import fontFaces from '../theme/fontFaces';
 import withStyles from '../../withStyles';
 

--- a/libs/spark/src/alpha/FormControl/FormControl.stories.tsx
+++ b/libs/spark/src/alpha/FormControl/FormControl.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type {
+  FormControlProps} from '..';
 import {
   Autocomplete,
   FormControl,
-  FormControlProps,
   FormHelperText,
   FormLabel,
   Input,

--- a/libs/spark/src/alpha/FormControl/FormControl.stories.tsx
+++ b/libs/spark/src/alpha/FormControl/FormControl.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type {
-  FormControlProps} from '..';
+import type { FormControlProps } from '..';
 import {
   Autocomplete,
   FormControl,

--- a/libs/spark/src/alpha/FormControl/FormControl.tsx
+++ b/libs/spark/src/alpha/FormControl/FormControl.tsx
@@ -1,12 +1,16 @@
-import React, { ElementType, forwardRef } from 'react';
-import MuiFormControl, {
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
   FormControlProps as MuiFormControlProps,
 } from '@material-ui/core/FormControl';
-import { OverridableComponent, OverrideProps, useId } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import MuiFormControl from '@material-ui/core/FormControl';
+import type { OverridableComponent, OverrideProps} from '../../utils';
+import { useId } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import clsx from 'clsx';
 import FormControlExtraContext from '../FormControlExtraContext';
-import { FormControlProperties } from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
 
 export interface FormControlTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/FormControl/FormControl.tsx
+++ b/libs/spark/src/alpha/FormControl/FormControl.tsx
@@ -1,10 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
-import type {
-  FormControlProps as MuiFormControlProps,
-} from '@material-ui/core/FormControl';
+import type { FormControlProps as MuiFormControlProps } from '@material-ui/core/FormControl';
 import MuiFormControl from '@material-ui/core/FormControl';
-import type { OverridableComponent, OverrideProps} from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { useId } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/FormControlExtraContext/FormControlExtraContext.ts
+++ b/libs/spark/src/alpha/FormControlExtraContext/FormControlExtraContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { FormControlProperties } from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
 
 /** internal */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/libs/spark/src/alpha/FormControlLabel/FormControlLabel.stories.tsx
+++ b/libs/spark/src/alpha/FormControlLabel/FormControlLabel.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Checkbox, FormControlLabel, FormControlLabelProps, Radio } from '..';
+import type { FormControlLabelProps} from '..';
+import { Checkbox, FormControlLabel, Radio } from '..';
 import { containBoxShadowInline, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = FormControlLabel as typeof FormControlLabel;

--- a/libs/spark/src/alpha/FormControlLabel/FormControlLabel.stories.tsx
+++ b/libs/spark/src/alpha/FormControlLabel/FormControlLabel.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type { FormControlLabelProps} from '..';
+import type { FormControlLabelProps } from '..';
 import { Checkbox, FormControlLabel, Radio } from '..';
 import { containBoxShadowInline, sparkThemeProvider } from '../../../stories';
 

--- a/libs/spark/src/alpha/FormControlLabel/FormControlLabel.tsx
+++ b/libs/spark/src/alpha/FormControlLabel/FormControlLabel.tsx
@@ -1,10 +1,7 @@
 import React, { cloneElement, forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  FormControlLabelProps as MuiFormControlLabelProps} from '@material-ui/core/FormControlLabel';
-import {
-  default as MuiFormControlLabel
-} from '@material-ui/core/FormControlLabel';
+import type { FormControlLabelProps as MuiFormControlLabelProps } from '@material-ui/core/FormControlLabel';
+import { default as MuiFormControlLabel } from '@material-ui/core/FormControlLabel';
 import { formControlState } from '../FormControl';
 import useFormControl from '../useFormControl';
 import type { StyledComponentProps, Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/FormControlLabel/FormControlLabel.tsx
+++ b/libs/spark/src/alpha/FormControlLabel/FormControlLabel.tsx
@@ -1,12 +1,14 @@
 import React, { cloneElement, forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  FormControlLabelProps as MuiFormControlLabelProps} from '@material-ui/core/FormControlLabel';
 import {
-  default as MuiFormControlLabel,
-  FormControlLabelProps as MuiFormControlLabelProps,
+  default as MuiFormControlLabel
 } from '@material-ui/core/FormControlLabel';
 import { formControlState } from '../FormControl';
 import useFormControl from '../useFormControl';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface FormControlLabelProps
   extends Omit<MuiFormControlLabelProps, 'classes'>,

--- a/libs/spark/src/alpha/FormGroup/FormGroup.stories.tsx
+++ b/libs/spark/src/alpha/FormGroup/FormGroup.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Checkbox, FormControlLabel, FormGroup, FormGroupProps } from '..';
+import type { FormGroupProps } from '..';
+import { Checkbox, FormControlLabel, FormGroup } from '..';
 import { containBoxShadow, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = FormGroup as typeof FormGroup;

--- a/libs/spark/src/alpha/FormGroup/FormGroup.tsx
+++ b/libs/spark/src/alpha/FormGroup/FormGroup.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef } from 'react';
-import type {
-  FormGroupProps as MuiFormGroupProps,
-} from '@material-ui/core/FormGroup';
+import type { FormGroupProps as MuiFormGroupProps } from '@material-ui/core/FormGroup';
 import MuiFormGroup from '@material-ui/core/FormGroup';
 import type { StyledComponentProps, Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/FormGroup/FormGroup.tsx
+++ b/libs/spark/src/alpha/FormGroup/FormGroup.tsx
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
-import MuiFormGroup, {
+import type {
   FormGroupProps as MuiFormGroupProps,
 } from '@material-ui/core/FormGroup';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import MuiFormGroup from '@material-ui/core/FormGroup';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface FormGroupProps
   extends Omit<MuiFormGroupProps, 'classes'>,

--- a/libs/spark/src/alpha/FormHelperText/FormHelperText.stories.tsx
+++ b/libs/spark/src/alpha/FormHelperText/FormHelperText.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { FormHelperText, FormHelperTextProps } from '..';
+import type { FormHelperTextProps } from '..';
+import { FormHelperText } from '..';
 import { Info } from '../../../stories';
 
 export const _retyped = FormHelperText as typeof FormHelperText;

--- a/libs/spark/src/alpha/FormHelperText/FormHelperText.tsx
+++ b/libs/spark/src/alpha/FormHelperText/FormHelperText.tsx
@@ -1,9 +1,12 @@
-import React, { ElementType, forwardRef, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import { buildVariant } from '../theme/typography';
-import useFormControl, { FormControlProperties } from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
+import useFormControl from '../useFormControl';
 
 export interface FormHelperTextTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/FormLabel/FormLabel.stories.tsx
+++ b/libs/spark/src/alpha/FormLabel/FormLabel.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { FormLabel, FormLabelProps } from '..';
+import type { FormLabelProps } from '..';
+import { FormLabel } from '..';
 import { sparkThemeProvider } from '../../../stories';
 
 export const _retyped = FormLabel as typeof FormLabel;

--- a/libs/spark/src/alpha/FormLabel/FormLabel.tsx
+++ b/libs/spark/src/alpha/FormLabel/FormLabel.tsx
@@ -1,12 +1,16 @@
-import React, { ElementType, forwardRef } from 'react';
-import MuiFormLabel, {
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
   FormLabelProps as MuiFormLabelProps,
 } from '@material-ui/core/FormLabel';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import MuiFormLabel from '@material-ui/core/FormLabel';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import clsx from 'clsx';
 import { buildVariant } from '../theme/typography';
-import useFormControl, { FormControlProperties } from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
+import useFormControl from '../useFormControl';
 
 export interface FormLabelTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/FormLabel/FormLabel.tsx
+++ b/libs/spark/src/alpha/FormLabel/FormLabel.tsx
@@ -1,8 +1,6 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
-import type {
-  FormLabelProps as MuiFormLabelProps,
-} from '@material-ui/core/FormLabel';
+import type { FormLabelProps as MuiFormLabelProps } from '@material-ui/core/FormLabel';
 import MuiFormLabel from '@material-ui/core/FormLabel';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/IconButton/IconButton.stories.tsx
+++ b/libs/spark/src/alpha/IconButton/IconButton.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme } from '../..';
-import { IconButton, IconButtonProps } from '..';
+import type { IconButtonProps } from '..';
+import { IconButton } from '..';
 import {
   ChevronDown,
   containBoxShadowInline,

--- a/libs/spark/src/alpha/IconButton/IconButton.tsx
+++ b/libs/spark/src/alpha/IconButton/IconButton.tsx
@@ -1,12 +1,15 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  IconButtonProps as MuiIconButtonProps} from '@material-ui/core/IconButton';
 import {
-  default as MuiIconButton,
-  IconButtonProps as MuiIconButtonProps,
+  default as MuiIconButton
 } from '@material-ui/core/IconButton';
-import { OverridableComponent, OverrideProps } from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { lighten, darken, alpha } from '@material-ui/core/styles';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface IconButtonTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/IconButton/IconButton.tsx
+++ b/libs/spark/src/alpha/IconButton/IconButton.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  IconButtonProps as MuiIconButtonProps} from '@material-ui/core/IconButton';
-import {
-  default as MuiIconButton
-} from '@material-ui/core/IconButton';
+import type { IconButtonProps as MuiIconButtonProps } from '@material-ui/core/IconButton';
+import { default as MuiIconButton } from '@material-ui/core/IconButton';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import { lighten, darken, alpha } from '@material-ui/core/styles';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/Input/Input.stories.tsx
+++ b/libs/spark/src/alpha/Input/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Input, InputProps as _InputProps } from '..';
+import type { InputProps as _InputProps } from '..';
+import { Input } from '..';
 import {
   containBoxShadow,
   enableHooks,

--- a/libs/spark/src/alpha/Input/Input.tsx
+++ b/libs/spark/src/alpha/Input/Input.tsx
@@ -1,13 +1,17 @@
-import React, { forwardRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  InputBaseProps as MuiInputBaseProps} from '@material-ui/core/InputBase';
 import {
-  default as MuiInputBase,
-  InputBaseProps as MuiInputBaseProps,
+  default as MuiInputBase
 } from '@material-ui/core/InputBase';
 import InputAdornment from '../InputAdornment';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import { buildVariant } from '../theme/typography';
-import useFormControl, { FormControlProperties } from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
+import useFormControl from '../useFormControl';
 
 export interface InputProps
   extends Omit<

--- a/libs/spark/src/alpha/Input/Input.tsx
+++ b/libs/spark/src/alpha/Input/Input.tsx
@@ -1,11 +1,8 @@
 import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  InputBaseProps as MuiInputBaseProps} from '@material-ui/core/InputBase';
-import {
-  default as MuiInputBase
-} from '@material-ui/core/InputBase';
+import type { InputBaseProps as MuiInputBaseProps } from '@material-ui/core/InputBase';
+import { default as MuiInputBase } from '@material-ui/core/InputBase';
 import InputAdornment from '../InputAdornment';
 import type { StyledComponentProps, Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/InputAdornment/InputAdornment.stories.tsx
+++ b/libs/spark/src/alpha/InputAdornment/InputAdornment.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { InputAdornment, InputAdornmentProps } from '..';
+import type { InputAdornmentProps } from '..';
+import { InputAdornment } from '..';
 import { Search, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = InputAdornment as typeof InputAdornment;

--- a/libs/spark/src/alpha/InputAdornment/InputAdornment.tsx
+++ b/libs/spark/src/alpha/InputAdornment/InputAdornment.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import { buildVariant } from '../theme/typography';
 import type { FormControlProperties } from '../useFormControl';

--- a/libs/spark/src/alpha/InputAdornment/InputAdornment.tsx
+++ b/libs/spark/src/alpha/InputAdornment/InputAdornment.tsx
@@ -1,9 +1,12 @@
 import clsx from 'clsx';
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import { buildVariant } from '../theme/typography';
-import useFormControl, { FormControlProperties } from '../useFormControl';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { FormControlProperties } from '../useFormControl';
+import useFormControl from '../useFormControl';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface InputAdornmentTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/LinearProgress/LinearProgress.stories.tsx
+++ b/libs/spark/src/alpha/LinearProgress/LinearProgress.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { LinearProgress, LinearProgressProps } from '..';
+import type { LinearProgressProps } from '..';
+import { LinearProgress } from '..';
 
 export const _retyped = LinearProgress as typeof LinearProgress;
 

--- a/libs/spark/src/alpha/LinearProgress/LinearProgress.tsx
+++ b/libs/spark/src/alpha/LinearProgress/LinearProgress.tsx
@@ -1,11 +1,14 @@
+import type {
+  LinearProgressProps as MuiLinearProgressProps} from '@material-ui/core/LinearProgress';
 import {
-  default as MuiLinearProgress,
-  LinearProgressProps as MuiLinearProgressProps,
+  default as MuiLinearProgress
 } from '@material-ui/core/LinearProgress';
 import clsx from 'clsx';
-import React, { forwardRef, isValidElement, ReactNode } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { ReactNode } from 'react';
+import React, { forwardRef, isValidElement } from 'react';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface LinearProgressProps
   extends StandardProps<

--- a/libs/spark/src/alpha/LinearProgress/LinearProgress.tsx
+++ b/libs/spark/src/alpha/LinearProgress/LinearProgress.tsx
@@ -1,8 +1,5 @@
-import type {
-  LinearProgressProps as MuiLinearProgressProps} from '@material-ui/core/LinearProgress';
-import {
-  default as MuiLinearProgress
-} from '@material-ui/core/LinearProgress';
+import type { LinearProgressProps as MuiLinearProgressProps } from '@material-ui/core/LinearProgress';
+import { default as MuiLinearProgress } from '@material-ui/core/LinearProgress';
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef, isValidElement } from 'react';

--- a/libs/spark/src/alpha/Link/Link.stories.tsx
+++ b/libs/spark/src/alpha/Link/Link.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { theme } from '../..';
-import { Link, LinkProps } from '..';
+import type { LinkProps } from '..';
+import { Link } from '..';
 import {
   containBoxShadowInline,
   inverseBackground,

--- a/libs/spark/src/alpha/Link/Link.tsx
+++ b/libs/spark/src/alpha/Link/Link.tsx
@@ -1,11 +1,14 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  LinkProps as MuiLinkProps} from '@material-ui/core/Link';
 import {
-  default as MuiLink,
-  LinkProps as MuiLinkProps,
+  default as MuiLink
 } from '@material-ui/core/Link';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface LinkTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Link/Link.tsx
+++ b/libs/spark/src/alpha/Link/Link.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  LinkProps as MuiLinkProps} from '@material-ui/core/Link';
-import {
-  default as MuiLink
-} from '@material-ui/core/Link';
+import type { LinkProps as MuiLinkProps } from '@material-ui/core/Link';
+import { default as MuiLink } from '@material-ui/core/Link';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/List/List.stories.tsx
+++ b/libs/spark/src/alpha/List/List.stories.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type {
-  ListProps} from '..';
+import type { ListProps } from '..';
 import {
   CheckboxListItem,
   Divider,
   IconButton,
   Link,
   List,
-  ListItem
+  ListItem,
 } from '..';
 import {
   CheckCircleDuotone,

--- a/libs/spark/src/alpha/List/List.stories.tsx
+++ b/libs/spark/src/alpha/List/List.stories.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type {
+  ListProps} from '..';
 import {
   CheckboxListItem,
   Divider,
   IconButton,
   Link,
   List,
-  ListItem,
-  ListProps,
+  ListItem
 } from '..';
 import {
   CheckCircleDuotone,

--- a/libs/spark/src/alpha/List/List.tsx
+++ b/libs/spark/src/alpha/List/List.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { ListSubheaderProps } from '../ListSubheader';
 import ListSubheader from '../ListSubheader';
-import type { OverridableComponent, OverrideProps} from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { useId } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/List/List.tsx
+++ b/libs/spark/src/alpha/List/List.tsx
@@ -1,8 +1,12 @@
-import React, { ElementType, forwardRef, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import ListSubheader, { ListSubheaderProps } from '../ListSubheader';
-import { OverridableComponent, OverrideProps, useId } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { ListSubheaderProps } from '../ListSubheader';
+import ListSubheader from '../ListSubheader';
+import type { OverridableComponent, OverrideProps} from '../../utils';
+import { useId } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ListTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/ListItem/ListItem.stories.tsx
+++ b/libs/spark/src/alpha/ListItem/ListItem.stories.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { makeStyles } from '../..';
+import type {
+  AvatarProps,
+  ListItemProps} from '..';
 import {
   Avatar,
-  AvatarProps,
   Checkbox,
   IconButton,
   Link,
   ListItem,
-  ListItemProps,
   useMediaQuery,
 } from '..';
 import {

--- a/libs/spark/src/alpha/ListItem/ListItem.stories.tsx
+++ b/libs/spark/src/alpha/ListItem/ListItem.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import { makeStyles } from '../..';
-import type {
-  AvatarProps,
-  ListItemProps} from '..';
+import type { AvatarProps, ListItemProps } from '..';
 import {
   Avatar,
   Checkbox,

--- a/libs/spark/src/alpha/ListItem/ListItem.tsx
+++ b/libs/spark/src/alpha/ListItem/ListItem.tsx
@@ -1,11 +1,8 @@
 import type { ElementType, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  ListItemProps as MuiListItemProps} from '@material-ui/core/ListItem';
-import {
-  default as MuiListItem
-} from '@material-ui/core/ListItem';
+import type { ListItemProps as MuiListItemProps } from '@material-ui/core/ListItem';
+import { default as MuiListItem } from '@material-ui/core/ListItem';
 import { default as MuiListItemSecondaryAction } from '@material-ui/core/ListItemSecondaryAction';
 import { darken, alpha } from '@material-ui/core/styles';
 import type { ExtendButtonBase } from '../../ButtonBase';

--- a/libs/spark/src/alpha/ListItem/ListItem.tsx
+++ b/libs/spark/src/alpha/ListItem/ListItem.tsx
@@ -1,15 +1,19 @@
-import React, { ElementType, forwardRef, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  ListItemProps as MuiListItemProps} from '@material-ui/core/ListItem';
 import {
-  default as MuiListItem,
-  ListItemProps as MuiListItemProps,
+  default as MuiListItem
 } from '@material-ui/core/ListItem';
 import { default as MuiListItemSecondaryAction } from '@material-ui/core/ListItemSecondaryAction';
 import { darken, alpha } from '@material-ui/core/styles';
-import { ExtendButtonBase } from '../../ButtonBase';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import ContentGroup, { ContentGroupProps } from '../ContentGroup';
-import withStyles, { Styles } from '../../withStyles';
+import type { ExtendButtonBase } from '../../ButtonBase';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { ContentGroupProps } from '../ContentGroup';
+import ContentGroup from '../ContentGroup';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ListItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/ListSubheader/ListSubheader.stories.tsx
+++ b/libs/spark/src/alpha/ListSubheader/ListSubheader.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { ListSubheader, ListSubheaderProps } from '..';
+import type { ListSubheaderProps } from '..';
+import { ListSubheader } from '..';
 
 export const _retyped = ListSubheader as typeof ListSubheader;
 

--- a/libs/spark/src/alpha/ListSubheader/ListSubheader.tsx
+++ b/libs/spark/src/alpha/ListSubheader/ListSubheader.tsx
@@ -1,7 +1,9 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ListSubheaderTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/ListSubheader/ListSubheader.tsx
+++ b/libs/spark/src/alpha/ListSubheader/ListSubheader.tsx
@@ -1,4 +1,4 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 import type { OverridableComponent, OverrideProps } from '../../utils';

--- a/libs/spark/src/alpha/Menu/Menu.stories.tsx
+++ b/libs/spark/src/alpha/Menu/Menu.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Button, CheckboxMenuItem, MenuItem, Menu, MenuProps } from '..';
+import type { MenuProps } from '..';
+import { Button, CheckboxMenuItem, MenuItem, Menu } from '..';
 import { enableHooks } from '../../../stories';
 
 export const _retyped = Menu as typeof Menu;

--- a/libs/spark/src/alpha/Menu/Menu.tsx
+++ b/libs/spark/src/alpha/Menu/Menu.tsx
@@ -1,14 +1,18 @@
 import React, { forwardRef } from 'react';
-import MuiMenu, {
+import type {
   MenuProps as MuiMenuProps,
   MenuClassKey as MuiMenuClassKey,
 } from '@material-ui/core/Menu';
+import MuiMenu from '@material-ui/core/Menu';
 import ListSubheader from '../ListSubheader';
-import { ListProps } from '../List';
-import { StandardProps, useId } from '../../utils';
-import { PaperProps, usePaperStyles } from '../Paper';
+import type { ListProps } from '../List';
+import type { StandardProps} from '../../utils';
+import { useId } from '../../utils';
+import type { PaperProps} from '../Paper';
+import { usePaperStyles } from '../Paper';
 import clsx from 'clsx';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MenuProps

--- a/libs/spark/src/alpha/Menu/Menu.tsx
+++ b/libs/spark/src/alpha/Menu/Menu.tsx
@@ -6,9 +6,9 @@ import type {
 import MuiMenu from '@material-ui/core/Menu';
 import ListSubheader from '../ListSubheader';
 import type { ListProps } from '../List';
-import type { StandardProps} from '../../utils';
+import type { StandardProps } from '../../utils';
 import { useId } from '../../utils';
-import type { PaperProps} from '../Paper';
+import type { PaperProps } from '../Paper';
 import { usePaperStyles } from '../Paper';
 import clsx from 'clsx';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/MenuItem/MenuItem.stories.tsx
+++ b/libs/spark/src/alpha/MenuItem/MenuItem.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Avatar, MenuItem, MenuItemProps } from '..';
+import type { MenuItemProps } from '..';
+import { Avatar, MenuItem } from '..';
 import { containBoxShadow, enableHooks, statefulValue } from '../../../stories';
 import { default as ListItemMeta } from '../ListItem/ListItem.stories';
 

--- a/libs/spark/src/alpha/MenuItem/MenuItem.tsx
+++ b/libs/spark/src/alpha/MenuItem/MenuItem.tsx
@@ -1,9 +1,12 @@
-import React, { ElementType, forwardRef, Ref } from 'react';
+import type { ElementType, Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import ListItem, { ListItemProps, ListItemTypeMap } from '../ListItem';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import { ExtendButtonBase } from '../../ButtonBase';
-import withStyles, { Styles } from '../../withStyles';
+import type { ListItemProps, ListItemTypeMap } from '../ListItem';
+import ListItem from '../ListItem';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { ExtendButtonBase } from '../../ButtonBase';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export type MenuItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/MenuList/MenuList.stories.tsx
+++ b/libs/spark/src/alpha/MenuList/MenuList.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { MenuItem, MenuList, MenuListProps } from '..';
+import type { MenuListProps } from '..';
+import { MenuItem, MenuList } from '..';
 import { containBoxShadow } from '../../../stories';
 
 export const _retyped = MenuList as typeof MenuList;

--- a/libs/spark/src/alpha/MenuList/MenuList.tsx
+++ b/libs/spark/src/alpha/MenuList/MenuList.tsx
@@ -1,11 +1,9 @@
 import type { Ref } from 'react';
 import React, { forwardRef } from 'react';
-import type {
-  MenuListProps as MuiMenuListProps,
-} from '@material-ui/core/MenuList';
+import type { MenuListProps as MuiMenuListProps } from '@material-ui/core/MenuList';
 import MuiMenuList from '@material-ui/core/MenuList';
 import ListSubheader from '../ListSubheader';
-import type { StandardProps} from '../../utils';
+import type { StandardProps } from '../../utils';
 import { useId } from '../../utils';
 import type { ListClassKey, ListProps } from '../List';
 

--- a/libs/spark/src/alpha/MenuList/MenuList.tsx
+++ b/libs/spark/src/alpha/MenuList/MenuList.tsx
@@ -1,10 +1,13 @@
-import React, { forwardRef, Ref } from 'react';
-import MuiMenuList, {
+import type { Ref } from 'react';
+import React, { forwardRef } from 'react';
+import type {
   MenuListProps as MuiMenuListProps,
 } from '@material-ui/core/MenuList';
+import MuiMenuList from '@material-ui/core/MenuList';
 import ListSubheader from '../ListSubheader';
-import { StandardProps, useId } from '../../utils';
-import { ListClassKey, ListProps } from '../List';
+import type { StandardProps} from '../../utils';
+import { useId } from '../../utils';
+import type { ListClassKey, ListProps } from '../List';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MenuListProps

--- a/libs/spark/src/alpha/ModalDialog/ModalDialog.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialog/ModalDialog.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type {
+  ModalDialogProps} from '..';
 import {
   Button,
   ModalDialog,
   ModalDialogActions,
   ModalDialogContent,
   ModalDialogContentText,
-  ModalDialogProps,
   ModalDialogTitle,
 } from '..';
 

--- a/libs/spark/src/alpha/ModalDialog/ModalDialog.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialog/ModalDialog.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type {
-  ModalDialogProps} from '..';
+import type { ModalDialogProps } from '..';
 import {
   Button,
   ModalDialog,

--- a/libs/spark/src/alpha/ModalDialog/ModalDialog.tsx
+++ b/libs/spark/src/alpha/ModalDialog/ModalDialog.tsx
@@ -1,8 +1,6 @@
-import type {
-  DialogProps as MuiDialogProps,
-} from '@material-ui/core/Dialog';
+import type { DialogProps as MuiDialogProps } from '@material-ui/core/Dialog';
 import MuiDialog from '@material-ui/core/Dialog';
-import type { ComponentType} from 'react';
+import type { ComponentType } from 'react';
 import React, { forwardRef } from 'react';
 import { Cross } from '../../internal';
 import type { IconButtonProps } from '../IconButton';

--- a/libs/spark/src/alpha/ModalDialog/ModalDialog.tsx
+++ b/libs/spark/src/alpha/ModalDialog/ModalDialog.tsx
@@ -1,13 +1,18 @@
-import MuiDialog, {
+import type {
   DialogProps as MuiDialogProps,
 } from '@material-ui/core/Dialog';
-import React, { ComponentType, forwardRef } from 'react';
+import MuiDialog from '@material-ui/core/Dialog';
+import type { ComponentType} from 'react';
+import React, { forwardRef } from 'react';
 import { Cross } from '../../internal';
-import IconButton, { IconButtonProps } from '../IconButton';
-import Paper, { PaperProps } from '../Paper';
-import withStyles, { Styles } from '../../withStyles';
-import { StandardProps } from '../../utils';
-import { ModalProps } from '../Modal';
+import type { IconButtonProps } from '../IconButton';
+import IconButton from '../IconButton';
+import type { PaperProps } from '../Paper';
+import Paper from '../Paper';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
+import type { StandardProps } from '../../utils';
+import type { ModalProps } from '../Modal';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ModalDialogProps

--- a/libs/spark/src/alpha/ModalDialogActions/ModalDialogActions.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialogActions/ModalDialogActions.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Button, ModalDialogActions, ModalDialogActionsProps } from '..';
+import type { ModalDialogActionsProps } from '..';
+import { Button, ModalDialogActions } from '..';
 
 export const _retyped = ModalDialogActions as typeof ModalDialogActions;
 

--- a/libs/spark/src/alpha/ModalDialogActions/ModalDialogActions.tsx
+++ b/libs/spark/src/alpha/ModalDialogActions/ModalDialogActions.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { HTMLAttributes, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ModalDialogActionsProps
   extends StandardProps<

--- a/libs/spark/src/alpha/ModalDialogContent/ModalDialogContent.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialogContent/ModalDialogContent.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { ModalDialogContent, ModalDialogTitleProps } from '..';
+import type { ModalDialogTitleProps } from '..';
+import { ModalDialogContent } from '..';
 
 export const _retyped = ModalDialogContent as typeof ModalDialogContent;
 

--- a/libs/spark/src/alpha/ModalDialogContent/ModalDialogContent.tsx
+++ b/libs/spark/src/alpha/ModalDialogContent/ModalDialogContent.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { HTMLAttributes, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ModalDialogContentProps
   extends StandardProps<

--- a/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { ModalDialogContentText, ModalDialogContentTextProps } from '..';
+import type { ModalDialogContentTextProps } from '..';
+import { ModalDialogContentText } from '..';
 
 export const _retyped = ModalDialogContentText as typeof ModalDialogContentText;
 

--- a/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.tsx
+++ b/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.tsx
@@ -1,7 +1,10 @@
-import React, { ElementType, forwardRef } from 'react';
-import Typography, { TypographyTypeMap } from '../Typography';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type { TypographyTypeMap } from '../Typography';
+import Typography from '../Typography';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ModalDialogContentTextTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.tsx
+++ b/libs/spark/src/alpha/ModalDialogContentText/ModalDialogContentText.tsx
@@ -1,4 +1,4 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type { TypographyTypeMap } from '../Typography';
 import Typography from '../Typography';

--- a/libs/spark/src/alpha/ModalDialogTitle/ModalDialogTitle.stories.tsx
+++ b/libs/spark/src/alpha/ModalDialogTitle/ModalDialogTitle.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { ModalDialogTitle, ModalDialogTitleProps } from '..';
+import type { ModalDialogTitleProps } from '..';
+import { ModalDialogTitle } from '..';
 
 export const _retyped = ModalDialogTitle as typeof ModalDialogTitle;
 

--- a/libs/spark/src/alpha/ModalDialogTitle/ModalDialogTitle.tsx
+++ b/libs/spark/src/alpha/ModalDialogTitle/ModalDialogTitle.tsx
@@ -1,8 +1,11 @@
 import clsx from 'clsx';
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
-import Typography, { TypographyProps } from '../Typography';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { HTMLAttributes, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
+import type { TypographyProps } from '../Typography';
+import Typography from '../Typography';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface ModalDialogTitleProps
   extends StandardProps<

--- a/libs/spark/src/alpha/Paper/Paper.stories.tsx
+++ b/libs/spark/src/alpha/Paper/Paper.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Paper, PaperProps } from '..';
+import type { PaperProps } from '..';
+import { Paper } from '..';
 import { containElevation } from '../../../stories';
 
 export const _retyped = (props: PaperProps) => <Paper {...props} />;

--- a/libs/spark/src/alpha/Paper/Paper.tsx
+++ b/libs/spark/src/alpha/Paper/Paper.tsx
@@ -1,12 +1,14 @@
 import clsx from 'clsx';
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import makeStyles from '../../makeStyles';
 import type { Borders } from '../theme/borders';
 import type { Palette } from '../theme/palette';
 import type { Radii } from '../theme/radii';
 import type { Shadows } from '../theme/shadows';
 import type { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface PaperTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Paper/Paper.tsx
+++ b/libs/spark/src/alpha/Paper/Paper.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import makeStyles from '../../makeStyles';
 import type { Borders } from '../theme/borders';

--- a/libs/spark/src/alpha/Radio/Radio.stories.tsx
+++ b/libs/spark/src/alpha/Radio/Radio.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Radio, RadioProps } from '..';
+import type { RadioProps } from '..';
+import { Radio } from '..';
 import {
   containBoxShadowInline,
   enableHooks,

--- a/libs/spark/src/alpha/Radio/Radio.tsx
+++ b/libs/spark/src/alpha/Radio/Radio.tsx
@@ -1,11 +1,14 @@
-import React, { forwardRef, Ref } from 'react';
+import type { Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  RadioProps as MuiRadioProps} from '@material-ui/core/Radio';
 import {
-  default as MuiRadio,
-  RadioProps as MuiRadioProps,
+  default as MuiRadio
 } from '@material-ui/core/Radio';
 import RadioIcon from './RadioIcon';
-import withStyles, { Styles, StyledComponentProps } from '../../withStyles';
+import type { Styles, StyledComponentProps } from '../../withStyles';
+import withStyles from '../../withStyles';
 import useRadioGroupExtra from '../useRadioGroupExtra/useRadioGroupExtra';
 
 export interface RadioProps

--- a/libs/spark/src/alpha/Radio/Radio.tsx
+++ b/libs/spark/src/alpha/Radio/Radio.tsx
@@ -1,11 +1,8 @@
 import type { Ref } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  RadioProps as MuiRadioProps} from '@material-ui/core/Radio';
-import {
-  default as MuiRadio
-} from '@material-ui/core/Radio';
+import type { RadioProps as MuiRadioProps } from '@material-ui/core/Radio';
+import { default as MuiRadio } from '@material-ui/core/Radio';
 import RadioIcon from './RadioIcon';
 import type { Styles, StyledComponentProps } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/RadioField/RadioField.stories.tsx
+++ b/libs/spark/src/alpha/RadioField/RadioField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { RadioField, RadioFieldProps } from '..';
+import type { RadioFieldProps } from '..';
+import { RadioField } from '..';
 import { containBoxShadowInline } from '../../../stories';
 
 export const _retyped = RadioField as typeof RadioField;

--- a/libs/spark/src/alpha/RadioField/RadioField.tsx
+++ b/libs/spark/src/alpha/RadioField/RadioField.tsx
@@ -1,10 +1,14 @@
-import React, { forwardRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import FormControlLabel, { FormControlLabelProps } from '../FormControlLabel';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
+import type { FormControlLabelProps } from '../FormControlLabel';
+import FormControlLabel from '../FormControlLabel';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
 import Radio from '../Radio/Radio';
 import { useId } from '../../utils';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface RadioFieldProps
   extends Omit<FormControlLabelProps, 'classes' | 'control'>,

--- a/libs/spark/src/alpha/RadioGroup/RadioGroup.stories.tsx
+++ b/libs/spark/src/alpha/RadioGroup/RadioGroup.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { RadioField, RadioGroup, RadioGroupProps } from '..';
+import type { RadioGroupProps } from '..';
+import { RadioField, RadioGroup } from '..';
 import { containBoxShadow, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = RadioGroup as typeof RadioGroup;

--- a/libs/spark/src/alpha/RadioGroup/RadioGroup.tsx
+++ b/libs/spark/src/alpha/RadioGroup/RadioGroup.tsx
@@ -1,11 +1,13 @@
 import React, { forwardRef } from 'react';
-import MuiRadioGroup, {
+import type {
   RadioGroupProps as MuiRadioGroupProps,
 } from '@material-ui/core/RadioGroup';
+import MuiRadioGroup from '@material-ui/core/RadioGroup';
 import RadioGroupExtraContext from '../RadioGroupExtraContext';
 import { formControlState } from '../FormControl';
 import useFormControl from '../useFormControl';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface RadioGroupProps
   extends Omit<MuiRadioGroupProps, 'classes'>,

--- a/libs/spark/src/alpha/RadioGroup/RadioGroup.tsx
+++ b/libs/spark/src/alpha/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef } from 'react';
-import type {
-  RadioGroupProps as MuiRadioGroupProps,
-} from '@material-ui/core/RadioGroup';
+import type { RadioGroupProps as MuiRadioGroupProps } from '@material-ui/core/RadioGroup';
 import MuiRadioGroup from '@material-ui/core/RadioGroup';
 import RadioGroupExtraContext from '../RadioGroupExtraContext';
 import { formControlState } from '../FormControl';

--- a/libs/spark/src/alpha/RadioGroupField/RadioGroupField.stories.tsx
+++ b/libs/spark/src/alpha/RadioGroupField/RadioGroupField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { RadioField, RadioGroupField, RadioGroupFieldProps } from '..';
+import type { RadioGroupFieldProps } from '..';
+import { RadioField, RadioGroupField } from '..';
 import { containBoxShadow, Info } from '../../../stories';
 
 export const _retyped = RadioGroupField as typeof RadioGroupField;

--- a/libs/spark/src/alpha/RadioGroupField/RadioGroupField.tsx
+++ b/libs/spark/src/alpha/RadioGroupField/RadioGroupField.tsx
@@ -1,8 +1,13 @@
-import React, { forwardRef, ReactNode, RefObject } from 'react';
-import FormControl, { FormControlProps } from '../FormControl';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
-import FormLabel, { FormLabelProps } from '../FormLabel';
-import RadioGroup, { RadioGroupProps } from '../RadioGroup';
+import type { ReactNode, RefObject } from 'react';
+import React, { forwardRef } from 'react';
+import type { FormControlProps } from '../FormControl';
+import FormControl from '../FormControl';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
+import type { FormLabelProps } from '../FormLabel';
+import FormLabel from '../FormLabel';
+import type { RadioGroupProps } from '../RadioGroup';
+import RadioGroup from '../RadioGroup';
 import { useId } from '../../utils';
 
 export interface RadioGroupFieldProps

--- a/libs/spark/src/alpha/SectionMessage/SectionMessage.stories.tsx
+++ b/libs/spark/src/alpha/SectionMessage/SectionMessage.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { SectionMessage, SectionMessageProps } from '..';
+import type { SectionMessageProps } from '..';
+import { SectionMessage } from '..';
 
 export default {
   title: '@ps/SectionMessage',

--- a/libs/spark/src/alpha/SectionMessage/SectionMessage.tsx
+++ b/libs/spark/src/alpha/SectionMessage/SectionMessage.tsx
@@ -1,8 +1,11 @@
-import React, { forwardRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import Alert, { AlertClassKey, AlertProps } from '../internal/Alert';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { AlertClassKey, AlertProps } from '../internal/Alert';
+import Alert from '../internal/Alert';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SectionMessageProps

--- a/libs/spark/src/alpha/Select/Select.stories.tsx
+++ b/libs/spark/src/alpha/Select/Select.stories.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type {
+  SelectProps as _SelectProps} from '..';
 import {
   CheckboxMenuItem,
   MenuItem,
-  Select,
-  SelectProps as _SelectProps,
+  Select
 } from '..';
 import {
   containBoxShadow,

--- a/libs/spark/src/alpha/Select/Select.stories.tsx
+++ b/libs/spark/src/alpha/Select/Select.stories.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type {
-  SelectProps as _SelectProps} from '..';
-import {
-  CheckboxMenuItem,
-  MenuItem,
-  Select
-} from '..';
+import type { SelectProps as _SelectProps } from '..';
+import { CheckboxMenuItem, MenuItem, Select } from '..';
 import {
   containBoxShadow,
   enableHooks,

--- a/libs/spark/src/alpha/Select/Select.tsx
+++ b/libs/spark/src/alpha/Select/Select.tsx
@@ -1,9 +1,7 @@
-import type { CSSProperties} from 'react';
+import type { CSSProperties } from 'react';
 import React, { cloneElement, forwardRef } from 'react';
 import type { SelectProps as MuiSelectProps } from '@material-ui/core/Select';
-import type {
-  SelectInputProps as MuiSelectInputProps,
-} from '@material-ui/core/Select/SelectInput';
+import type { SelectInputProps as MuiSelectInputProps } from '@material-ui/core/Select/SelectInput';
 import MuiSelectInput from '@material-ui/core/Select/SelectInput';
 import MuiNativeSelectInput, {
   styles as nativeSelectStyles,
@@ -16,7 +14,7 @@ import { ChevronDown } from '../../internal';
 import type { Theme } from '../../theme';
 import type { TagProps } from '../Tag';
 import Tag from '../Tag';
-import type { PaperProps} from '../Paper';
+import type { PaperProps } from '../Paper';
 import { usePaperStyles } from '../Paper';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/Select/Select.tsx
+++ b/libs/spark/src/alpha/Select/Select.tsx
@@ -1,19 +1,25 @@
-import React, { cloneElement, CSSProperties, forwardRef } from 'react';
-import { SelectProps as MuiSelectProps } from '@material-ui/core/Select';
-import MuiSelectInput, {
+import type { CSSProperties} from 'react';
+import React, { cloneElement, forwardRef } from 'react';
+import type { SelectProps as MuiSelectProps } from '@material-ui/core/Select';
+import type {
   SelectInputProps as MuiSelectInputProps,
 } from '@material-ui/core/Select/SelectInput';
+import MuiSelectInput from '@material-ui/core/Select/SelectInput';
 import MuiNativeSelectInput, {
   styles as nativeSelectStyles,
 } from '@material-ui/core/NativeSelect/NativeSelect';
-import Input, { InputProps } from '../Input';
-import { StandardProps } from '../../utils';
+import type { InputProps } from '../Input';
+import Input from '../Input';
+import type { StandardProps } from '../../utils';
 import clsx from 'clsx';
 import { ChevronDown } from '../../internal';
-import { Theme } from '../../theme';
-import Tag, { TagProps } from '../Tag';
-import { PaperProps, usePaperStyles } from '../Paper';
-import withStyles, { Styles } from '../../withStyles';
+import type { Theme } from '../../theme';
+import type { TagProps } from '../Tag';
+import Tag from '../Tag';
+import type { PaperProps} from '../Paper';
+import { usePaperStyles } from '../Paper';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import useFormControl from '../useFormControl';
 
 declare module '@material-ui/core/NativeSelect/NativeSelect' {

--- a/libs/spark/src/alpha/SideBarDrawer/SideBarDrawer.tsx
+++ b/libs/spark/src/alpha/SideBarDrawer/SideBarDrawer.tsx
@@ -1,10 +1,13 @@
 import clsx from 'clsx';
-import React, { HTMLAttributes } from 'react';
-import Drawer, { DrawerClassKey, DrawerProps } from '../Drawer';
+import type { HTMLAttributes } from 'react';
+import React from 'react';
+import type { DrawerClassKey, DrawerProps } from '../Drawer';
+import Drawer from '../Drawer';
 import useMediaQuery from '../useMediaQuery';
 import useSideBar from '../useSideBar';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SideBarDrawerProps

--- a/libs/spark/src/alpha/SideBarList/SideBarList.tsx
+++ b/libs/spark/src/alpha/SideBarList/SideBarList.tsx
@@ -1,5 +1,7 @@
-import List, { ListClassKey, ListProps } from '../List';
-import withStyles, { Styles } from '../../withStyles';
+import type { ListClassKey, ListProps } from '../List';
+import List from '../List';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SideBarListProps extends ListProps {}

--- a/libs/spark/src/alpha/SideBarListItem/SideBarListItem.tsx
+++ b/libs/spark/src/alpha/SideBarListItem/SideBarListItem.tsx
@@ -1,5 +1,5 @@
 import { alpha } from '@material-ui/core/styles';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type {
   ListItemClassKey,

--- a/libs/spark/src/alpha/SideBarListItem/SideBarListItem.tsx
+++ b/libs/spark/src/alpha/SideBarListItem/SideBarListItem.tsx
@@ -1,15 +1,18 @@
 import { alpha } from '@material-ui/core/styles';
-import React, { ElementType, forwardRef } from 'react';
-import ListItem, {
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type {
   ListItemClassKey,
   ListItemProps,
   ListItemTypeMap,
 } from '../ListItem';
+import ListItem from '../ListItem';
 import useMediaQuery from '../useMediaQuery';
 import useSideBar from '../useSideBar';
-import withStyles, { Styles } from '../../withStyles';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import { ExtendButtonBase } from '../../ButtonBase';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { ExtendButtonBase } from '../../ButtonBase';
 
 export type SideBarListItemTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/SideBarListSubheader/SideBarListSubheader.ts
+++ b/libs/spark/src/alpha/SideBarListSubheader/SideBarListSubheader.ts
@@ -1,8 +1,10 @@
-import ListSubheader, {
+import type {
   ListSubheaderClassKey,
   ListSubheaderProps,
 } from '../ListSubheader';
-import withStyles, { Styles } from '../../withStyles';
+import ListSubheader from '../ListSubheader';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 import { buildVariant } from '../theme/typography';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/libs/spark/src/alpha/SideBarProvider/SideBarProvider.stories.tsx
+++ b/libs/spark/src/alpha/SideBarProvider/SideBarProvider.stories.tsx
@@ -1,10 +1,11 @@
-import { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
+import type {
+  SideBarProviderProps} from '..';
 import {
   SideBarDrawer,
   SideBarListItem,
   SideBarListSubheader,
   SideBarList,
-  SideBarProviderProps,
   SideBarProvider,
   useSideBarTrigger,
   Divider,

--- a/libs/spark/src/alpha/SideBarProvider/SideBarProvider.stories.tsx
+++ b/libs/spark/src/alpha/SideBarProvider/SideBarProvider.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type {
-  SideBarProviderProps} from '..';
+import type { SideBarProviderProps } from '..';
 import {
   SideBarDrawer,
   SideBarListItem,

--- a/libs/spark/src/alpha/SideBarProvider/SideBarProvider.tsx
+++ b/libs/spark/src/alpha/SideBarProvider/SideBarProvider.tsx
@@ -1,7 +1,5 @@
 import clsx from 'clsx';
-import type {
-  HTMLAttributes,
-  ReactNode} from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import React, {
   forwardRef,
   useCallback,

--- a/libs/spark/src/alpha/SideBarProvider/SideBarProvider.tsx
+++ b/libs/spark/src/alpha/SideBarProvider/SideBarProvider.tsx
@@ -1,17 +1,20 @@
 import clsx from 'clsx';
-import React, {
+import type {
   HTMLAttributes,
-  ReactNode,
+  ReactNode} from 'react';
+import React, {
   forwardRef,
   useCallback,
   useEffect,
   useMemo,
   useState,
 } from 'react';
-import SideBarContext, { SideBarContextValue } from '../SideBarContext';
+import type { SideBarContextValue } from '../SideBarContext';
+import SideBarContext from '../SideBarContext';
 import useMediaQuery from '../useMediaQuery';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface SideBarProviderProps
   extends StandardProps<

--- a/libs/spark/src/alpha/SvgIcon/SvgIcon.stories.tsx
+++ b/libs/spark/src/alpha/SvgIcon/SvgIcon.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { SvgIcon, SvgIconProps } from '..';
+import type { SvgIconProps } from '..';
+import { SvgIcon } from '..';
 import { inverseBackground } from '../../../stories';
 
 export const _retyped = SvgIcon as typeof SvgIcon;

--- a/libs/spark/src/alpha/SvgIcon/SvgIcon.tsx
+++ b/libs/spark/src/alpha/SvgIcon/SvgIcon.tsx
@@ -1,11 +1,14 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  SvgIconProps as MuiSvgIconProps} from '@material-ui/core/SvgIcon';
 import {
-  default as MuiSvgIcon,
-  SvgIconProps as MuiSvgIconProps,
+  default as MuiSvgIcon
 } from '@material-ui/core/SvgIcon';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface SvgIconTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/SvgIcon/SvgIcon.tsx
+++ b/libs/spark/src/alpha/SvgIcon/SvgIcon.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  SvgIconProps as MuiSvgIconProps} from '@material-ui/core/SvgIcon';
-import {
-  default as MuiSvgIcon
-} from '@material-ui/core/SvgIcon';
+import type { SvgIconProps as MuiSvgIconProps } from '@material-ui/core/SvgIcon';
+import { default as MuiSvgIcon } from '@material-ui/core/SvgIcon';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';

--- a/libs/spark/src/alpha/Switch/Switch.stories.tsx
+++ b/libs/spark/src/alpha/Switch/Switch.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Switch, SwitchProps } from '..';
+import type { SwitchProps } from '..';
+import { Switch } from '..';
 import {
   containBoxShadowInline,
   enableHooks,

--- a/libs/spark/src/alpha/Switch/Switch.tsx
+++ b/libs/spark/src/alpha/Switch/Switch.tsx
@@ -1,11 +1,8 @@
 import type { Ref } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  SwitchProps as MuiSwitchProps} from '@material-ui/core/Switch';
-import {
-  default as MuiSwitch
-} from '@material-ui/core/Switch';
+import type { SwitchProps as MuiSwitchProps } from '@material-ui/core/Switch';
+import { default as MuiSwitch } from '@material-ui/core/Switch';
 import type { StyledComponentProps, Styles } from '../../withStyles';
 import withStyles from '../../withStyles';
 

--- a/libs/spark/src/alpha/Switch/Switch.tsx
+++ b/libs/spark/src/alpha/Switch/Switch.tsx
@@ -1,10 +1,13 @@
-import React, { forwardRef, Ref } from 'react';
+import type { Ref } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  SwitchProps as MuiSwitchProps} from '@material-ui/core/Switch';
 import {
-  default as MuiSwitch,
-  SwitchProps as MuiSwitchProps,
+  default as MuiSwitch
 } from '@material-ui/core/Switch';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface SwitchProps
   extends Omit<

--- a/libs/spark/src/alpha/SwitchField/SwitchField.stories.tsx
+++ b/libs/spark/src/alpha/SwitchField/SwitchField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { SwitchField, SwitchFieldProps } from '..';
+import type { SwitchFieldProps } from '..';
+import { SwitchField } from '..';
 import { containBoxShadow } from '../../../stories';
 
 export const _retyped = SwitchField as typeof SwitchField;

--- a/libs/spark/src/alpha/SwitchField/SwitchField.tsx
+++ b/libs/spark/src/alpha/SwitchField/SwitchField.tsx
@@ -1,10 +1,14 @@
-import React, { forwardRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import FormControlLabel, { FormControlLabelProps } from '../FormControlLabel';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
+import type { FormControlLabelProps } from '../FormControlLabel';
+import FormControlLabel from '../FormControlLabel';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
 import Switch from '../Switch/Switch';
 import { useId } from '../../utils';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface SwitchFieldProps
   extends Omit<FormControlLabelProps, 'classes' | 'control'>,

--- a/libs/spark/src/alpha/Tab/Tab.stories.tsx
+++ b/libs/spark/src/alpha/Tab/Tab.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import { Tab, TabProps, Tabs, TabsProps } from '..';
+import type { TabProps, TabsProps } from '..';
+import { Tab, Tabs } from '..';
 import { containBoxShadowInline, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = Tab as typeof Tab;

--- a/libs/spark/src/alpha/Tab/Tab.tsx
+++ b/libs/spark/src/alpha/Tab/Tab.tsx
@@ -1,7 +1,7 @@
 import type { TabProps as MuiTabProps } from '@material-ui/core/Tab';
 import MuiTab from '@material-ui/core/Tab';
 import clsx from 'clsx';
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import type { ButtonBaseTypeMap } from '../../ButtonBase';
 import useTabs from '../useTabs';

--- a/libs/spark/src/alpha/Tab/Tab.tsx
+++ b/libs/spark/src/alpha/Tab/Tab.tsx
@@ -1,10 +1,13 @@
-import MuiTab, { TabProps as MuiTabProps } from '@material-ui/core/Tab';
+import type { TabProps as MuiTabProps } from '@material-ui/core/Tab';
+import MuiTab from '@material-ui/core/Tab';
 import clsx from 'clsx';
-import React, { ElementType, forwardRef } from 'react';
-import { ButtonBaseTypeMap } from '../../ButtonBase';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
+import type { ButtonBaseTypeMap } from '../../ButtonBase';
 import useTabs from '../useTabs';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface TabTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/TabPanel/TabPanel.stories.tsx
+++ b/libs/spark/src/alpha/TabPanel/TabPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import type { TabPanelProps} from '..';
+import type { TabPanelProps } from '..';
 import { TabPanel, Tabs } from '..';
 import { sparkThemeProvider } from '../../../stories';
 

--- a/libs/spark/src/alpha/TabPanel/TabPanel.stories.tsx
+++ b/libs/spark/src/alpha/TabPanel/TabPanel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import { TabPanel, TabPanelProps, Tabs } from '..';
+import type { TabPanelProps} from '..';
+import { TabPanel, Tabs } from '..';
 import { sparkThemeProvider } from '../../../stories';
 
 export const _retyped = TabPanel as typeof TabPanel;

--- a/libs/spark/src/alpha/TabPanel/TabPanel.tsx
+++ b/libs/spark/src/alpha/TabPanel/TabPanel.tsx
@@ -1,8 +1,10 @@
-import MuiTabPanel, {
+import type {
   TabPanelProps as MuiTabPanelProps,
 } from '@material-ui/lab/TabPanel';
+import MuiTabPanel from '@material-ui/lab/TabPanel';
 import React, { forwardRef } from 'react';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface TabPanelProps extends MuiTabPanelProps {}

--- a/libs/spark/src/alpha/TabPanel/TabPanel.tsx
+++ b/libs/spark/src/alpha/TabPanel/TabPanel.tsx
@@ -1,6 +1,4 @@
-import type {
-  TabPanelProps as MuiTabPanelProps,
-} from '@material-ui/lab/TabPanel';
+import type { TabPanelProps as MuiTabPanelProps } from '@material-ui/lab/TabPanel';
 import MuiTabPanel from '@material-ui/lab/TabPanel';
 import React, { forwardRef } from 'react';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/Tabs/Tabs.stories.tsx
+++ b/libs/spark/src/alpha/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import { Tab, TabPanel, Tabs, TabsList, TabsProps } from '..';
+import type { TabsProps } from '..';
+import { Tab, TabPanel, Tabs, TabsList } from '..';
 import {
   containBoxShadow,
   enableHooks,

--- a/libs/spark/src/alpha/Tabs/Tabs.tsx
+++ b/libs/spark/src/alpha/Tabs/Tabs.tsx
@@ -1,19 +1,9 @@
 import MuiTabContext from '@material-ui/lab/TabContext';
 import clsx from 'clsx';
-import type {
-  ElementType,
-  SyntheticEvent} from 'react';
-import React, {
-  forwardRef,
-  useCallback,
-  useMemo,
-} from 'react';
-import type {
-  OverridableComponent,
-  OverrideProps} from '../../utils';
-import {
-  useControlled,
-} from '../../utils';
+import type { ElementType, SyntheticEvent } from 'react';
+import React, { forwardRef, useCallback, useMemo } from 'react';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import { useControlled } from '../../utils';
 import type { Styles } from '../../withStyles';
 import withStyles from '../../withStyles';
 import type { TabsContextValue } from '../TabsContext';

--- a/libs/spark/src/alpha/Tabs/Tabs.tsx
+++ b/libs/spark/src/alpha/Tabs/Tabs.tsx
@@ -1,19 +1,23 @@
 import MuiTabContext from '@material-ui/lab/TabContext';
 import clsx from 'clsx';
-import React, {
+import type {
   ElementType,
+  SyntheticEvent} from 'react';
+import React, {
   forwardRef,
-  SyntheticEvent,
   useCallback,
   useMemo,
 } from 'react';
-import {
+import type {
   OverridableComponent,
-  OverrideProps,
+  OverrideProps} from '../../utils';
+import {
   useControlled,
 } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
-import TabsContext, { TabsContextValue } from '../TabsContext';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
+import type { TabsContextValue } from '../TabsContext';
+import TabsContext from '../TabsContext';
 
 export interface TabsTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/TabsContext/TabsContext.ts
+++ b/libs/spark/src/alpha/TabsContext/TabsContext.ts
@@ -1,5 +1,6 @@
-import { TabContextValue as MuiTabContextValue } from '@material-ui/lab/TabContext';
-import { createContext, SyntheticEvent } from 'react';
+import type { TabContextValue as MuiTabContextValue } from '@material-ui/lab/TabContext';
+import type { SyntheticEvent } from 'react';
+import { createContext } from 'react';
 
 type Value = string | false;
 

--- a/libs/spark/src/alpha/TabsList/TabsList.stories.tsx
+++ b/libs/spark/src/alpha/TabsList/TabsList.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
 import React from 'react';
-import { Tab, Tabs, TabsList, TabsListProps, TabsProps } from '..';
+import type { TabsListProps, TabsProps } from '..';
+import { Tab, Tabs, TabsList } from '..';
 import { containBoxShadow, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = TabsList as typeof TabsList;

--- a/libs/spark/src/alpha/TabsList/TabsList.tsx
+++ b/libs/spark/src/alpha/TabsList/TabsList.tsx
@@ -1,12 +1,14 @@
-import MuiTabList, {
+import type {
   TabListTypeMap as MuiTabListTypeMap,
   TabListProps as MuiTabListProps,
 } from '@material-ui/lab/TabList';
+import MuiTabList from '@material-ui/lab/TabList';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import useTabs from '../useTabs';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface TabsListTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Tag/Tag.stories.tsx
+++ b/libs/spark/src/alpha/Tag/Tag.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Tag, TagProps } from '..';
+import type { TagProps } from '..';
+import { Tag } from '..';
 import {
   containBoxShadowInline,
   Filter,

--- a/libs/spark/src/alpha/Tag/Tag.tsx
+++ b/libs/spark/src/alpha/Tag/Tag.tsx
@@ -1,14 +1,17 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  ChipProps as MuiChipProps} from '@material-ui/core/Chip';
 import {
-  default as MuiChip,
-  ChipProps as MuiChipProps,
+  default as MuiChip
 } from '@material-ui/core/Chip';
 import { CrossSmall } from '../../internal';
-import { OverridableComponent, OverrideProps } from '../../utils';
+import type { OverridableComponent, OverrideProps } from '../../utils';
 import { buildVariant } from '../theme/typography';
 import { alpha, darken } from '@material-ui/core/styles';
-import withStyles, { Styles } from '../../withStyles';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface TagTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/Tag/Tag.tsx
+++ b/libs/spark/src/alpha/Tag/Tag.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  ChipProps as MuiChipProps} from '@material-ui/core/Chip';
-import {
-  default as MuiChip
-} from '@material-ui/core/Chip';
+import type { ChipProps as MuiChipProps } from '@material-ui/core/Chip';
+import { default as MuiChip } from '@material-ui/core/Chip';
 import { CrossSmall } from '../../internal';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import { buildVariant } from '../theme/typography';

--- a/libs/spark/src/alpha/TextField/TextField.stories.tsx
+++ b/libs/spark/src/alpha/TextField/TextField.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { TextField, TextFieldProps } from '..';
+import type { TextFieldProps } from '..';
+import { TextField } from '..';
 import { default as SelectMeta } from '../Select/Select.stories';
 import {
   containBoxShadow,

--- a/libs/spark/src/alpha/TextField/TextField.tsx
+++ b/libs/spark/src/alpha/TextField/TextField.tsx
@@ -1,15 +1,21 @@
-import React, {
-  forwardRef,
+import type {
   InputHTMLAttributes,
   ReactNode,
   Ref,
-  RefObject,
+  RefObject} from 'react';
+import React, {
+  forwardRef
 } from 'react';
-import Input, { InputProps } from '../Input';
-import FormLabel, { FormLabelProps } from '../FormLabel';
-import FormControl, { FormControlProps } from '../FormControl';
-import FormHelperText, { FormHelperTextProps } from '../FormHelperText';
-import Select, { SelectProps } from '../Select';
+import type { InputProps } from '../Input';
+import Input from '../Input';
+import type { FormLabelProps } from '../FormLabel';
+import FormLabel from '../FormLabel';
+import type { FormControlProps } from '../FormControl';
+import FormControl from '../FormControl';
+import type { FormHelperTextProps } from '../FormHelperText';
+import FormHelperText from '../FormHelperText';
+import type { SelectProps } from '../Select';
+import Select from '../Select';
 
 export interface TextFieldProps
   extends Omit<

--- a/libs/spark/src/alpha/TextField/TextField.tsx
+++ b/libs/spark/src/alpha/TextField/TextField.tsx
@@ -1,11 +1,5 @@
-import type {
-  InputHTMLAttributes,
-  ReactNode,
-  Ref,
-  RefObject} from 'react';
-import React, {
-  forwardRef
-} from 'react';
+import type { InputHTMLAttributes, ReactNode, Ref, RefObject } from 'react';
+import React, { forwardRef } from 'react';
 import type { InputProps } from '../Input';
 import Input from '../Input';
 import type { FormLabelProps } from '../FormLabel';

--- a/libs/spark/src/alpha/Toast/Toast.stories.tsx
+++ b/libs/spark/src/alpha/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Toast, ToastProps } from '..';
+import type { ToastProps } from '..';
+import { Toast } from '..';
 import { Email } from '../../../stories';
 
 export default {

--- a/libs/spark/src/alpha/Toast/Toast.tsx
+++ b/libs/spark/src/alpha/Toast/Toast.tsx
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import Alert, { AlertClassKey, AlertProps } from '../internal/Alert';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { AlertClassKey, AlertProps } from '../internal/Alert';
+import Alert from '../internal/Alert';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ToastProps extends StandardProps<AlertProps, ToastClassKey> {}

--- a/libs/spark/src/alpha/ToastsContext/ToastsContext.d.ts
+++ b/libs/spark/src/alpha/ToastsContext/ToastsContext.d.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   OptionsObject as NotistackOptionsObject,
   SnackbarKey as NotistackSnackbarKey,
 } from 'notistack';
-import { ReactNode } from 'react';
-import { ToastProps } from '../Toast/Toast';
+import type { ReactNode } from 'react';
+import type { ToastProps } from '../Toast/Toast';
 
 export type ToastId = NotistackSnackbarKey;
 

--- a/libs/spark/src/alpha/ToastsProvider/ToastsProvider.stories.tsx
+++ b/libs/spark/src/alpha/ToastsProvider/ToastsProvider.stories.tsx
@@ -1,7 +1,7 @@
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type { ToastsProviderProps} from '..';
+import type { ToastsProviderProps } from '..';
 import { ToastsProvider, Button, useToasts } from '..';
 import { Email, enableHooks, largeWidth } from '../../../stories';
 

--- a/libs/spark/src/alpha/ToastsProvider/ToastsProvider.stories.tsx
+++ b/libs/spark/src/alpha/ToastsProvider/ToastsProvider.stories.tsx
@@ -1,6 +1,8 @@
-import React, { ReactNode, useState } from 'react';
+import type { ReactNode} from 'react';
+import React, { useState } from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { ToastsProvider, ToastsProviderProps, Button, useToasts } from '..';
+import type { ToastsProviderProps} from '..';
+import { ToastsProvider, Button, useToasts } from '..';
 import { Email, enableHooks, largeWidth } from '../../../stories';
 
 export const _retyped = ToastsProvider as typeof ToastsProvider;

--- a/libs/spark/src/alpha/ToastsProvider/ToastsProvider.tsx
+++ b/libs/spark/src/alpha/ToastsProvider/ToastsProvider.tsx
@@ -1,10 +1,13 @@
-import {
+import type {
   CustomContentProps as NotistackCustomContentProps,
-  SnackbarProvider as NotistackSnackbarProvider,
-  SnackbarProviderProps as NotistackSnackbarProviderProps,
+  SnackbarProviderProps as NotistackSnackbarProviderProps} from 'notistack';
+import {
+  SnackbarProvider as NotistackSnackbarProvider
 } from 'notistack';
-import React, { forwardRef, JSXElementConstructor } from 'react';
-import Toast, { ToastProps } from '../Toast';
+import type { JSXElementConstructor } from 'react';
+import React, { forwardRef } from 'react';
+import type { ToastProps } from '../Toast';
+import Toast from '../Toast';
 import useToasts from '../useToasts';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/libs/spark/src/alpha/ToastsProvider/ToastsProvider.tsx
+++ b/libs/spark/src/alpha/ToastsProvider/ToastsProvider.tsx
@@ -1,9 +1,8 @@
 import type {
   CustomContentProps as NotistackCustomContentProps,
-  SnackbarProviderProps as NotistackSnackbarProviderProps} from 'notistack';
-import {
-  SnackbarProvider as NotistackSnackbarProvider
+  SnackbarProviderProps as NotistackSnackbarProviderProps,
 } from 'notistack';
+import { SnackbarProvider as NotistackSnackbarProvider } from 'notistack';
 import type { JSXElementConstructor } from 'react';
 import React, { forwardRef } from 'react';
 import type { ToastProps } from '../Toast';

--- a/libs/spark/src/alpha/Tooltip/Tooltip.stories.tsx
+++ b/libs/spark/src/alpha/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import type { TooltipProps} from '..';
+import type { TooltipProps } from '..';
 import { IconButton, Tooltip, Typography } from '..';
 import { Plus } from '../../../stories';
 import type { DecoratorFn } from '@storybook/react';

--- a/libs/spark/src/alpha/Tooltip/Tooltip.stories.tsx
+++ b/libs/spark/src/alpha/Tooltip/Tooltip.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { IconButton, Tooltip, TooltipProps, Typography } from '..';
+import type { TooltipProps} from '..';
+import { IconButton, Tooltip, Typography } from '..';
 import { Plus } from '../../../stories';
-import { DecoratorFn } from '@storybook/react';
+import type { DecoratorFn } from '@storybook/react';
 
 export const _retyped = Tooltip as typeof Tooltip;
 

--- a/libs/spark/src/alpha/Tooltip/Tooltip.tsx
+++ b/libs/spark/src/alpha/Tooltip/Tooltip.tsx
@@ -1,8 +1,5 @@
-import type {
-  TooltipProps as MuiTooltipProps} from '@material-ui/core/Tooltip';
-import {
-  default as MuiTooltip
-} from '@material-ui/core/Tooltip';
+import type { TooltipProps as MuiTooltipProps } from '@material-ui/core/Tooltip';
+import { default as MuiTooltip } from '@material-ui/core/Tooltip';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import type { StyledComponentProps, Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/Tooltip/Tooltip.tsx
+++ b/libs/spark/src/alpha/Tooltip/Tooltip.tsx
@@ -1,10 +1,12 @@
+import type {
+  TooltipProps as MuiTooltipProps} from '@material-ui/core/Tooltip';
 import {
-  default as MuiTooltip,
-  TooltipProps as MuiTooltipProps,
+  default as MuiTooltip
 } from '@material-ui/core/Tooltip';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
-import withStyles, { StyledComponentProps, Styles } from '../../withStyles';
+import type { StyledComponentProps, Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface TooltipProps

--- a/libs/spark/src/alpha/TopBar/TopBar.stories.tsx
+++ b/libs/spark/src/alpha/TopBar/TopBar.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { TopBar, TopBarProps } from '..';
+import type { TopBarProps } from '..';
+import { TopBar } from '..';
 
 export const _retyped = TopBar as typeof TopBar;
 

--- a/libs/spark/src/alpha/TopBar/TopBar.tsx
+++ b/libs/spark/src/alpha/TopBar/TopBar.tsx
@@ -1,8 +1,5 @@
-import type {
-  AppBarProps as MuiAppBarProps} from '@material-ui/core/AppBar';
-import {
-  default as MuiAppBar
-} from '@material-ui/core/AppBar';
+import type { AppBarProps as MuiAppBarProps } from '@material-ui/core/AppBar';
+import { default as MuiAppBar } from '@material-ui/core/AppBar';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import type { StandardProps } from '../../utils';

--- a/libs/spark/src/alpha/TopBar/TopBar.tsx
+++ b/libs/spark/src/alpha/TopBar/TopBar.tsx
@@ -1,11 +1,13 @@
+import type {
+  AppBarProps as MuiAppBarProps} from '@material-ui/core/AppBar';
 import {
-  default as MuiAppBar,
-  AppBarProps as MuiAppBarProps,
+  default as MuiAppBar
 } from '@material-ui/core/AppBar';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
-import { StandardProps } from '../../utils';
-import withStyles, { Styles } from '../../withStyles';
+import type { StandardProps } from '../../utils';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface TopBarProps
   extends StandardProps<

--- a/libs/spark/src/alpha/Typography/Typography.stories.tsx
+++ b/libs/spark/src/alpha/Typography/Typography.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story as DefaultStory } from '@storybook/react/types-6-0';
-import { Typography, TypographyProps } from '..';
+import type { TypographyProps } from '..';
+import { Typography } from '..';
 import { inverseBackground, sparkThemeProvider } from '../../../stories';
 
 export const _retyped = Typography as typeof Typography;

--- a/libs/spark/src/alpha/Typography/Typography.tsx
+++ b/libs/spark/src/alpha/Typography/Typography.tsx
@@ -1,11 +1,8 @@
-import type { ElementType} from 'react';
+import type { ElementType } from 'react';
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
-import type {
-  TypographyProps as MuiTypographyProps} from '@material-ui/core/Typography';
-import {
-  default as MuiTypography
-} from '@material-ui/core/Typography';
+import type { TypographyProps as MuiTypographyProps } from '@material-ui/core/Typography';
+import { default as MuiTypography } from '@material-ui/core/Typography';
 import type { OverridableComponent, OverrideProps } from '../../utils';
 import type { TypographyVariant } from '../theme/typography';
 import type { Styles } from '../../withStyles';

--- a/libs/spark/src/alpha/Typography/Typography.tsx
+++ b/libs/spark/src/alpha/Typography/Typography.tsx
@@ -1,12 +1,15 @@
-import React, { ElementType, forwardRef } from 'react';
+import type { ElementType} from 'react';
+import React, { forwardRef } from 'react';
 import clsx from 'clsx';
+import type {
+  TypographyProps as MuiTypographyProps} from '@material-ui/core/Typography';
 import {
-  default as MuiTypography,
-  TypographyProps as MuiTypographyProps,
+  default as MuiTypography
 } from '@material-ui/core/Typography';
-import { OverridableComponent, OverrideProps } from '../../utils';
-import { TypographyVariant } from '../theme/typography';
-import withStyles, { Styles } from '../../withStyles';
+import type { OverridableComponent, OverrideProps } from '../../utils';
+import type { TypographyVariant } from '../theme/typography';
+import type { Styles } from '../../withStyles';
+import withStyles from '../../withStyles';
 
 export interface TypographyTypeMap<
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/spark/src/alpha/createSvgIcon/createSvgIcon.tsx
+++ b/libs/spark/src/alpha/createSvgIcon/createSvgIcon.tsx
@@ -1,5 +1,7 @@
-import React, { forwardRef, memo, ReactNode } from 'react';
-import SvgIcon, { SvgIconProps } from '../SvgIcon';
+import type { ReactNode } from 'react';
+import React, { forwardRef, memo } from 'react';
+import type { SvgIconProps } from '../SvgIcon';
+import SvgIcon from '../SvgIcon';
 
 const createSvgIcon = (
   path: ReactNode,

--- a/libs/spark/src/alpha/internal/Alert.tsx
+++ b/libs/spark/src/alpha/internal/Alert.tsx
@@ -1,13 +1,16 @@
-import Paper, { PaperProps } from '@material-ui/core/Paper';
+import type { PaperProps } from '@material-ui/core/Paper';
+import Paper from '@material-ui/core/Paper';
 import clsx from 'clsx';
-import React, { forwardRef, ReactNode, SyntheticEvent } from 'react';
+import type { ReactNode, SyntheticEvent } from 'react';
+import React, { forwardRef } from 'react';
 import AlertTriangle from './AlertTriangle';
 import AlertOctagon from './AlertOctagon';
 import CheckCircle2 from './CheckCircle2';
 import Cross from './Cross';
 import Info from './Info';
-import IconButton, { IconButtonProps } from '../IconButton';
-import { StandardProps } from '../../utils';
+import type { IconButtonProps } from '../IconButton';
+import IconButton from '../IconButton';
+import type { StandardProps } from '../../utils';
 import withStyles from '../../withStyles';
 
 export interface AlertProps

--- a/libs/spark/src/alpha/theme/borders.ts
+++ b/libs/spark/src/alpha/theme/borders.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import palette from './palette';
 
 export interface Borders {

--- a/libs/spark/src/alpha/theme/fontFaces.ts
+++ b/libs/spark/src/alpha/theme/fontFaces.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 /**
  * A small, internal utility to generate a standard `src` property value for `@font-face` declarations.

--- a/libs/spark/src/alpha/theme/palette.stories.tsx
+++ b/libs/spark/src/alpha/theme/palette.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { styled, theme, Theme } from '../..';
+import type { Theme } from '../..';
+import { styled, theme } from '../..';
 
 export default {
   title: '@ps/theme/palette',

--- a/libs/spark/src/alpha/theme/palette.ts
+++ b/libs/spark/src/alpha/theme/palette.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 // Global tokens
 // see https://spectrum.adobe.com/page/design-tokens/#Global-tokens

--- a/libs/spark/src/alpha/theme/radii.ts
+++ b/libs/spark/src/alpha/theme/radii.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 export interface Radii {
   zero: CSS.Property.BorderRadius;

--- a/libs/spark/src/alpha/theme/shadows.ts
+++ b/libs/spark/src/alpha/theme/shadows.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 import palette from './palette';
 
 export interface Shadows {

--- a/libs/spark/src/alpha/useAutocomplete/useAutocomplete.ts
+++ b/libs/spark/src/alpha/useAutocomplete/useAutocomplete.ts
@@ -1,5 +1,4 @@
-import useAutocomplete_mui, {
-  createFilterOptions as createFilterOptions_mui,
+import type {
   UseAutocompleteProps as UseAutocompleteProps_mui,
   UseAutocompleteResultGetClearProps as UseAutocompleteResultGetClearProps_mui,
   UseAutocompleteResultGetInputLabelProps as UseAutocompleteResultGetInputLabelProps_mui,
@@ -9,9 +8,11 @@ import useAutocomplete_mui, {
   UseAutocompleteResultGetPopupIndicatorProps as UseAutocompleteResultGetPopupIndicatorProps_mui,
   UseAutocompleteResultGetRootProps as UseAutocompleteResultGetRootProps_mui,
   UseAutocompleteResultGetTagProps as UseAutocompleteResultGetTagProps_mui,
-  Value as Value_mui,
+  Value as Value_mui} from '@material-ui/lab/useAutocomplete';
+import useAutocomplete_mui, {
+  createFilterOptions as createFilterOptions_mui
 } from '@material-ui/lab/useAutocomplete';
-import { HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 
 export const createFilterOptions = createFilterOptions_mui;
 

--- a/libs/spark/src/alpha/useAutocomplete/useAutocomplete.ts
+++ b/libs/spark/src/alpha/useAutocomplete/useAutocomplete.ts
@@ -8,9 +8,10 @@ import type {
   UseAutocompleteResultGetPopupIndicatorProps as UseAutocompleteResultGetPopupIndicatorProps_mui,
   UseAutocompleteResultGetRootProps as UseAutocompleteResultGetRootProps_mui,
   UseAutocompleteResultGetTagProps as UseAutocompleteResultGetTagProps_mui,
-  Value as Value_mui} from '@material-ui/lab/useAutocomplete';
+  Value as Value_mui,
+} from '@material-ui/lab/useAutocomplete';
 import useAutocomplete_mui, {
-  createFilterOptions as createFilterOptions_mui
+  createFilterOptions as createFilterOptions_mui,
 } from '@material-ui/lab/useAutocomplete';
 import type { HTMLAttributes } from 'react';
 

--- a/libs/spark/src/alpha/useAutocomplete/useAutocomplete_mui.ts
+++ b/libs/spark/src/alpha/useAutocomplete/useAutocomplete_mui.ts
@@ -1,4 +1,7 @@
-import type { UseAutocompleteProps, Value } from '@material-ui/lab/useAutocomplete';
+import type {
+  UseAutocompleteProps,
+  Value,
+} from '@material-ui/lab/useAutocomplete';
 import type { HTMLAttributes, Key, LabelHTMLAttributes, Ref } from 'react';
 
 declare module '@material-ui/lab/useAutocomplete' {

--- a/libs/spark/src/alpha/useAutocomplete/useAutocomplete_mui.ts
+++ b/libs/spark/src/alpha/useAutocomplete/useAutocomplete_mui.ts
@@ -1,5 +1,5 @@
-import { UseAutocompleteProps, Value } from '@material-ui/lab/useAutocomplete';
-import { HTMLAttributes, Key, LabelHTMLAttributes, Ref } from 'react';
+import type { UseAutocompleteProps, Value } from '@material-ui/lab/useAutocomplete';
+import type { HTMLAttributes, Key, LabelHTMLAttributes, Ref } from 'react';
 
 declare module '@material-ui/lab/useAutocomplete' {
   export default function useAutocomplete<

--- a/libs/spark/src/alpha/useDropdown/useDropdown.ts
+++ b/libs/spark/src/alpha/useDropdown/useDropdown.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import DropdownContext, { DropdownContextValue } from '../DropdownContext';
+import type { DropdownContextValue } from '../DropdownContext';
+import DropdownContext from '../DropdownContext';
 
 const useDropdown = (): DropdownContextValue => {
   return useContext(DropdownContext);

--- a/libs/spark/src/alpha/useFormControlExtra/useFormControlExtra.ts
+++ b/libs/spark/src/alpha/useFormControlExtra/useFormControlExtra.ts
@@ -1,10 +1,7 @@
 import { useContext } from 'react';
 import FormControlExtraContext from '../FormControlExtraContext';
-import type {
-  FormControlProperties} from '../useFormControl';
-import {
-  DEFAULT_FORM_CONTROL_API_VALUES
-} from '../useFormControl';
+import type { FormControlProperties } from '../useFormControl';
+import { DEFAULT_FORM_CONTROL_API_VALUES } from '../useFormControl';
 
 /** internal */
 export type UseFormControlExtraParams = Partial<

--- a/libs/spark/src/alpha/useFormControlExtra/useFormControlExtra.ts
+++ b/libs/spark/src/alpha/useFormControlExtra/useFormControlExtra.ts
@@ -1,8 +1,9 @@
 import { useContext } from 'react';
 import FormControlExtraContext from '../FormControlExtraContext';
+import type {
+  FormControlProperties} from '../useFormControl';
 import {
-  DEFAULT_FORM_CONTROL_API_VALUES,
-  FormControlProperties,
+  DEFAULT_FORM_CONTROL_API_VALUES
 } from '../useFormControl';
 
 /** internal */

--- a/libs/spark/src/alpha/useMediaQuery/useMediaQuery.ts
+++ b/libs/spark/src/alpha/useMediaQuery/useMediaQuery.ts
@@ -1,4 +1,5 @@
-import useMuiMediaQuery, { Options } from '@material-ui/core/useMediaQuery';
+import type { Options } from '@material-ui/core/useMediaQuery';
+import useMuiMediaQuery from '@material-ui/core/useMediaQuery';
 import type { Theme } from '../../theme';
 import useTheme from '../useTheme';
 

--- a/libs/spark/src/alpha/useSideBarTrigger/useSideBarTrigger.ts
+++ b/libs/spark/src/alpha/useSideBarTrigger/useSideBarTrigger.ts
@@ -1,6 +1,6 @@
-import { TransitionProps } from '@material-ui/core/transitions';
-import { ButtonProps } from '../Button';
-import { IconButtonProps } from '../IconButton';
+import type { TransitionProps } from '@material-ui/core/transitions';
+import type { ButtonProps } from '../Button';
+import type { IconButtonProps } from '../IconButton';
 import useSideBar from '../useSideBar';
 import { useMediaQuery } from '..';
 import { useEffect } from 'react';

--- a/libs/spark/src/alpha/useTabs/useTabs.ts
+++ b/libs/spark/src/alpha/useTabs/useTabs.ts
@@ -1,6 +1,7 @@
 import { useTabContext as useMuiTabContext } from '@material-ui/lab/TabContext';
 import { useContext } from 'react';
-import TabsContext, { TabsContextValue } from '../TabsContext';
+import type { TabsContextValue } from '../TabsContext';
+import TabsContext from '../TabsContext';
 
 const useTabs = (): TabsContextValue => {
   const value = useContext(TabsContext);

--- a/libs/spark/src/alpha/useToasts/useToasts.ts
+++ b/libs/spark/src/alpha/useToasts/useToasts.ts
@@ -1,8 +1,5 @@
-import type {
-  OptionsObject as NotistackOptionsObject} from 'notistack';
-import {
-  useSnackbar as useNotistackSnackbar,
-} from 'notistack';
+import type { OptionsObject as NotistackOptionsObject } from 'notistack';
+import { useSnackbar as useNotistackSnackbar } from 'notistack';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ToastsContextValue } from '../ToastsContext';
 import type { _Enqueue } from '../ToastsContext/ToastsContext';

--- a/libs/spark/src/alpha/useToasts/useToasts.ts
+++ b/libs/spark/src/alpha/useToasts/useToasts.ts
@@ -1,10 +1,11 @@
+import type {
+  OptionsObject as NotistackOptionsObject} from 'notistack';
 import {
-  OptionsObject as NotistackOptionsObject,
   useSnackbar as useNotistackSnackbar,
 } from 'notistack';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ToastsContextValue } from '../ToastsContext';
-import { _Enqueue } from '../ToastsContext/ToastsContext';
+import type { ToastsContextValue } from '../ToastsContext';
+import type { _Enqueue } from '../ToastsContext/ToastsContext';
 
 const useToasts = (): ToastsContextValue => {
   const _notistackSnackbar = useNotistackSnackbar();

--- a/libs/spark/src/styled/styled.ts
+++ b/libs/spark/src/styled/styled.ts
@@ -1,9 +1,10 @@
-import { ComponentProps, ComponentType, ElementType } from 'react';
+import type { ComponentProps, ComponentType, ElementType } from 'react';
+import type {
+  StyledProps} from '@material-ui/core/styles/styled';
 import {
-  default as muiStyled,
-  StyledProps,
+  default as muiStyled
 } from '@material-ui/core/styles/styled';
-import {
+import type {
   CreateCSSProperties,
   StyledComponentProps,
   WithStylesOptions,

--- a/libs/spark/src/styled/styled.ts
+++ b/libs/spark/src/styled/styled.ts
@@ -1,9 +1,6 @@
 import type { ComponentProps, ComponentType, ElementType } from 'react';
-import type {
-  StyledProps} from '@material-ui/core/styles/styled';
-import {
-  default as muiStyled
-} from '@material-ui/core/styles/styled';
+import type { StyledProps } from '@material-ui/core/styles/styled';
+import { default as muiStyled } from '@material-ui/core/styles/styled';
 import type {
   CreateCSSProperties,
   StyledComponentProps,

--- a/libs/spark/src/theme/fontFaces.ts
+++ b/libs/spark/src/theme/fontFaces.ts
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 const nunitoRegular: CSS.AtRule.FontFace = {
   fontFamily: '"Nunito"',

--- a/libs/spark/src/theme/props.ts
+++ b/libs/spark/src/theme/props.ts
@@ -1,4 +1,4 @@
-import { ComponentsProps } from '@material-ui/core/styles/props';
+import type { ComponentsProps } from '@material-ui/core/styles/props';
 import { MuiAutocompleteDefaultProps } from '../Autocomplete/defaults';
 import { MuiAlertDefaultProps } from '../Alert/defaults';
 import { MuiButtonDefaultProps } from '../Button/defaults';

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -1,21 +1,27 @@
-import { createTheme, Theme as MuiTheme } from '@material-ui/core/styles';
+import type { Theme as MuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import initialTheme from './initialTheme';
 import overrides from './overrides';
 import props from './props';
 import type {} from './themeAugmentation';
-import borders_alpha, {
+import type {
   Borders as Borders_alpha,
 } from '../alpha/theme/borders';
-import palette_alpha, {
+import borders_alpha from '../alpha/theme/borders';
+import type {
   Palette as Palette_alpha,
 } from '../alpha/theme/palette';
-import radii_alpha, { Radii as Radii_alpha } from '../alpha/theme/radii';
-import shadows_alpha, {
+import palette_alpha from '../alpha/theme/palette';
+import type { Radii as Radii_alpha } from '../alpha/theme/radii';
+import radii_alpha from '../alpha/theme/radii';
+import type {
   Shadows as Shadows_alpha,
 } from '../alpha/theme/shadows';
-import typography_alpha, {
+import shadows_alpha from '../alpha/theme/shadows';
+import type {
   TypographyOptions as TypographyOptions_alpha,
 } from '../alpha/theme/typography';
+import typography_alpha from '../alpha/theme/typography';
 export interface Theme extends MuiTheme {
   borders_alpha: Borders_alpha;
   palette_alpha: Palette_alpha;

--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -4,23 +4,15 @@ import initialTheme from './initialTheme';
 import overrides from './overrides';
 import props from './props';
 import type {} from './themeAugmentation';
-import type {
-  Borders as Borders_alpha,
-} from '../alpha/theme/borders';
+import type { Borders as Borders_alpha } from '../alpha/theme/borders';
 import borders_alpha from '../alpha/theme/borders';
-import type {
-  Palette as Palette_alpha,
-} from '../alpha/theme/palette';
+import type { Palette as Palette_alpha } from '../alpha/theme/palette';
 import palette_alpha from '../alpha/theme/palette';
 import type { Radii as Radii_alpha } from '../alpha/theme/radii';
 import radii_alpha from '../alpha/theme/radii';
-import type {
-  Shadows as Shadows_alpha,
-} from '../alpha/theme/shadows';
+import type { Shadows as Shadows_alpha } from '../alpha/theme/shadows';
 import shadows_alpha from '../alpha/theme/shadows';
-import type {
-  TypographyOptions as TypographyOptions_alpha,
-} from '../alpha/theme/typography';
+import type { TypographyOptions as TypographyOptions_alpha } from '../alpha/theme/typography';
 import typography_alpha from '../alpha/theme/typography';
 export interface Theme extends MuiTheme {
   borders_alpha: Borders_alpha;

--- a/libs/spark/src/useAutocomplete_unstable/index.ts
+++ b/libs/spark/src/useAutocomplete_unstable/index.ts
@@ -5,6 +5,8 @@ export {
 export {
   /** @deprecated */
   createFilterOptions,
+} from '../alpha/useAutocomplete';
+export type {
   /** @deprecated */
   UseAutocompleteProps as UseAutocomplete_UnstableProps,
   /** @deprecated */

--- a/libs/spark/src/useFormControl_unstable/index.ts
+++ b/libs/spark/src/useFormControl_unstable/index.ts
@@ -2,7 +2,7 @@ export {
   /** @deprecated use `alpha/useFormControl` */
   default,
 } from '../alpha/useFormControl';
-export {
+export type {
   /** @deprecated */
   UseFormControlParams as UseFormControl_UnstableParams,
   /** @deprecated */

--- a/libs/spark/src/utils/StandardProps.ts
+++ b/libs/spark/src/utils/StandardProps.ts
@@ -1,5 +1,5 @@
-import { CSSProperties, Ref } from 'react';
-import { StyledComponentProps } from '../withStyles';
+import type { CSSProperties, Ref } from 'react';
+import type { StyledComponentProps } from '../withStyles';
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/libs/spark/src/utils/createSvgIcon.tsx
+++ b/libs/spark/src/utils/createSvgIcon.tsx
@@ -1,7 +1,8 @@
 // Original credit to https://github.com/mui-org/material-ui/blob/1c5beec4be20eae30e75c69ab513bbfec3e9baaf/packages/material-ui/src/utils/createSvgIcon.js
 //  Changes made since
 
-import React, { forwardRef, memo, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React, { forwardRef, memo } from 'react';
 import SvgIcon from '../SvgIcon';
 import type { SvgIconProps } from '../SvgIcon';
 

--- a/libs/spark/src/utils/useClassesCapture.ts
+++ b/libs/spark/src/utils/useClassesCapture.ts
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ClassNameMap } from './ClassNameMap';
+import type { ClassNameMap } from './ClassNameMap';
 
 /**
  * Capture custom classes while preserving all other classes.

--- a/libs/spark/src/utils/useMergeClasses.ts
+++ b/libs/spark/src/utils/useMergeClasses.ts
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ClassNameMap } from './ClassNameMap';
+import type { ClassNameMap } from './ClassNameMap';
 
 /**
  * Merge `classes` objects.

--- a/libs/spark/src/withStyles/withStyles.ts
+++ b/libs/spark/src/withStyles/withStyles.ts
@@ -9,10 +9,9 @@ import type {
   StyleRules,
   StyleRulesCallback,
   WithStyles,
-  WithStylesOptions} from '@material-ui/core/styles/withStyles';
-import {
-  default as muiWithStyles
+  WithStylesOptions,
 } from '@material-ui/core/styles/withStyles';
+import { default as muiWithStyles } from '@material-ui/core/styles/withStyles';
 import type { DefaultTheme, Theme } from '../theme';
 import initialTheme from '../theme/initialTheme';
 

--- a/libs/spark/src/withStyles/withStyles.ts
+++ b/libs/spark/src/withStyles/withStyles.ts
@@ -1,6 +1,5 @@
-import { PropInjector } from '@material-ui/types';
-import {
-  default as muiWithStyles,
+import type { PropInjector } from '@material-ui/types';
+import type {
   BaseCSSProperties,
   ClassNameMap,
   CreateCSSProperties,
@@ -10,7 +9,9 @@ import {
   StyleRules,
   StyleRulesCallback,
   WithStyles,
-  WithStylesOptions,
+  WithStylesOptions} from '@material-ui/core/styles/withStyles';
+import {
+  default as muiWithStyles
 } from '@material-ui/core/styles/withStyles';
 import type { DefaultTheme, Theme } from '../theme';
 import initialTheme from '../theme/initialTheme';

--- a/libs/spark/stories/decorators.tsx
+++ b/libs/spark/stories/decorators.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, ChangeEvent, MouseEvent } from 'react';
+import type { ChangeEvent, MouseEvent } from 'react';
+import { useState, useEffect } from 'react';
 import { SparkThemeProvider, styled } from '../src';
 
 /**


### PR DESCRIPTION
### Problem
The compiled javascript is still exporting types from a file that no longer has types. Eg:
[`/@prenda/spark/esm/useAutocomplete_unstable/index.js`](https://unpkg.com/browse/@prenda/spark@2.0.0-alpha.17/esm/useAutocomplete_unstable/index.js)
```javascript
export {
/** @deprecated use `alpha/useAutocomplete` */
default } from '../alpha/useAutocomplete';
export {
/** @deprecated */
createFilterOptions
/** @deprecated */
, UseAutocompleteProps as UseAutocomplete_UnstableProps
/** @deprecated */
, UseAutocompleteResult as UseAutocomplete_UnstableResult
/** @deprecated */
, UseAutocompleteResultGetClearIndicatorProps as UseAutocomplete_UnstableResultGetClearIndicatorProps
/** @deprecated */
, UseAutocompleteResultGetInputLabelProps as UseAutocomplete_UnstableResultGetInputLabelProps
/** @deprecated */
, UseAutocompleteResultGetInputProps as UseAutocomplete_UnstableResultGetInputProps
/** @deprecated */
, UseAutocompleteResultGetListboxProps as UseAutocomplete_UnstableResultGetListboxProps
/** @deprecated */
, UseAutocompleteResultGetMultipleValueProps as UseAutocomplete_UnstableResultGetMultipleValueProps
/** @deprecated */
, UseAutocompleteResultGetOptionProps as UseAutocomplete_UnstableResultGetOptionProps
/** @deprecated */
, UseAutocompleteResultGetPopupIndicatorProps as UseAutocomplete_UnstableResultGetPopupIndicatorProps
/** @deprecated */
, UseAutocompleteResultGetRootProps as UseAutocomplete_UnstableResultGetRootProps
/** @deprecated */
, UseAutocompleteValue } from '../alpha/useAutocomplete';
```

Thus, when trying to use in a build with more strict checks (like a Remix application) this presents an error similar to 
```
Error: Build failed with 279 errors:
node_modules/@prenda/spark/esm/useAutocomplete_unstable/index.js:6:0: ERROR: No matching export in "node_modules/@prenda/spark/esm/alpha/useAutocomplete" for import "UseAutocompleteProps"
```

### This solution
Use the  `@typescript-eslint/consistent-type-imports` and `@typescript-eslint/consistent-type-exports` eslint rules, and update all imports/exports to follow it. Now the build step is able to correctly remove the type imports/exports.

```javascript
export {
/** @deprecated use `alpha/useAutocomplete` */
default } from '../alpha/useAutocomplete';
export {
/** @deprecated */
createFilterOptions } from '../alpha/useAutocomplete';
```