### PR TITLE
fix: cast theme from MuiTheme to Theme

### DIFF
--- a/libs/spark/src/theme/theme.ts
+++ b/libs/spark/src/theme/theme.ts
@@ -39,7 +39,7 @@ const theme = createTheme({
   ...initialTheme,
   props,
   overrides: overrides(initialTheme),
-});
+}) as Theme;
 
 theme.unstable_borders = borders_alpha;
 theme.borders_alpha = borders_alpha;


### PR DESCRIPTION
### Problem
When using `theme` from `@prenda/spark` in a Remix app, it shows type errors for `theme.palette_alpha` and the like. Investigating the type, the `createTheme` function returns a `MuiTheme` type as seen [here](https://unpkg.com/browse/@prenda/spark@2.0.0-alpha.18/theme/theme.d.ts). 

### Solution
Use type casting to cast it to the `Theme` type, extending the `MuiTheme` with the PDS-specific properties.  
(This could have also used `DefaultTheme` here. Not sure which is preferable.)