### PR TITLE
chore: add project dependency checks

### DIFF
--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -13,6 +13,24 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredDependencies": [
+              "vite",
+              "@vitejs/plugin-react",
+              "vite-plugin-dts",
+              "@nx/vite"
+            ],
+            "ignoredFiles": ["vite.config.ts"]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,5 +8,7 @@
       "import": "./index.mjs",
       "require": "./index.js"
     }
-  }
+  },
+  "type": "module",
+  "dependencies": {}
 }

--- a/packages/icons/.eslintrc.json
+++ b/packages/icons/.eslintrc.json
@@ -13,6 +13,24 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredDependencies": [
+              "vite",
+              "@vitejs/plugin-react",
+              "vite-plugin-dts",
+              "@nx/vite"
+            ],
+            "ignoredFiles": ["vite.config.ts"]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,5 +8,7 @@
       "import": "./index.mjs",
       "require": "./index.js"
     }
-  }
+  },
+  "type": "module",
+  "dependencies": {}
 }

--- a/packages/tokens/.eslintrc.json
+++ b/packages/tokens/.eslintrc.json
@@ -13,6 +13,24 @@
     {
       "files": ["*.js", "*.jsx"],
       "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredDependencies": [
+              "vite",
+              "@vitejs/plugin-react",
+              "vite-plugin-dts",
+              "@nx/vite"
+            ],
+            "ignoredFiles": ["vite.config.ts"]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -8,5 +8,7 @@
       "import": "./index.mjs",
       "require": "./index.js"
     }
-  }
+  },
+  "type": "module",
+  "dependencies": {}
 }


### PR DESCRIPTION
Ensure that projects with a build target (i.e. components, icons, tokens) properly declare their dependencies.