### PR TITLE
chore: fix chromatic workflow by disabling turbo snap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,7 +33,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DESIGN_SYSTEM_COMPONENTS }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: dist/storybook/components
-          onlyChanged: true
 
   publish-storybook-icons:
     runs-on: ubuntu-latest
@@ -60,7 +59,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DESIGN_SYSTEM_ICONS }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: dist/storybook/icons
-          onlyChanged: true
 
   publish-storybook-host:
     runs-on: ubuntu-latest
@@ -87,4 +85,3 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN__DESIGN_SYSTEM }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: dist/storybook/storybook-host
-          onlyChanged: true


### PR DESCRIPTION
This seems to be causing issues with publishing to chromatic. The reason in the error is that preview stats are enabled. I couldn’t figure out how to generate that file. Passing the flag `-- --webpack-stats-jon` did not seem to generate the file in my local `dist/`.