### PR TITLE
chore: add pre-commit format check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+bash << EOF
+if npm run --silent format:check >/dev/null; then
+  :
+else
+  # allow author review of formatting changes
+  npm run format:write
+  echo "[pre-commit] Failed format check. Please review and commit formatting changes."
+  exit 1
+fi
+EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
+        "husky": "^9.0.11",
         "jest": "^29.4.1",
         "jest-environment-jsdom": "^29.4.1",
         "jsdom": "~22.1.0",
@@ -12808,6 +12809,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
+    "husky": "^9.0.11",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
     "jsdom": "~22.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "storybook:build": "nx run-many -t build-storybook",
     "storybook:build:host": "nx run storybook-host:build-storybook",
     "storybook:build:components": "nx run components:build-storybook",
-    "storybook:build:icons": "nx run icons:build-storybook"
+    "storybook:build:icons": "nx run icons:build-storybook",
+    "prepare": "husky"
   },
   "dependencies": {
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
     "format:check": "nx format:check --all",
+    "format:write": "nx format:write --all",
     "storybook": "npx concurrently -c \"auto\" --handle-input \"npm:storybook:pkgs\" \"npm:storybook:host\"",
     "storybook:pkgs": "nx run storybook-host:compose-storybooks",
     "storybook:host": "nx run storybook-host:storybook",


### PR DESCRIPTION
Delete local `.husky`. Follow latest [Husky getting started](https://typicode.github.io/husky/get-started.html). Recreate pre-commit hook decided in #319 .