### PR TITLE
chore: add manual trigger to workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish-storybook-components:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
To debug that the issue in solved in [Disable chromatic turbo snap](https://www.notion.so/Disable-chromatic-turbo-snap-e7570add40eb40aab04505803a4b4bd5?pvs=21) that was encountered in [Update design-system to Nx v19](https://www.notion.so/Update-design-system-to-Nx-v19-22015d683c1745a9ab969f8ee7aee25c?pvs=21) was not a result of the upgrade, I would like to manually trigger the workflow(s) for the main branch.