### PR TITLE
chore: ignore storybook build log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ node_modules
 npm-debug.log
 yarn-error.log
 testem.log
+build-storybook.log
 /typings
 
 # System Files


### PR DESCRIPTION
Appeared while I was developing tokens.