### PR TITLE
chore: fix built projects not containing updated dependencies

### DIFF
--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -13,7 +13,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/packages/components"
+        "outputPath": "dist/packages/components",
+        "emptyOutDir": true
       },
       "configurations": {
         "development": {

--- a/packages/icons/project.json
+++ b/packages/icons/project.json
@@ -13,7 +13,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/packages/icons"
+        "outputPath": "dist/packages/icons",
+        "emptyOutDir": true
       },
       "configurations": {
         "development": {

--- a/packages/tokens/project.json
+++ b/packages/tokens/project.json
@@ -13,7 +13,8 @@
       "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/packages/tokens"
+        "outputPath": "dist/packages/tokens",
+        "emptyOutDir": true
       },
       "configurations": {
         "development": {


### PR DESCRIPTION
Ensure that re-building a project will result in a package.json that reflects the updated dependencies.